### PR TITLE
feat: テーマカラー設定を個別Wikiページに反映できるよう修正

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,6 +84,47 @@ body {
   font-family: var(--font-sans);
 }
 
+.wiki-theme-scope {
+  --wiki-page-background: var(--wiki-page-background-light);
+  --wiki-header-background: var(--wiki-header-background-light);
+  --wiki-header-text: var(--wiki-header-text-light);
+  --wiki-hero-overlay: var(--wiki-hero-overlay-light);
+  --wiki-hero-accent: var(--wiki-hero-accent-light);
+  --wiki-card-background: var(--wiki-card-background-light);
+  --wiki-card-background-muted: var(--wiki-card-background-muted-light);
+  --wiki-card-border: var(--wiki-card-border-light);
+  --wiki-accent-background: var(--wiki-accent-background-light);
+  --wiki-accent-text: var(--wiki-accent-text-light);
+}
+
+:root[data-theme="dark"] .wiki-theme-scope {
+  --wiki-page-background: var(--wiki-page-background-dark);
+  --wiki-header-background: var(--wiki-header-background-dark);
+  --wiki-header-text: var(--wiki-header-text-dark);
+  --wiki-hero-overlay: var(--wiki-hero-overlay-dark);
+  --wiki-hero-accent: var(--wiki-hero-accent-dark);
+  --wiki-card-background: var(--wiki-card-background-dark);
+  --wiki-card-background-muted: var(--wiki-card-background-muted-dark);
+  --wiki-card-border: var(--wiki-card-border-dark);
+  --wiki-accent-background: var(--wiki-accent-background-dark);
+  --wiki-accent-text: var(--wiki-accent-text-dark);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .wiki-theme-scope {
+    --wiki-page-background: var(--wiki-page-background-dark);
+    --wiki-header-background: var(--wiki-header-background-dark);
+    --wiki-header-text: var(--wiki-header-text-dark);
+    --wiki-hero-overlay: var(--wiki-hero-overlay-dark);
+    --wiki-hero-accent: var(--wiki-hero-accent-dark);
+    --wiki-card-background: var(--wiki-card-background-dark);
+    --wiki-card-background-muted: var(--wiki-card-background-muted-dark);
+    --wiki-card-border: var(--wiki-card-border-dark);
+    --wiki-accent-background: var(--wiki-accent-background-dark);
+    --wiki-accent-text: var(--wiki-accent-text-dark);
+  }
+}
+
 .section-accordion[open] > summary .section-accordion__chevron {
   transform: rotate(180deg);
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -35,5 +35,20 @@ describe("Home", () => {
         name: /Open Wiki Detail Demo/i,
       }),
     ).toHaveAttribute("href", "/wiki/aurora-echo");
+    expect(
+      screen.getByRole("heading", {
+        name: /Wiki theme color checks/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /Rose Stage Warm magenta tint with brighter accents/i,
+      }),
+    ).toHaveAttribute("href", "/wiki/aurora-echo?themeColor=%23d94f70");
+    expect(
+      screen.getByRole("link", {
+        name: /Signal Mint High-chroma green stress case/i,
+      }),
+    ).toHaveAttribute("href", "/wiki/aurora-echo?themeColor=%2300d084");
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,32 @@ import { ThemeToggle } from "./ThemeToggle";
 import { getThemePaletteSections } from "./themePalette";
 
 const paletteSections = getThemePaletteSections();
