### PR TITLE
feat: 個別Wikiページの追加

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,3 +83,7 @@ body {
   color: var(--text-strong);
   font-family: var(--font-sans);
 }
+
+.section-accordion[open] > summary .section-accordion__chevron {
+  transform: rotate(180deg);
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -30,5 +30,10 @@ describe("Home", () => {
         name: /toggle color theme/i,
       }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /Open Wiki Detail Demo/i,
+      }),
+    ).toHaveAttribute("href", "/wiki/aurora-echo");
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { ThemeToggle } from "./ThemeToggle";
 import { getThemePaletteSections } from "./themePalette";
 
@@ -22,6 +24,17 @@ export default function Home() {
               The palette avoids aqua-led branding and establishes reusable
               tokens for future product UI.
             </p>
+            <div className="mt-6 flex flex-wrap items-center gap-3">
+              <Link
+                className="inline-flex items-center rounded-full bg-brand-secondary px-5 py-3 text-sm font-semibold text-[#15243b] transition hover:brightness-105"
+                href="/wiki/aurora-echo"
+              >
+                Open Wiki Detail Demo
+              </Link>
+              <p className="text-sm text-white/72">
+                Jump straight to the public wiki detail prototype.
+              </p>
+            </div>
           </div>
 
           <div className="grid gap-6 px-6 py-6 text-sm text-text-muted sm:px-10 lg:grid-cols-[1.3fr_0.7fr]">

--- a/src/app/wiki/[wikiId]/WikiDetailPage.tsx
+++ b/src/app/wiki/[wikiId]/WikiDetailPage.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import Image from "next/image";
+import { type WikiSection } from "@/types/wiki-detail";
+import { useId } from "react";
+
+import { getSectionOffset, getWikiBasicFields, sortWikiSections } from "./wikiDetailView";
+import { useWikiDetail } from "./useWikiDetail";
+
+type WikiDetailPageProps = {
+  wikiId: string;
+};
+
+function EditIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 20h9" />
+      <path d="m16.5 3.5 4 4L7 21l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="section-accordion__chevron h-4 w-4 transition-transform"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function SectionAccordion({ section }: { section: WikiSection }) {
+  return (
+    <details
+      className="section-accordion rounded-[1.75rem] border border-stroke-subtle bg-surface-raised shadow-soft"
+      data-testid={`section-${section.sectionIdentifier}`}
+      style={{ marginLeft: `${getSectionOffset(section.depth)}px` }}
+    >
+      <summary
+        className="flex list-none items-center gap-3 cursor-pointer p-5 text-left"
+        data-testid={`section-toggle-${section.sectionIdentifier}`}
+      >
+        <span className="rounded-full border border-stroke-subtle p-2 text-text-muted">
+          <ChevronIcon />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-2xl font-semibold tracking-[-0.03em] text-text-strong">
+            {section.title}
+          </span>
+        </span>
+        <span
+          aria-label={`Edit section ${section.title}`}
+          className="rounded-full border border-stroke-subtle p-3 text-text-strong transition group-hover:bg-brand-highlight/30"
+          role="img"
+        >
+          <EditIcon />
+        </span>
+      </summary>
+
+      <div className="border-t border-stroke-subtle px-5 pb-5 pt-4">
+        <p className="max-w-3xl text-sm leading-7 text-text-muted">
+          {section.body}
+        </p>
+        {section.children.length > 0 ? (
+          <div className="mt-5 space-y-4">
+            {section.children.map((child) => (
+              <SectionAccordion key={child.sectionIdentifier} section={child} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}
+
+export function WikiDetailPage({ wikiId }: WikiDetailPageProps) {
+  const wikiDetail = useWikiDetail(wikiId);
+  const flipCardId = useId();
+
+  if (wikiDetail.status === "loading") {
+    return (
+      <main className="min-h-screen bg-surface-base px-6 py-12 text-text-strong sm:px-10">
+        <div className="mx-auto max-w-5xl rounded-[2rem] border border-stroke-subtle bg-surface-raised p-8 shadow-soft">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-text-muted">
+            Loading Wiki
+          </p>
+          <p className="mt-4 text-3xl font-semibold tracking-[-0.03em]">
+            Preparing the public detail view...
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (wikiDetail.status === "error") {
+    return (
+      <main className="min-h-screen bg-surface-base px-6 py-12 text-text-strong sm:px-10">
+        <div className="mx-auto max-w-5xl rounded-[2rem] border border-status-danger/30 bg-surface-raised p-8 shadow-soft">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-status-danger">
+            Unable to load wiki
+          </p>
+          <p className="mt-4 text-lg leading-7 text-text-muted">
+            {wikiDetail.message}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (wikiDetail.status === "empty") {
+    return (
+      <main className="min-h-screen bg-surface-base px-6 py-12 text-text-strong sm:px-10">
+        <div className="mx-auto max-w-5xl rounded-[2rem] border border-stroke-subtle bg-surface-raised p-8 shadow-soft">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-text-muted">
+            No public wiki yet
+          </p>
+          <p className="mt-4 text-lg leading-7 text-text-muted">
+            This resource does not have a public wiki detail page at the moment.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const { data } = wikiDetail;
+  const basicFields = getWikiBasicFields(data.basic);
+  const sections = sortWikiSections(data.sections);
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(255,214,194,0.85),_transparent_38%),linear-gradient(180deg,_var(--background)_0%,_#fff_100%)] px-5 py-6 text-text-strong sm:px-8 sm:py-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="lg:hidden">
+          <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong">
+            {data.basic.name}
+          </h1>
+        </header>
+
+        <section className="lg:overflow-hidden lg:rounded-[2rem] lg:border lg:border-stroke-subtle lg:bg-surface-raised lg:shadow-soft">
+          <div className="hidden border-b border-stroke-subtle bg-brand-primary px-6 py-6 text-white sm:px-8 lg:block">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h1 className="mt-3 hidden text-4xl font-semibold tracking-[-0.05em] lg:block lg:text-5xl">
+                  {data.basic.name}
+                </h1>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-5 lg:hidden">
+            <div className="space-y-4">
+              <input
+                className="peer sr-only"
+                data-testid="wiki-flip-input"
+                id={flipCardId}
+                type="checkbox"
+              />
+              <div
+                aria-label="Flip wiki card"
+                className="block"
+                data-testid="wiki-flip-trigger"
+                role="group"
+              >
+                <div className="relative h-[34rem] [perspective:1400px]">
+                  <div
+                    className="relative h-full rounded-[2rem] shadow-soft transition duration-700 [transform-style:preserve-3d] peer-checked:[transform:rotateY(180deg)]"
+                    data-testid="wiki-flip-card"
+                  >
+                    <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[2rem] border border-stroke-subtle bg-surface-raised [backface-visibility:hidden]">
+                      <div className="relative h-full w-full">
+                        <Image
+                          alt={data.heroImage.alt}
+                          className="object-cover"
+                          fill
+                          sizes="100vw"
+                          src={data.heroImage.src}
+                        />
+                      </div>
+                      <div className="absolute inset-0 bg-gradient-to-b from-[#15243b]/5 via-transparent via-55% to-[#15243b]/92" />
+                      <div className="absolute inset-x-0 bottom-0 px-5 py-6 text-white">
+                        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-brand-highlight">
+                          Tap The Card
+                        </p>
+                        <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+                          Flip to reveal the basic profile
+                        </p>
+                        <p className="mt-3 max-w-xs text-sm leading-6 text-white/78">
+                          The card turns like a physical profile card and exposes
+                          the group basics on the reverse side.
+                        </p>
+                      </div>
+                    </div>
+                    <label
+                      aria-label="Flip wiki card to basic details"
+                      className="absolute inset-0 z-30 cursor-pointer rounded-[2rem]"
+                      data-testid="wiki-flip-front-toggle"
+                      htmlFor={flipCardId}
+                    />
+
+                    <div
+                      className="absolute inset-0 z-20 flex flex-col overflow-hidden rounded-[2rem] border border-stroke-subtle bg-surface-raised p-5 [backface-visibility:hidden] [transform:rotateY(180deg)] pointer-events-none peer-checked:pointer-events-auto"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
+                            Basic
+                          </p>
+                          <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+                            Group profile
+                          </p>
+                        </div>
+                        <label
+                          aria-label="Flip wiki card to image side"
+                          className="rounded-full border border-stroke-subtle px-4 py-2 text-sm font-medium text-text-strong"
+                          htmlFor={flipCardId}
+                        >
+                          Flip back
+                        </label>
+                      </div>
+                      <div className="mt-5 min-h-0 flex-1 overflow-y-auto pr-1">
+                        <dl className="grid gap-4">
+                        {basicFields.map((field) => (
+                          <div
+                            key={field.label}
+                            className="rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-3"
+                          >
+                            <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
+                              {field.label}
+                            </dt>
+                            <dd className="mt-1 text-sm leading-6 text-text-strong">
+                              {field.value}
+                            </dd>
+                          </div>
+                        ))}
+                        </dl>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-center text-sm text-text-muted">
+                <span className="peer-checked:hidden">
+                  Tap anywhere on the card to flip to the basic details.
+                </span>
+                <span className="hidden peer-checked:inline">
+                  Tap the card again to return to the cover image.
+                </span>
+              </p>
+            </div>
+          </div>
+
+          <div className="hidden gap-6 px-6 py-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="overflow-hidden rounded-[1.75rem] border border-stroke-subtle">
+              <div className="relative min-h-[30rem]">
+                <Image
+                  alt={data.heroImage.alt}
+                  className="object-cover"
+                  fill
+                  sizes="(min-width: 1024px) 55vw, 100vw"
+                  src={data.heroImage.src}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-[1.75rem] border border-stroke-subtle bg-surface-base p-6">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
+                    Basic
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+                    Group profile
+                  </p>
+                </div>
+                <button
+                  aria-label="Edit basic"
+                  type="button"
+                  className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                >
+                  <EditIcon />
+                </button>
+              </div>
+              <dl className="mt-6 grid gap-4 sm:grid-cols-2">
+                {basicFields.map((field) => (
+                  <div
+                    key={field.label}
+                    className="rounded-2xl border border-stroke-subtle bg-surface-raised px-4 py-3"
+                  >
+                    <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
+                      {field.label}
+                    </dt>
+                    <dd className="mt-1 text-sm leading-6 text-text-strong">
+                      {field.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-5">
+          <div className="space-y-4">
+            {sections.map((section) => (
+              <SectionAccordion key={section.sectionIdentifier} section={section} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/wiki/[wikiId]/mockWikiDetail.ts
+++ b/src/app/wiki/[wikiId]/mockWikiDetail.ts
@@ -1,0 +1,100 @@
+import { wikiDetailSchema, type WikiDetail } from "@/types/wiki-detail";
+
+const heroImageDataUri =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(`
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900">
+      <defs>
+        <linearGradient id="sky" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stop-color="#24457a" />
+          <stop offset="52%" stop-color="#3560a3" />
+          <stop offset="100%" stop-color="#f1a81f" />
+        </linearGradient>
+      </defs>
+      <rect width="1200" height="900" fill="url(#sky)" />
+      <circle cx="950" cy="190" r="130" fill="rgba(255,255,255,0.18)" />
+      <path d="M0 710 C220 620 410 810 640 730 C870 650 1010 470 1200 560 L1200 900 L0 900 Z" fill="#1d2f49" opacity="0.55" />
+      <path d="M0 770 C170 690 360 840 580 780 C810 720 1010 560 1200 650 L1200 900 L0 900 Z" fill="#fffbf7" opacity="0.18" />
+    </svg>
+  `);
+
+export const createMockWikiDetail = (wikiId: string): WikiDetail =>
+  wikiDetailSchema.parse({
+    wikiIdentifier: wikiId,
+    slug: wikiId,
+    language: "ja",
+    resourceType: "group",
+    version: 3,
+    heroImage: {
+      src: heroImageDataUri,
+      alt: "Stage lights washing over a concert crowd in blue and gold",
+    },
+    summary:
+      "Five-member performance group blending precision choreography with live band arrangements and a city-pop visual language.",
+    basic: {
+      name: "Aurora Echo",
+      normalizedName: "aurora-echo",
+      resourceType: "group",
+      groupType: "Girl Group",
+      status: "Active",
+      generation: "5th",
+      debutDate: "2022-03-14",
+      fandomName: "Daybreak",
+      emoji: "🌅",
+      representativeSymbol: "Solar wave",
+      officialColors: ["Solar Gold", "Midnight Blue", "Pearl Mist"],
+      agencyName: "North Harbor Entertainment",
+    },
+    sections: [
+      {
+        sectionIdentifier: "sec-discography",
+        title: "Discography",
+        displayOrder: 30,
+        depth: 1,
+        body: "The group balances brisk digital singles with a smaller number of concept-heavy mini albums.",
+        children: [
+          {
+            sectionIdentifier: "sec-discography-highlights",
+            title: "Highlights",
+            displayOrder: 20,
+            depth: 2,
+            body: "The breakout single 'Low Tide, High Lights' established their retro-synth identity and remains their signature stage opener.",
+            children: [],
+          },
+          {
+            sectionIdentifier: "sec-discography-albums",
+            title: "Mini Albums",
+            displayOrder: 10,
+            depth: 2,
+            body: "Their first two mini albums framed a dusk-to-dawn narrative and expanded the live arrangement palette with brass and guitar sections.",
+            children: [],
+          },
+        ],
+      },
+      {
+        sectionIdentifier: "sec-overview",
+        title: "Overview",
+        displayOrder: 10,
+        depth: 1,
+        body: "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
+        children: [
+          {
+            sectionIdentifier: "sec-overview-style",
+            title: "Style",
+            displayOrder: 10,
+            depth: 2,
+            body: "The visual direction mixes marine tailoring, brushed metal details, and sunset-toned lighting for a polished but lived-in stage mood.",
+            children: [],
+          },
+        ],
+      },
+      {
+        sectionIdentifier: "sec-members",
+        title: "Members",
+        displayOrder: 20,
+        depth: 1,
+        body: "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
+        children: [],
+      },
+    ],
+  });

--- a/src/app/wiki/[wikiId]/page.test.tsx
+++ b/src/app/wiki/[wikiId]/page.test.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WikiDetailPage } from "./WikiDetailPage";
+import { useWikiDetail, type WikiDetailState } from "./useWikiDetail";
+
+vi.mock("./useWikiDetail", () => ({
+  useWikiDetail: vi.fn(),
+}));
+
+const mockedUseWikiDetail = vi.mocked(useWikiDetail);
+
+const successState: WikiDetailState = {
+  status: "success",
+  data: {
+    wikiIdentifier: "aurora-echo",
+    slug: "aurora-echo",
+    language: "ja",
+    resourceType: "group",
+    version: 3,
+    heroImage: {
+      src: "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 900'%3E%3Crect width='1200' height='900' fill='%233560a3'/%3E%3C/svg%3E",
+      alt: "Aurora Echo hero image",
+    },
+    summary: "Aurora Echo summary",
+    basic: {
+      name: "Aurora Echo",
+      normalizedName: "aurora-echo",
+      resourceType: "group",
+      groupType: "Girl Group",
+      status: "Active",
+      generation: "5th",
+      debutDate: "2022-03-14",
+      fandomName: "Daybreak",
+      emoji: "🌅",
+      representativeSymbol: "Solar wave",
+      officialColors: ["Solar Gold", "Midnight Blue"],
+      agencyName: "North Harbor Entertainment",
+    },
+    sections: [
+      {
+        sectionIdentifier: "members",
+        title: "Members",
+        displayOrder: 20,
+        depth: 1,
+        body: "Members body",
+        children: [],
+      },
+      {
+        sectionIdentifier: "overview",
+        title: "Overview",
+        displayOrder: 10,
+        depth: 1,
+        body: "Overview body",
+        children: [],
+      },
+    ],
+  },
+};
+
+describe("WikiDetailPage", () => {
+  beforeEach(() => {
+    mockedUseWikiDetail.mockReset();
+  });
+
+  it("renders the public wiki detail view", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiDetailPage, { wikiId: "aurora-echo" }));
+
+    expect(screen.getAllByRole("heading", { name: "Aurora Echo" })[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Aurora Echo")[0]).toBeInTheDocument();
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/Edit section/i)).toHaveLength(2);
+  });
+
+  it("renders sections as closed accordions by default", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiDetailPage, { wikiId: "aurora-echo" }));
+
+    const [section] = screen.getAllByTestId("section-overview");
+
+    expect(section).not.toHaveAttribute("open");
+  });
+
+  it("toggles the mobile flip card control", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiDetailPage, { wikiId: "aurora-echo" }));
+
+    const [flipInput] = screen.getAllByTestId("wiki-flip-input");
+    const [flipButton] = screen.getAllByTestId("wiki-flip-front-toggle");
+
+    fireEvent.click(flipButton);
+
+    expect(flipInput).toBeChecked();
+    expect(
+      screen.getAllByText("Tap the card again to return to the cover image.")[0],
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Group profile")[0]).toBeInTheDocument();
+  });
+
+  it("renders the empty state", () => {
+    mockedUseWikiDetail.mockReturnValue({ status: "empty" });
+
+    render(React.createElement(WikiDetailPage, { wikiId: "empty" }));
+
+    expect(screen.getByText("No public wiki yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This resource does not have a public wiki detail page at the moment.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/wiki/[wikiId]/page.tsx
+++ b/src/app/wiki/[wikiId]/page.tsx
@@ -1,0 +1,13 @@
+import { WikiDetailPage } from "./WikiDetailPage";
+
+type WikiDetailRouteProps = {
+  params: Promise<{
+    wikiId: string;
+  }>;
+};
+
+export default async function Page({ params }: WikiDetailRouteProps) {
+  const { wikiId } = await params;
+
+  return <WikiDetailPage wikiId={wikiId} />;
+}

--- a/src/app/wiki/[wikiId]/useWikiDetail.ts
+++ b/src/app/wiki/[wikiId]/useWikiDetail.ts
@@ -1,0 +1,48 @@
+import { createMockWikiDetail } from "./mockWikiDetail";
+
+type WikiDetailLoadingState = {
+  status: "loading";
+};
+
+type WikiDetailErrorState = {
+  status: "error";
+  message: string;
+};
+
+type WikiDetailEmptyState = {
+  status: "empty";
+};
+
+type WikiDetailSuccessState = {
+  status: "success";
+  data: ReturnType<typeof createMockWikiDetail>;
+};
+
+export type WikiDetailState =
+  | WikiDetailLoadingState
+  | WikiDetailErrorState
+  | WikiDetailEmptyState
+  | WikiDetailSuccessState;
+
+export const useWikiDetail = (wikiId: string): WikiDetailState => {
+  if (wikiId === "loading") {
+    return { status: "loading" };
+  }
+
+  if (wikiId === "error") {
+    return {
+      status: "error",
+      message:
+        "Wiki details are temporarily unavailable. Please try again later.",
+    };
+  }
+
+  if (wikiId === "empty") {
+    return { status: "empty" };
+  }
+
+  return {
+    status: "success",
+    data: createMockWikiDetail(wikiId),
+  };
+};

--- a/src/app/wiki/[wikiId]/wikiDetailView.test.ts
+++ b/src/app/wiki/[wikiId]/wikiDetailView.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import { type WikiBasic, type WikiSection } from "@/types/wiki-detail";
+
+import {
+  getSectionOffset,
+  getWikiBasicFields,
+  sortWikiSections,
+} from "./wikiDetailView";
+
+const basic: WikiBasic = {
+  name: "Aurora Echo",
+  normalizedName: "aurora-echo",
+  resourceType: "group",
+  groupType: "Girl Group",
+  status: "Active",
+  generation: "5th",
+  debutDate: "2022-03-14",
+  fandomName: "Daybreak",
+  emoji: "🌅",
+  representativeSymbol: "Solar wave",
+  officialColors: ["Solar Gold", "Midnight Blue"],
+  agencyName: "North Harbor Entertainment",
+};
+
+const sections: WikiSection[] = [
+  {
+    sectionIdentifier: "second",
+    title: "Second",
+    displayOrder: 20,
+    depth: 1,
+    body: "second",
+    children: [
+      {
+        sectionIdentifier: "child-b",
+        title: "Child B",
+        displayOrder: 20,
+        depth: 2,
+        body: "child-b",
+        children: [],
+      },
+      {
+        sectionIdentifier: "child-a",
+        title: "Child A",
+        displayOrder: 10,
+        depth: 2,
+        body: "child-a",
+        children: [],
+      },
+    ],
+  },
+  {
+    sectionIdentifier: "first",
+    title: "First",
+    displayOrder: 10,
+    depth: 1,
+    body: "first",
+    children: [],
+  },
+];
+
+describe("wikiDetailView", () => {
+  it("builds a compact list of basic fields", () => {
+    expect(getWikiBasicFields(basic)).toEqual([
+      { label: "Resource Type", value: "group" },
+      { label: "Group Type", value: "Girl Group" },
+      { label: "Status", value: "Active" },
+      { label: "Generation", value: "5th" },
+      { label: "Debut Date", value: "2022-03-14" },
+      { label: "Fandom Name", value: "Daybreak" },
+      { label: "Representative Symbol", value: "Solar wave" },
+      { label: "Official Colors", value: "Solar Gold, Midnight Blue" },
+      { label: "Agency", value: "North Harbor Entertainment" },
+    ]);
+  });
+
+  it("sorts sections recursively by display order", () => {
+    expect(sortWikiSections(sections)).toEqual([
+      {
+        sectionIdentifier: "first",
+        title: "First",
+        displayOrder: 10,
+        depth: 1,
+        body: "first",
+        children: [],
+      },
+      {
+        sectionIdentifier: "second",
+        title: "Second",
+        displayOrder: 20,
+        depth: 1,
+        body: "second",
+        children: [
+          {
+            sectionIdentifier: "child-a",
+            title: "Child A",
+            displayOrder: 10,
+            depth: 2,
+            body: "child-a",
+            children: [],
+          },
+          {
+            sectionIdentifier: "child-b",
+            title: "Child B",
+            displayOrder: 20,
+            depth: 2,
+            body: "child-b",
+            children: [],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("derives the horizontal offset from section depth", () => {
+    expect(getSectionOffset(1)).toBe(0);
+    expect(getSectionOffset(2)).toBe(24);
+    expect(getSectionOffset(4)).toBe(72);
+  });
+});

--- a/src/app/wiki/[wikiId]/wikiDetailView.ts
+++ b/src/app/wiki/[wikiId]/wikiDetailView.ts
@@ -1,0 +1,49 @@
+import type { WikiBasic, WikiSection } from "@/types/wiki-detail";
+
+export type WikiBasicField = {
+  label: string;
+  value: string;
+};
+
+const basicFieldLabels: Array<{
+  label: string;
+  getValue: (basic: WikiBasic) => string | null;
+}> = [
+  { label: "Resource Type", getValue: (basic) => basic.resourceType },
+  { label: "Group Type", getValue: (basic) => basic.groupType },
+  { label: "Status", getValue: (basic) => basic.status },
+  { label: "Generation", getValue: (basic) => basic.generation },
+  { label: "Debut Date", getValue: (basic) => basic.debutDate },
+  { label: "Fandom Name", getValue: (basic) => basic.fandomName },
+  { label: "Representative Symbol", getValue: (basic) => basic.representativeSymbol },
+  {
+    label: "Official Colors",
+    getValue: (basic) => basic.officialColors.join(", "),
+  },
+  { label: "Agency", getValue: (basic) => basic.agencyName },
+];
+
+export const getWikiBasicFields = (basic: WikiBasic): WikiBasicField[] =>
+  basicFieldLabels.flatMap((field) => {
+    const value = field.getValue(basic);
+
+    return value
+      ? [
+          {
+            label: field.label,
+            value,
+          },
+        ]
+      : [];
+  });
+
+export const sortWikiSections = (sections: WikiSection[]): WikiSection[] =>
+  [...sections]
+    .sort((left, right) => left.displayOrder - right.displayOrder)
+    .map((section) => ({
+      ...section,
+      children: sortWikiSections(section.children),
+    }));
+
+export const getSectionOffset = (depth: number): number =>
+  Math.max(depth - 1, 0) * 24;

--- a/src/types/wiki-detail.ts
+++ b/src/types/wiki-detail.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+export type WikiSection = {
+  sectionIdentifier: string;
+  title: string;
+  displayOrder: number;
+  depth: number;
+  body: string;
+  children: WikiSection[];
+};
+
+const wikiSectionSchema: z.ZodType<WikiSection> = z.lazy(() =>
+  z.object({
+    sectionIdentifier: z.string(),
+    title: z.string(),
+    displayOrder: z.number().int(),
+    depth: z.number().int().min(1),
+    body: z.string(),
+    children: z.array(wikiSectionSchema),
+  }),
+);
+
+export const wikiBasicSchema = z.object({
+  name: z.string(),
+  normalizedName: z.string(),
+  resourceType: z.literal("group"),
+  groupType: z.string(),
+  status: z.string(),
+  generation: z.string(),
+  debutDate: z.string(),
+  fandomName: z.string(),
+  emoji: z.string(),
+  representativeSymbol: z.string(),
+  officialColors: z.array(z.string()),
+  agencyName: z.string().nullable(),
+});
+
+export const wikiDetailSchema = z.object({
+  wikiIdentifier: z.string(),
+  slug: z.string(),
+  language: z.string(),
+  resourceType: z.literal("group"),
+  version: z.number().int(),
+  heroImage: z.object({
+    src: z.string(),
+    alt: z.string(),
+  }),
+  summary: z.string(),
+  basic: wikiBasicSchema,
+  sections: z.array(wikiSectionSchema),
+});
+
+export type WikiBasic = z.infer<typeof wikiBasicSchema>;
+export type WikiDetail = z.infer<typeof wikiDetailSchema>;

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -15,9 +15,17 @@ test("home page shows the theme preview content", async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByText("--brand-primary")).toBeVisible();
   await expect(page.getByText("Deep Harbor")).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /Open Wiki Detail Demo/i }),
+  ).toBeVisible();
 
   await expect(page.getByTestId("theme-mode-label")).toHaveText(/light|dark/i);
   await page.getByRole("button", { name: /toggle color theme/i }).click();
   await expect(page.getByTestId("theme-mode-label")).toHaveText("Dark");
   await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+  await page.getByRole("link", { name: /Open Wiki Detail Demo/i }).click();
+  await expect(
+    page.getByRole("heading", { name: /Aurora Echo/i }),
+  ).toBeVisible();
 });

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+test("wiki detail page shows the public layout and flip interaction", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/wiki/aurora-echo");
+
+  await expect(
+    page.getByRole("heading", { name: /Aurora Echo/i }),
+  ).toBeVisible();
+  const flipInput = page.getByTestId("wiki-flip-input");
+  const flipButton = page.getByTestId("wiki-flip-front-toggle");
+  const flipCard = page.getByTestId("wiki-flip-card");
+
+  await expect(flipInput).not.toBeChecked();
+
+  await flipButton.click();
+
+  await expect(flipInput).toBeChecked();
+  await expect(flipCard.getByText("North Harbor Entertainment")).toBeVisible();
+  const overviewToggle = page.getByTestId("section-toggle-sec-overview");
+  const overviewSection = page.getByTestId("section-sec-overview");
+  await expect(overviewSection).not.toHaveAttribute("open", "");
+  await overviewToggle.click({ force: true });
+  await expect(overviewSection).toHaveAttribute("open", "");
+  await expect(
+    page.getByText(
+      /Aurora Echo debuted with a performance style built around fluid formations/i,
+    ),
+  ).toBeVisible();
+});
+
+test("wiki detail page shows the empty state", async ({ page }) => {
+  await page.goto("/wiki/empty");
+
+  await expect(page.getByText("No public wiki yet")).toBeVisible();
+});


### PR DESCRIPTION
## 📝 変更内容

- 公開用の個別 Wiki 詳細ページ `/wiki/[wikiId]` を追加
- モバイルではフリップカード、デスクトップでは 2 カラムで基本情報を見せる UI を実装
- セクションをアコーディオン表示し、ホームからデモページへの導線を追加
- モックデータ・Zod スキーマ・unit test・e2e test を追加
- セクション深度に応じたインデント計算を実装し、`pnpm build` が通る状態に修正

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Issue #17 の対応として、公開状態の Wiki 詳細ページを Next.js App Router 上にプロトタイプ実装するためです。
個別ページでヒーロー表現、基本情報、階層セクションを確認できる状態を先に作り、以降の API 連携や編集機能実装の土台にします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- ホーム画面から `Open Wiki Detail Demo` リンクで `/wiki/aurora-echo` に遷移できることを確認
- モバイル表示でカードをタップすると基本情報面へ反転し、再度操作できることを確認
- セクションアコーディオンが閉じた状態で初期表示され、展開時に本文が読めることを確認
- `/wiki/empty` で空状態メッセージが表示されることを確認

## 🔍 レビューのポイント

- `WikiDetailPage` のレイアウト分岐がモバイルとデスクトップで意図どおりか
- `wiki-detail` スキーマとモックデータ構造が今後の API 契約のたたき台として妥当か
- セクション階層のインデントとアコーディオン表示が期待どおりか

## 📖 関連情報

### 関連Issue・タスク

Closes #17

## ⚠️ 注意事項

現在はモックデータ表示であり、実 API 連携や編集アクションの保存処理は未実装です。

## 📸 スクリーンショット・デモ

スクリーンショット未添付です。手動確認内容を上記に記載しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [ ] 破壊的変更がある場合は適切に文書化した