+const wikiThemeDemos = [
+  {
+    name: "Default",
+    description: "Current fixed palette without themeColor",
+    href: "/wiki/aurora-echo",
+    swatch: "linear-gradient(135deg, #3560a3 0%, #f1a81f 100%)",
+  },
+  {
+    name: "Rose Stage",
+    description: "Warm magenta tint with brighter accents",
+    href: "/wiki/aurora-echo?themeColor=%23d94f70",
+    swatch: "#d94f70",
+  },
+  {
+    name: "Signal Mint",
+    description: "High-chroma green stress case",
+    href: "/wiki/aurora-echo?themeColor=%2300d084",
+    swatch: "#00d084",
+  },
+  {
+    name: "Night Pulse",
+    description: "Deep blue-purple for dark theme checks",
+    href: "/wiki/aurora-echo?themeColor=%234c5cff",
+    swatch: "#4c5cff",
+  },
+];
 
 export default function Home() {
   return (
@@ -63,6 +89,55 @@ export default function Home() {
                 <li>Background hierarchy comes from surface and text tokens.</li>
               </ul>
             </div>
+          </div>
+        </section>
+
+        <section
+          aria-labelledby="wiki-theme-demo-heading"
+          className="rounded-[2rem] border border-stroke-subtle bg-surface-raised p-6 shadow-soft sm:p-8"
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-text-muted">
+                Demo
+              </p>
+              <h2
+                id="wiki-theme-demo-heading"
+                className="text-3xl font-semibold tracking-[-0.03em]"
+              >
+                Wiki theme color checks
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-text-muted">
+              Each shortcut opens the same Wiki detail page with a different
+              `themeColor` payload so gradients, cards, and contrast can be
+              reviewed quickly.
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-4">
+            {wikiThemeDemos.map((demo) => (
+              <Link
+                key={demo.name}
+                className="group rounded-[1.5rem] border border-stroke-subtle bg-surface-base p-4 transition hover:-translate-y-0.5 hover:shadow-soft"
+                data-testid={`wiki-theme-demo-${demo.name.toLowerCase().replace(/\s+/g, "-")}`}
+                href={demo.href}
+              >
+                <div
+                  aria-hidden="true"
+                  className="h-24 rounded-[1.25rem] border border-black/5"
+                  style={{
+                    background: demo.swatch,
+                  }}
+                />
+                <p className="mt-4 text-lg font-semibold tracking-[-0.02em] text-text-strong">
+                  {demo.name}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-text-muted">
+                  {demo.description}
+                </p>
+              </Link>
+            ))}
           </div>
         </section>
 

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -5,10 +5,45 @@ import { type WikiSection } from "@/types/wiki-detail";
 import { useId, useState } from "react";
 
 import { getWikiBasicFields, sortWikiSections } from "./wikiDetailView";
+import { buildWikiThemeCssVariables } from "./wikiThemePalette";
 import { useWikiDetail } from "./useWikiDetail";
 
 type WikiDetailPageProps = {
   slug: string;
+  themeColor?: string;
+};
+
+const mainBackgroundStyle = {
+  backgroundColor: "var(--background)",
+  backgroundImage:
+    "var(--wiki-page-background, radial-gradient(circle at top, rgba(255,214,194,0.85), transparent 38%), linear-gradient(180deg, var(--background) 0%, #fff 100%))",
+};
+
+const cardSurfaceStyle = {
+  backgroundColor: "var(--wiki-card-background, var(--surface-raised))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+const cardSurfaceMutedStyle = {
+  backgroundColor: "var(--wiki-card-background-muted, var(--surface-base))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+const transparentFrameStyle = {
+  backgroundColor: "transparent",
+  borderColor: "transparent",
+  boxShadow: "none",
+};
+
+const heroOverlayStyle = {
+  backgroundImage:
+    "var(--wiki-hero-overlay, linear-gradient(to bottom, rgba(21, 36, 59, 0.05), transparent 55%, rgba(21, 36, 59, 0.92)))",
+};
+
+const accentBadgeStyle = {
+  backgroundColor: "var(--wiki-accent-background, rgba(255, 214, 194, 0.3))",
+  color: "var(--wiki-accent-text, var(--text-strong))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
 };
 
 function EditIcon() {
@@ -51,12 +86,16 @@ function SectionAccordion({ section }: { section: WikiSection }) {
     <details
       className="section-accordion rounded-[1.75rem] border border-stroke-subtle bg-surface-raised shadow-soft"
       data-testid={`section-${section.sectionIdentifier}`}
+      style={cardSurfaceStyle}
     >
       <summary
         className="flex list-none items-center gap-3 cursor-pointer p-5 text-left"
         data-testid={`section-toggle-${section.sectionIdentifier}`}
       >
-        <span className="rounded-full border border-stroke-subtle p-2 text-text-muted">
+        <span
+          className="rounded-full border border-stroke-subtle p-2 text-text-muted"
+          style={cardSurfaceMutedStyle}
+        >
           <ChevronIcon />
         </span>
         <span className="min-w-0 flex-1">
@@ -68,12 +107,16 @@ function SectionAccordion({ section }: { section: WikiSection }) {
           aria-label={`Edit section ${section.title}`}
           className="rounded-full border border-stroke-subtle p-3 text-text-strong transition group-hover:bg-brand-highlight/30"
           role="img"
+          style={cardSurfaceMutedStyle}
         >
           <EditIcon />
         </span>
       </summary>
 
-      <div className="border-t border-stroke-subtle px-5 pb-5 pt-4">
+      <div
+        className="border-t border-stroke-subtle px-5 pb-5 pt-4"
+        style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}
+      >
         <p className="max-w-3xl text-sm leading-7 text-text-muted">
           {section.body}
         </p>
@@ -89,8 +132,8 @@ function SectionAccordion({ section }: { section: WikiSection }) {
   );
 }
 
-export function WikiDetailPage({ slug }: WikiDetailPageProps) {
-  const wikiDetail = useWikiDetail(slug);
+export function WikiDetailPage({ slug, themeColor }: WikiDetailPageProps) {
+  const wikiDetail = useWikiDetail(slug, { themeColor });
   const flipCardId = useId();
   const [isFlipped, setIsFlipped] = useState(false);
 
@@ -142,27 +185,40 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
   const { data } = wikiDetail;
   const basicFields = getWikiBasicFields(data.basic);
   const sections = sortWikiSections(data.sections);
+  const themeStyles = buildWikiThemeCssVariables(data.themeColor);
+  const themeLabel = data.themeColor?.toUpperCase();
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(255,214,194,0.85),_transparent_38%),linear-gradient(180deg,_var(--background)_0%,_#fff_100%)] px-5 py-6 text-text-strong sm:px-8 sm:py-10">
+    <main
+      className="wiki-theme-scope min-h-screen px-5 py-6 text-text-strong sm:px-8 sm:py-10"
+      data-testid="wiki-theme-root"
+      style={{
+        ...themeStyles,
+        ...mainBackgroundStyle,
+      }}
+    >
       <div className="mx-auto flex max-w-6xl flex-col gap-8">
-        <header className="lg:hidden">
-          <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong">
-            {data.basic.name}
-          </h1>
+        <header>
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
+              {data.basic.name}
+            </h1>
+            {themeLabel ? (
+              <span
+                className="rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]"
+                data-testid="wiki-theme-badge"
+                style={accentBadgeStyle}
+              >
+                Theme {themeLabel}
+              </span>
+            ) : null}
+          </div>
         </header>
 
-        <section className="lg:overflow-hidden lg:rounded-[2rem] lg:border lg:border-stroke-subtle lg:bg-surface-raised lg:shadow-soft">
-          <div className="hidden border-b border-stroke-subtle bg-brand-primary px-6 py-6 text-white sm:px-8 lg:block">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h1 className="mt-3 hidden text-4xl font-semibold tracking-[-0.05em] lg:block lg:text-5xl">
-                  {data.basic.name}
-                </h1>
-              </div>
-            </div>
-          </div>
-
+        <section
+          className="lg:rounded-[2rem]"
+          style={transparentFrameStyle}
+        >
           <div className="grid gap-5 lg:hidden">
             <div className="space-y-4">
               <input
@@ -185,7 +241,10 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                     }`}
                     data-testid="wiki-flip-card"
                   >
-                    <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-[2rem] border border-stroke-subtle bg-surface-raised [backface-visibility:hidden]">
+                    <div
+                      className="pointer-events-none absolute inset-0 overflow-hidden rounded-[2rem] border border-stroke-subtle bg-surface-raised [backface-visibility:hidden]"
+                      style={cardSurfaceStyle}
+                    >
                       <div className="relative h-full w-full">
                         <Image
                           alt={data.heroImage.alt}
@@ -195,9 +254,12 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                           src={data.heroImage.src}
                         />
                       </div>
-                      <div className="absolute inset-0 bg-gradient-to-b from-[#15243b]/5 via-transparent via-55% to-[#15243b]/92" />
+                      <div className="absolute inset-0" style={heroOverlayStyle} />
                       <div className="absolute inset-x-0 bottom-0 px-5 py-6 text-white">
-                        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-brand-highlight">
+                        <p
+                          className="text-xs font-semibold uppercase tracking-[0.28em]"
+                          style={{ color: "var(--wiki-hero-accent, var(--brand-highlight))" }}
+                        >
                           Tap The Card
                         </p>
                         <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
@@ -223,6 +285,7 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                         isFlipped ? "pointer-events-auto" : "pointer-events-none"
                       }`}
                       onClick={() => setIsFlipped(false)}
+                      style={cardSurfaceStyle}
                     >
                       <div className="flex items-start justify-between gap-4">
                         <div>
@@ -239,19 +302,20 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                         onClick={(event) => event.stopPropagation()}
                       >
                         <dl className="grid gap-4">
-                        {basicFields.map((field) => (
-                          <div
-                            key={field.label}
-                            className="rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-3"
-                          >
-                            <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
-                              {field.label}
-                            </dt>
-                            <dd className="mt-1 text-sm leading-6 text-text-strong">
-                              {field.value}
-                            </dd>
-                          </div>
-                        ))}
+                          {basicFields.map((field) => (
+                            <div
+                              key={field.label}
+                              className="rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-3"
+                              style={cardSurfaceMutedStyle}
+                            >
+                              <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
+                                {field.label}
+                              </dt>
+                              <dd className="mt-1 text-sm leading-6 text-text-strong">
+                                {field.value}
+                              </dd>
+                            </div>
+                          ))}
                         </dl>
                       </div>
                     </div>
@@ -270,9 +334,12 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
             </div>
           </div>
 
-          <div className="hidden gap-6 px-6 py-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
-            <div className="overflow-hidden rounded-[1.75rem] border border-stroke-subtle">
-              <div className="relative min-h-[30rem]">
+          <div className="hidden gap-6 py-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
+            <div
+              className="h-full overflow-hidden rounded-[1.75rem] border border-stroke-subtle"
+              style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}
+            >
+              <div className="relative h-full min-h-[30rem]">
                 <Image
                   alt={data.heroImage.alt}
                   className="object-cover"
@@ -283,7 +350,10 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
               </div>
             </div>
 
-            <div className="rounded-[1.75rem] border border-stroke-subtle bg-surface-base p-6">
+            <div
+              className="rounded-[1.75rem] border border-stroke-subtle bg-surface-base p-6"
+              style={cardSurfaceMutedStyle}
+            >
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
@@ -297,6 +367,7 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                   aria-label="Edit basic"
                   type="button"
                   className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                  style={cardSurfaceStyle}
                 >
                   <EditIcon />
                 </button>
@@ -306,6 +377,7 @@ export function WikiDetailPage({ slug }: WikiDetailPageProps) {
                   <div
                     key={field.label}
                     className="rounded-2xl border border-stroke-subtle bg-surface-raised px-4 py-3"
+                    style={cardSurfaceStyle}
                   >
                     <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
                       {field.label}

--- a/src/app/wiki/[slug]/mockWikiDetail.ts
+++ b/src/app/wiki/[slug]/mockWikiDetail.ts
@@ -18,13 +18,21 @@ const heroImageDataUri =
     </svg>
   `);
 
-export const createMockWikiDetail = (slug: string): WikiDetail =>
+type CreateMockWikiDetailOptions = {
+  themeColor?: string;
+};
+
+export const createMockWikiDetail = (
+  slug: string,
+  options?: CreateMockWikiDetailOptions,
+): WikiDetail =>
   wikiDetailSchema.parse({
     wikiIdentifier: slug,
     slug,
     language: "ja",
     resourceType: "group",
     version: 3,
+    themeColor: options?.themeColor ?? null,
     heroImage: {
       src: heroImageDataUri,
       alt: "Stage lights washing over a concert crowd in blue and gold",

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -19,6 +19,7 @@ const successState: WikiDetailState = {
     language: "ja",
     resourceType: "group",
     version: 3,
+    themeColor: null,
     heroImage: {
       src: "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 900'%3E%3Crect width='1200' height='900' fill='%233560a3'/%3E%3C/svg%3E",
       alt: "Aurora Echo hero image",
@@ -74,6 +75,7 @@ describe("WikiDetailPage", () => {
     expect(screen.getByText("Overview")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
     expect(screen.getAllByLabelText(/Edit section/i)).toHaveLength(2);
+    expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
   });
 
   it("renders sections as closed accordions by default", () => {
@@ -101,6 +103,30 @@ describe("WikiDetailPage", () => {
       screen.getAllByText("Tap the card again to return to the cover image.")[0],
     ).toBeInTheDocument();
     expect(screen.getAllByText("Group profile")[0]).toBeInTheDocument();
+  });
+
+  it("injects theme css variables and badges when themeColor is provided", () => {
+    mockedUseWikiDetail.mockReturnValue({
+      ...successState,
+      data: {
+        ...successState.data,
+        themeColor: "#d94f70",
+      },
+    });
+
+    const { container } = render(
+      React.createElement(WikiDetailPage, { slug: "aurora-echo" }),
+    );
+
+    expect(screen.getByTestId("wiki-theme-badge")).toHaveTextContent(
+      "Theme #D94F70",
+    );
+    const rootStyle = container
+      .querySelector('[data-testid="wiki-theme-root"]')
+      ?.getAttribute("style");
+
+    expect(rootStyle).toContain("--wiki-page-background-light:");
+    expect(rootStyle).toContain("--wiki-header-background-dark:");
   });
 
   it("renders the empty state", () => {

--- a/src/app/wiki/[slug]/page.tsx
+++ b/src/app/wiki/[slug]/page.tsx
@@ -4,10 +4,17 @@ type WikiDetailRouteProps = {
   params: Promise<{
     slug: string;
   }>;
+  searchParams: Promise<{
+    themeColor?: string | string[];
+  }>;
 };
 
-export default async function Page({ params }: WikiDetailRouteProps) {
-  const { slug } = await params;
+const getThemeColor = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
 
-  return <WikiDetailPage slug={slug} />;
+export default async function Page({ params, searchParams }: WikiDetailRouteProps) {
+  const { slug } = await params;
+  const { themeColor } = await searchParams;
+
+  return <WikiDetailPage slug={slug} themeColor={getThemeColor(themeColor)} />;
 }

--- a/src/app/wiki/[slug]/useWikiDetail.ts
+++ b/src/app/wiki/[slug]/useWikiDetail.ts
@@ -24,7 +24,14 @@ export type WikiDetailState =
   | WikiDetailEmptyState
   | WikiDetailSuccessState;
 
-export const useWikiDetail = (slug: string): WikiDetailState => {
+type UseWikiDetailOptions = {
+  themeColor?: string;
+};
+
+export const useWikiDetail = (
+  slug: string,
+  options?: UseWikiDetailOptions,
+): WikiDetailState => {
   if (slug === "loading") {
     return { status: "loading" };
   }
@@ -43,6 +50,6 @@ export const useWikiDetail = (slug: string): WikiDetailState => {
 
   return {
     status: "success",
-    data: createMockWikiDetail(slug),
+    data: createMockWikiDetail(slug, { themeColor: options?.themeColor }),
   };
 };

--- a/src/app/wiki/[slug]/wikiThemePalette.test.ts
+++ b/src/app/wiki/[slug]/wikiThemePalette.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWikiThemeCssVariables,
+  createWikiThemePalette,
+  wikiThemeTestHelpers,
+} from "./wikiThemePalette";
+
+describe("wikiThemePalette", () => {
+  it("returns no css variables when themeColor is missing or invalid", () => {
+    expect(buildWikiThemeCssVariables(undefined)).toBeUndefined();
+    expect(buildWikiThemeCssVariables("")).toBeUndefined();
+    expect(buildWikiThemeCssVariables("not-a-color")).toBeUndefined();
+  });
+
+  it("normalizes shorthand and full hex colors", () => {
+    expect(wikiThemeTestHelpers.normalizeHexColor("#abc")).toBe("#aabbcc");
+    expect(wikiThemeTestHelpers.normalizeHexColor("D46A6A")).toBe("#d46a6a");
+  });
+
+  it("keeps readable contrast for light and dark palettes", () => {
+    const lightPalette = createWikiThemePalette("#ff0055", "light");
+    const darkPalette = createWikiThemePalette("#00ff66", "dark");
+
+    expect(
+      wikiThemeTestHelpers.getContrastRatio(
+        lightPalette.headerBackground,
+        lightPalette.headerText,
+      ),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      wikiThemeTestHelpers.getContrastRatio(
+        darkPalette.headerBackground,
+        darkPalette.headerText,
+      ),
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(lightPalette.pageBackground).toContain("radial-gradient");
+    expect(darkPalette.pageBackground).toContain("linear-gradient");
+  });
+
+  it("softens extreme colors into derived surfaces instead of flat fills", () => {
+    const palette = createWikiThemePalette("#00ff00", "light");
+
+    expect(palette.cardBackground).not.toBe("#00ff00");
+    expect(palette.cardBackgroundMuted).not.toBe("#00ff00");
+    expect(palette.cardBorder).toContain("rgba(");
+  });
+
+  it("builds paired light and dark css variables for the page", () => {
+    const variables = buildWikiThemeCssVariables("#4c7dff");
+
+    expect(variables).toMatchObject({
+      "--wiki-page-background-light": expect.stringContaining("radial-gradient"),
+      "--wiki-page-background-dark": expect.stringContaining("linear-gradient"),
+      "--wiki-header-background-light": expect.stringMatching(/^#/),
+      "--wiki-header-background-dark": expect.stringMatching(/^#/),
+    });
+  });
+});

--- a/src/app/wiki/[slug]/wikiThemePalette.ts
+++ b/src/app/wiki/[slug]/wikiThemePalette.ts
@@ -1,0 +1,288 @@
+import type { CSSProperties } from "react";
+
+import type { ThemeMode } from "@/app/themeMode";
+
+type RgbColor = {
+  red: number;
+  green: number;
+  blue: number;
+};
+
+type HslColor = {
+  hue: number;
+  saturation: number;
+  lightness: number;
+};
+
+type ThemeBase = {
+  surfaceBase: string;
+  surfaceRaised: string;
+  textStrong: string;
+  headerBase: string;
+  highlight: string;
+};
+
+export type WikiThemePalette = {
+  pageBackground: string;
+  headerBackground: string;
+  headerText: string;
+  heroOverlay: string;
+  heroAccent: string;
+  cardBackground: string;
+  cardBackgroundMuted: string;
+  cardBorder: string;
+  accentBackground: string;
+  accentText: string;
+};
+
+const themeBases: Record<ThemeMode, ThemeBase> = {
+  light: {
+    surfaceBase: "#fffbf7",
+    surfaceRaised: "#ffffff",
+    textStrong: "#1d2f49",
+    headerBase: "#3560a3",
+    highlight: "#ffd6c2",
+  },
+  dark: {
+    surfaceBase: "#16223a",
+    surfaceRaised: "#21304b",
+    textStrong: "#fff7ef",
+    headerBase: "#9fc0f2",
+    highlight: "#4a6492",
+  },
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const normalizeHexColor = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  const normalized = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+
+  if (/^[0-9a-fA-F]{3}$/.test(normalized)) {
+    return `#${normalized
+      .split("")
+      .map((character) => `${character}${character}`)
+      .join("")
+      .toLowerCase()}`;
+  }
+
+  if (/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return `#${normalized.toLowerCase()}`;
+  }
+
+  return null;
+};
+
+const hexToRgb = (hexColor: string): RgbColor => {
+  const normalized = hexColor.slice(1);
+
+  return {
+    red: Number.parseInt(normalized.slice(0, 2), 16),
+    green: Number.parseInt(normalized.slice(2, 4), 16),
+    blue: Number.parseInt(normalized.slice(4, 6), 16),
+  };
+};
+
+const rgbToHex = ({ red, green, blue }: RgbColor): string =>
+  `#${[red, green, blue]
+    .map((channel) => clamp(Math.round(channel), 0, 255).toString(16).padStart(2, "0"))
+    .join("")}`;
+
+const rgbToRgba = ({ red, green, blue }: RgbColor, alpha: number): string =>
+  `rgba(${Math.round(red)}, ${Math.round(green)}, ${Math.round(blue)}, ${clamp(alpha, 0, 1)})`;
+
+const mixColors = (left: string, right: string, ratio: number): string => {
+  const mixRatio = clamp(ratio, 0, 1);
+  const leftColor = hexToRgb(left);
+  const rightColor = hexToRgb(right);
+
+  return rgbToHex({
+    red: leftColor.red + (rightColor.red - leftColor.red) * mixRatio,
+    green: leftColor.green + (rightColor.green - leftColor.green) * mixRatio,
+    blue: leftColor.blue + (rightColor.blue - leftColor.blue) * mixRatio,
+  });
+};
+
+const rgbToHsl = ({ red, green, blue }: RgbColor): HslColor => {
+  const redUnit = red / 255;
+  const greenUnit = green / 255;
+  const blueUnit = blue / 255;
+  const maxChannel = Math.max(redUnit, greenUnit, blueUnit);
+  const minChannel = Math.min(redUnit, greenUnit, blueUnit);
+  const delta = maxChannel - minChannel;
+  const lightness = (maxChannel + minChannel) / 2;
+
+  if (delta === 0) {
+    return { hue: 0, saturation: 0, lightness };
+  }
+
+  const saturation =
+    lightness > 0.5 ? delta / (2 - maxChannel - minChannel) : delta / (maxChannel + minChannel);
+
+  const hueSegment =
+    maxChannel === redUnit
+      ? ((greenUnit - blueUnit) / delta + (greenUnit < blueUnit ? 6 : 0)) / 6
+      : maxChannel === greenUnit
+        ? ((blueUnit - redUnit) / delta + 2) / 6
+        : ((redUnit - greenUnit) / delta + 4) / 6;
+
+  return {
+    hue: hueSegment,
+    saturation,
+    lightness,
+  };
+};
+
+const hslToRgb = ({ hue, saturation, lightness }: HslColor): RgbColor => {
+  if (saturation === 0) {
+    const grayscale = lightness * 255;
+    return { red: grayscale, green: grayscale, blue: grayscale };
+  }
+
+  const hueToChannel = (offset: number): number => {
+    const wrapped = (offset + 1) % 1;
+
+    if (wrapped < 1 / 6) {
+      return temporaryOne + (temporaryTwo - temporaryOne) * 6 * wrapped;
+    }
+
+    if (wrapped < 1 / 2) {
+      return temporaryTwo;
+    }
+
+    if (wrapped < 2 / 3) {
+      return temporaryOne + (temporaryTwo - temporaryOne) * (2 / 3 - wrapped) * 6;
+    }
+
+    return temporaryOne;
+  };
+
+  const temporaryTwo =
+    lightness < 0.5
+      ? lightness * (1 + saturation)
+      : lightness + saturation - lightness * saturation;
+  const temporaryOne = 2 * lightness - temporaryTwo;
+
+  return {
+    red: hueToChannel(hue + 1 / 3) * 255,
+    green: hueToChannel(hue) * 255,
+    blue: hueToChannel(hue - 1 / 3) * 255,
+  };
+};
+
+const getRelativeLuminance = (hexColor: string): number => {
+  const transform = (value: number): number => {
+    const channel = value / 255;
+    return channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+  };
+
+  const { red, green, blue } = hexToRgb(hexColor);
+
+  return 0.2126 * transform(red) + 0.7152 * transform(green) + 0.0722 * transform(blue);
+};
+
+const getContrastRatio = (left: string, right: string): number => {
+  const leftLuminance = getRelativeLuminance(left);
+  const rightLuminance = getRelativeLuminance(right);
+  const [lighter, darker] =
+    leftLuminance >= rightLuminance
+      ? [leftLuminance, rightLuminance]
+      : [rightLuminance, leftLuminance];
+
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const pickReadableText = (background: string, darkText: string, lightText: string): string =>
+  getContrastRatio(background, darkText) >= getContrastRatio(background, lightText)
+    ? darkText
+    : lightText;
+
+const getBalancedThemeColor = (themeColor: string, mode: ThemeMode): string => {
+  const hslColor = rgbToHsl(hexToRgb(themeColor));
+
+  return rgbToHex(
+    hslToRgb({
+      hue: hslColor.hue,
+      saturation: clamp(hslColor.saturation, 0.24, mode === "light" ? 0.72 : 0.64),
+      lightness: clamp(
+        hslColor.lightness,
+        mode === "light" ? 0.38 : 0.5,
+        mode === "light" ? 0.62 : 0.72,
+      ),
+    }),
+  );
+};
+
+export const createWikiThemePalette = (
+  themeColor: string,
+  mode: ThemeMode,
+): WikiThemePalette => {
+  const base = themeBases[mode];
+  const balancedThemeColor = getBalancedThemeColor(themeColor, mode);
+  const glowColor = mixColors(base.highlight, balancedThemeColor, mode === "light" ? 0.48 : 0.62);
+  const headerBackground = mixColors(base.headerBase, balancedThemeColor, mode === "light" ? 0.62 : 0.44);
+  const cardBackground = mixColors(base.surfaceRaised, balancedThemeColor, mode === "light" ? 0.08 : 0.16);
+  const cardBackgroundMuted = mixColors(base.surfaceBase, balancedThemeColor, mode === "light" ? 0.12 : 0.2);
+  const accentBackground = mixColors(base.highlight, balancedThemeColor, mode === "light" ? 0.42 : 0.56);
+  const pageStart = mixColors(base.surfaceBase, balancedThemeColor, mode === "light" ? 0.06 : 0.14);
+  const pageEnd = mixColors(base.surfaceRaised, balancedThemeColor, mode === "light" ? 0.12 : 0.18);
+
+  return {
+    pageBackground: `radial-gradient(circle at top, ${rgbToRgba(hexToRgb(glowColor), mode === "light" ? 0.82 : 0.58)}, transparent 40%), linear-gradient(180deg, ${pageStart} 0%, ${pageEnd} 100%)`,
+    headerBackground,
+    headerText: pickReadableText(headerBackground, "#15243b", "#fffaf4"),
+    heroOverlay: `linear-gradient(180deg, ${rgbToRgba(hexToRgb(mixColors("#15243b", balancedThemeColor, 0.2)), mode === "light" ? 0.08 : 0.14)} 0%, ${rgbToRgba(hexToRgb(mixColors("#15243b", balancedThemeColor, 0.56)), mode === "light" ? 0.72 : 0.88)} 100%)`,
+    heroAccent: pickReadableText(accentBackground, "#15243b", "#fffaf4"),
+    cardBackground,
+    cardBackgroundMuted,
+    cardBorder: rgbToRgba(hexToRgb(mixColors(base.headerBase, balancedThemeColor, mode === "light" ? 0.4 : 0.5)), mode === "light" ? 0.24 : 0.34),
+    accentBackground,
+    accentText: pickReadableText(accentBackground, "#15243b", "#fffaf4"),
+  };
+};
+
+export const buildWikiThemeCssVariables = (
+  themeColor: string | null | undefined,
+): CSSProperties | undefined => {
+  const normalizedThemeColor = normalizeHexColor(themeColor);
+
+  if (!normalizedThemeColor) {
+    return undefined;
+  }
+
+  const lightPalette = createWikiThemePalette(normalizedThemeColor, "light");
+  const darkPalette = createWikiThemePalette(normalizedThemeColor, "dark");
+
+  return {
+    "--wiki-page-background-light": lightPalette.pageBackground,
+    "--wiki-page-background-dark": darkPalette.pageBackground,
+    "--wiki-header-background-light": lightPalette.headerBackground,
+    "--wiki-header-background-dark": darkPalette.headerBackground,
+    "--wiki-header-text-light": lightPalette.headerText,
+    "--wiki-header-text-dark": darkPalette.headerText,
+    "--wiki-hero-overlay-light": lightPalette.heroOverlay,
+    "--wiki-hero-overlay-dark": darkPalette.heroOverlay,
+    "--wiki-hero-accent-light": lightPalette.heroAccent,
+    "--wiki-hero-accent-dark": darkPalette.heroAccent,
+    "--wiki-card-background-light": lightPalette.cardBackground,
+    "--wiki-card-background-dark": darkPalette.cardBackground,
+    "--wiki-card-background-muted-light": lightPalette.cardBackgroundMuted,
+    "--wiki-card-background-muted-dark": darkPalette.cardBackgroundMuted,
+    "--wiki-card-border-light": lightPalette.cardBorder,
+    "--wiki-card-border-dark": darkPalette.cardBorder,
+    "--wiki-accent-background-light": lightPalette.accentBackground,
+    "--wiki-accent-background-dark": darkPalette.accentBackground,
+    "--wiki-accent-text-light": lightPalette.accentText,
+    "--wiki-accent-text-dark": darkPalette.accentText,
+  } as CSSProperties;
+};
+
+export const wikiThemeTestHelpers = {
+  getContrastRatio,
+  normalizeHexColor,
+};

--- a/src/types/wiki-detail.ts
+++ b/src/types/wiki-detail.ts
@@ -41,6 +41,7 @@ export const wikiDetailSchema = z.object({
   language: z.string(),
   resourceType: z.literal("group"),
   version: z.number().int(),
+  themeColor: z.string().nullable().optional(),
   heroImage: z.object({
     src: z.string(),
     alt: z.string(),

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -29,3 +29,18 @@ test("home page shows the theme preview content", async ({ page }) => {
     page.getByRole("heading", { name: /Aurora Echo/i }),
   ).toBeVisible();
 });
+
+test("home page demo links open the wiki detail page with a theme color override", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("wiki-theme-demo-rose-stage").click();
+
+  await expect(page).toHaveURL(/themeColor=%23d94f70/);
+  await expect(page.getByTestId("wiki-theme-badge")).toHaveText("Theme #D94F70");
+  await expect(page.getByTestId("wiki-theme-root")).toHaveAttribute(
+    "style",
+    /--wiki-page-background-light:/,
+  );
+});

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -4,11 +4,16 @@ test("wiki detail page shows the public layout and flip interaction", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
-  await page.goto("/wiki/aurora-echo");
+  await page.goto("/wiki/aurora-echo?themeColor=%234c5cff");
 
   await expect(
     page.getByRole("heading", { name: /Aurora Echo/i }),
   ).toBeVisible();
+  await expect(page.getByTestId("wiki-theme-badge")).toHaveText("Theme #4C5CFF");
+  await expect(page.getByTestId("wiki-theme-root")).toHaveAttribute(
+    "style",
+    /--wiki-header-background-light:/,
+  );
   const flipInput = page.getByTestId("wiki-flip-input");
   const flipButton = page.getByTestId("wiki-flip-front-toggle");
   const flipCard = page.getByTestId("wiki-flip-card");


### PR DESCRIPTION
## 📝 変更内容

- Wiki 詳細ページで `themeColor` クエリを受け取り、カラー値からライト/ダーク両対応の派生パレットを生成して CSS 変数として適用するように変更
- `WikiDetailPage` のカード、背景、アクセント表示を固定配色からテーマ変数参照に切り替え、テーマ指定時はバッジ表示も追加
- ホーム画面に複数の `themeColor` パターンを素早く確認できる Wiki デモリンク群を追加
- mock データと型定義に `themeColor` を追加し、unit test / e2e test を拡張

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki 詳細ページの見た目を複数テーマカラーで確認できるようにし、配色差し替え時でも背景・カード・アクセント・文字コントラストが破綻しない実装にするためです。ホームから確認導線を用意して、テーマ検証を手早く回せるようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- ホーム画面のデモリンクから `themeColor` 付きの Wiki 詳細ページへ遷移できることをテストで確認
- Wiki 詳細ページでテーマバッジと CSS 変数が適用されることを unit test / e2e test で確認

## 🔍 レビューのポイント

- `src/app/wiki/[slug]/wikiThemePalette.ts` の配色導出ロジックが極端な色でも破綻しにくいか
- `themeColor` 未指定時に従来表示へフォールバックする挙動に問題がないか
- ホームのデモリンク追加が既存導線やアクセシビリティに悪影響を与えていないか

## 📖 関連情報

### 関連Issue・タスク

Closes #28

## ⚠️ 注意事項

- API 連携ではなく mock データ経由で `themeColor` を扱っています
- `.codex/tmp/` に未追跡ファイルがありますが、PR 差分には含まれていません

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [ ] 破壊的変更がある場合は適切に文書化した
