### PR TITLE
feat: Wiki編集ページの作成

### DIFF
--- a/packages/wiki/src/index.ts
+++ b/packages/wiki/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./getWikiDetailState";
 export * from "./mockWikiDetail";
 export * from "./types/wiki";
+export * from "./wikiEditModel";
 export * from "./wikiDetailView";

--- a/packages/wiki/src/mockWikiDetail.ts
+++ b/packages/wiki/src/mockWikiDetail.ts
@@ -37,8 +37,6 @@ export const createMockWikiDetail = (
       src: heroImageDataUri,
       alt: "Stage lights washing over a concert crowd in blue and gold",
     },
-    summary:
-      "Five-member performance group blending precision choreography with live band arrangements and a city-pop visual language.",
     basic: {
       name: "Aurora Echo",
       normalizedName: "aurora-echo",
@@ -55,53 +53,187 @@ export const createMockWikiDetail = (
     },
     sections: [
       {
+        type: "section",
         sectionIdentifier: "sec-discography",
         title: "Discography",
         displayOrder: 30,
         depth: 1,
-        body: "The group balances brisk digital singles with a smaller number of concept-heavy mini albums.",
+        contents: [
+          {
+            blockIdentifier: "block-discography-text",
+            blockType: "text",
+            displayOrder: 10,
+            content:
+              "The group balances brisk digital singles with a smaller number of concept-heavy mini albums.",
+          },
+          {
+            blockIdentifier: "block-discography-image",
+            blockType: "image",
+            displayOrder: 20,
+            imageIdentifier: "img-discography-stage",
+            imageSrc: heroImageDataUri,
+            caption: "Editable discography image",
+            alt: "Concert stage image for Discography",
+          },
+          {
+            blockIdentifier: "block-discography-gallery",
+            blockType: "image_gallery",
+            displayOrder: 30,
+            images: [
+              {
+                imageIdentifier: "img-gallery-one",
+                imageSrc: heroImageDataUri,
+                alt: "Gallery image one",
+              },
+              {
+                imageIdentifier: "img-gallery-two",
+                imageSrc: heroImageDataUri,
+                alt: "Gallery image two",
+              },
+            ],
+            caption: "Editable gallery",
+          },
+          {
+            blockIdentifier: "block-discography-embed",
+            blockType: "embed",
+            displayOrder: 40,
+            provider: "youtube",
+            embedId: "low-tide-high-lights",
+            caption: "Stage video",
+          },
+          {
+            blockIdentifier: "block-discography-quote",
+            blockType: "quote",
+            displayOrder: 50,
+            content: "A dusk-to-dawn pop sequence.",
+            source: "K-Pool editorial",
+          },
+          {
+            blockIdentifier: "block-discography-list",
+            blockType: "list",
+            displayOrder: 60,
+            listType: "bullet",
+            items: ["Low Tide, High Lights", "Pearl Signal"],
+          },
+          {
+            blockIdentifier: "block-discography-table",
+            blockType: "table",
+            displayOrder: 70,
+            headers: ["Release", "Year"],
+            rows: [["Low Tide, High Lights", "2022"]],
+          },
+          {
+            blockIdentifier: "block-discography-profiles",
+            blockType: "profile_card_list",
+            displayOrder: 80,
+            wikiIdentifiers: ["aurora-echo"],
+            title: "Related profiles",
+          },
+        ],
         children: [
           {
+            type: "section",
             sectionIdentifier: "sec-discography-highlights",
             title: "Highlights",
             displayOrder: 20,
             depth: 2,
-            body: "The breakout single 'Low Tide, High Lights' established their retro-synth identity and remains their signature stage opener.",
+            contents: [
+              {
+                blockIdentifier: "block-discography-highlights-text",
+                blockType: "text",
+                displayOrder: 10,
+                content:
+                  "The breakout single 'Low Tide, High Lights' established their retro-synth identity and remains their signature stage opener.",
+              },
+              {
+                type: "section",
+                sectionIdentifier: "sec-discography-highlights-chart",
+                title: "Chart notes",
+                displayOrder: 20,
+                depth: 3,
+                contents: [
+                  {
+                    blockIdentifier: "block-discography-highlights-chart-text",
+                    blockType: "text",
+                    displayOrder: 10,
+                    content:
+                      "Depth three content is editable but cannot receive a child section.",
+                  },
+                ],
+                children: [],
+              },
+            ],
             children: [],
           },
           {
+            type: "section",
             sectionIdentifier: "sec-discography-albums",
             title: "Mini Albums",
             displayOrder: 10,
             depth: 2,
-            body: "Their first two mini albums framed a dusk-to-dawn narrative and expanded the live arrangement palette with brass and guitar sections.",
+            contents: [
+              {
+                blockIdentifier: "block-discography-albums-text",
+                blockType: "text",
+                displayOrder: 10,
+                content:
+                  "Their first two mini albums framed a dusk-to-dawn narrative and expanded the live arrangement palette with brass and guitar sections.",
+              },
+            ],
             children: [],
           },
         ],
       },
       {
+        type: "section",
         sectionIdentifier: "sec-overview",
         title: "Overview",
         displayOrder: 10,
         depth: 1,
-        body: "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
+        contents: [
+          {
+            blockIdentifier: "block-overview-text",
+            blockType: "text",
+            displayOrder: 10,
+            content:
+              "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
+          },
+        ],
         children: [
           {
+            type: "section",
             sectionIdentifier: "sec-overview-style",
             title: "Style",
             displayOrder: 10,
             depth: 2,
-            body: "The visual direction mixes marine tailoring, brushed metal details, and sunset-toned lighting for a polished but lived-in stage mood.",
+            contents: [
+              {
+                blockIdentifier: "block-overview-style-text",
+                blockType: "text",
+                displayOrder: 10,
+                content:
+                  "The visual direction mixes marine tailoring, brushed metal details, and sunset-toned lighting for a polished but lived-in stage mood.",
+              },
+            ],
             children: [],
           },
         ],
       },
       {
+        type: "section",
         sectionIdentifier: "sec-members",
         title: "Members",
         displayOrder: 20,
         depth: 1,
-        body: "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
+        contents: [
+          {
+            blockIdentifier: "block-members-text",
+            blockType: "text",
+            displayOrder: 10,
+            content:
+              "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
+          },
+        ],
         children: [],
       },
     ],

--- a/packages/wiki/src/types/wiki.ts
+++ b/packages/wiki/src/types/wiki.ts
@@ -1,21 +1,175 @@
 import { z } from "zod";
 
 export type WikiSection = {
+  type: "section";
   sectionIdentifier: string;
   title: string;
   displayOrder: number;
   depth: number;
-  body: string;
+  contents: WikiSectionContent[];
   children: WikiSection[];
 };
 
+export type WikiBlockType =
+  | "text"
+  | "image"
+  | "image_gallery"
+  | "embed"
+  | "quote"
+  | "list"
+  | "table"
+  | "profile_card_list";
+
+export type WikiEmbedProvider = "youtube" | "spotify" | "x" | "tiktok";
+
+export type WikiListType = "bullet" | "numbered";
+
+export type WikiTextBlock = {
+  blockIdentifier: string;
+  blockType: "text";
+  displayOrder: number;
+  content: string;
+};
+
+export type WikiImageBlock = {
+  blockIdentifier: string;
+  blockType: "image";
+  displayOrder: number;
+  imageIdentifier: string;
+  imageSrc: string;
+  caption: string | null;
+  alt: string | null;
+};
+
+export type WikiImageGalleryBlock = {
+  blockIdentifier: string;
+  blockType: "image_gallery";
+  displayOrder: number;
+  images: Array<{
+    imageIdentifier: string;
+    imageSrc: string;
+    alt: string | null;
+  }>;
+  caption: string | null;
+};
+
+export type WikiEmbedBlock = {
+  blockIdentifier: string;
+  blockType: "embed";
+  displayOrder: number;
+  provider: WikiEmbedProvider;
+  embedId: string;
+  caption: string | null;
+};
+
+export type WikiQuoteBlock = {
+  blockIdentifier: string;
+  blockType: "quote";
+  displayOrder: number;
+  content: string;
+  source: string | null;
+};
+
+export type WikiListBlock = {
+  blockIdentifier: string;
+  blockType: "list";
+  displayOrder: number;
+  listType: WikiListType;
+  items: string[];
+};
+
+export type WikiTableBlock = {
+  blockIdentifier: string;
+  blockType: "table";
+  displayOrder: number;
+  headers: string[] | null;
+  rows: string[][];
+};
+
+export type WikiProfileCardListBlock = {
+  blockIdentifier: string;
+  blockType: "profile_card_list";
+  displayOrder: number;
+  wikiIdentifiers: string[];
+  title: string | null;
+};
+
+export type WikiBlock =
+  | WikiTextBlock
+  | WikiImageBlock
+  | WikiImageGalleryBlock
+  | WikiEmbedBlock
+  | WikiQuoteBlock
+  | WikiListBlock
+  | WikiTableBlock
+  | WikiProfileCardListBlock;
+
+export type WikiSectionContent = WikiSection | WikiBlock;
+
+const wikiBlockBaseSchema = z.object({
+  blockIdentifier: z.string(),
+  displayOrder: z.number().int(),
+});
+
+const wikiBlockSchema = z.discriminatedUnion("blockType", [
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("text"),
+    content: z.string(),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("image"),
+    imageIdentifier: z.string(),
+    imageSrc: z.string(),
+    caption: z.string().nullable(),
+    alt: z.string().nullable(),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("image_gallery"),
+    images: z.array(
+      z.object({
+        imageIdentifier: z.string(),
+        imageSrc: z.string(),
+        alt: z.string().nullable(),
+      }),
+    ),
+    caption: z.string().nullable(),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("embed"),
+    provider: z.enum(["youtube", "spotify", "x", "tiktok"]),
+    embedId: z.string(),
+    caption: z.string().nullable(),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("quote"),
+    content: z.string(),
+    source: z.string().nullable(),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("list"),
+    listType: z.enum(["bullet", "numbered"]),
+    items: z.array(z.string()),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("table"),
+    headers: z.array(z.string()).nullable(),
+    rows: z.array(z.array(z.string())),
+  }),
+  wikiBlockBaseSchema.extend({
+    blockType: z.literal("profile_card_list"),
+    wikiIdentifiers: z.array(z.string()),
+    title: z.string().nullable(),
+  }),
+]);
+
 const wikiSectionSchema: z.ZodType<WikiSection> = z.lazy(() =>
   z.object({
+    type: z.literal("section"),
     sectionIdentifier: z.string(),
     title: z.string(),
     displayOrder: z.number().int(),
     depth: z.number().int().min(1),
-    body: z.string(),
+    contents: z.array(z.union([wikiSectionSchema, wikiBlockSchema])),
     children: z.array(wikiSectionSchema),
   }),
 );
@@ -46,7 +200,6 @@ export const wikiDetailSchema = z.object({
     src: z.string(),
     alt: z.string(),
   }),
-  summary: z.string(),
   basic: wikiBasicSchema,
   sections: z.array(wikiSectionSchema),
 });

--- a/packages/wiki/src/wikiDetailView.test.ts
+++ b/packages/wiki/src/wikiDetailView.test.ts
@@ -25,36 +25,40 @@ const basic: WikiBasic = {
 
 const sections: WikiSection[] = [
   {
+    type: "section",
     sectionIdentifier: "second",
     title: "Second",
     displayOrder: 20,
     depth: 1,
-    body: "second",
+    contents: [],
     children: [
       {
+        type: "section",
         sectionIdentifier: "child-b",
         title: "Child B",
         displayOrder: 20,
         depth: 2,
-        body: "child-b",
+        contents: [],
         children: [],
       },
       {
+        type: "section",
         sectionIdentifier: "child-a",
         title: "Child A",
         displayOrder: 10,
         depth: 2,
-        body: "child-a",
+        contents: [],
         children: [],
       },
     ],
   },
   {
+    type: "section",
     sectionIdentifier: "first",
     title: "First",
     displayOrder: 10,
     depth: 1,
-    body: "first",
+    contents: [],
     children: [],
   },
 ];
@@ -77,34 +81,38 @@ describe("wikiDetailView", () => {
   it("sorts sections recursively by display order", () => {
     expect(sortWikiSections(sections)).toEqual([
       {
+        type: "section",
         sectionIdentifier: "first",
         title: "First",
         displayOrder: 10,
         depth: 1,
-        body: "first",
+        contents: [],
         children: [],
       },
       {
+        type: "section",
         sectionIdentifier: "second",
         title: "Second",
         displayOrder: 20,
         depth: 1,
-        body: "second",
+        contents: [],
         children: [
           {
+            type: "section",
             sectionIdentifier: "child-a",
             title: "Child A",
             displayOrder: 10,
             depth: 2,
-            body: "child-a",
+            contents: [],
             children: [],
           },
           {
+            type: "section",
             sectionIdentifier: "child-b",
             title: "Child B",
             displayOrder: 20,
             depth: 2,
-            body: "child-b",
+            contents: [],
             children: [],
           },
         ],

--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addWikiBlock,
+  addWikiSection,
+  deleteWikiContent,
+  getWikiContentEditorId,
+  toWikiSectionContentPayload,
+  updateWikiBlock,
+  updateWikiSection,
+} from "./wikiEditModel";
+import { createMockWikiDetail } from "./mockWikiDetail";
+import type { WikiBlock, WikiSection } from "./types/wiki";
+
+const createSection = (overrides?: Partial<WikiSection>): WikiSection => ({
+  sectionIdentifier: "sec-root",
+  title: "Root",
+  displayOrder: 10,
+  depth: 1,
+  contents: [
+    {
+      blockIdentifier: "block-root-text",
+      blockType: "text",
+      displayOrder: 10,
+      content: "Root text",
+    },
+  ],
+  children: [],
+  ...overrides,
+});
+
+describe("wikiEditModel", () => {
+  it("adds nested sections until backend max depth and opens the new section editor", () => {
+    const [updated, editId] = addWikiSection([createSection()], "sec-root");
+
+    expect(updated[0]?.contents).toContainEqual(
+      expect.objectContaining({
+        type: "section",
+        depth: 2,
+        title: "New section",
+      }),
+    );
+    expect(editId).toMatch(/^section:/);
+  });
+
+  it("does not add a child section under depth 3", () => {
+    const depthThree = createSection({
+      depth: 3,
+      contents: [],
+    });
+
+    const [updated, editId] = addWikiSection([depthThree], "sec-root");
+
+    expect(updated[0]?.contents).toEqual([]);
+    expect(editId).toBeNull();
+  });
+
+  it("adds a block and opens the block editor", () => {
+    const [updated, editId] = addWikiBlock([createSection()], "sec-root", "quote");
+
+    expect(updated[0]?.contents).toContainEqual(
+      expect.objectContaining({
+        blockType: "quote",
+        content: "New quote",
+      }),
+    );
+    expect(editId).toMatch(/^block:/);
+  });
+
+  it("updates and deletes section content without mutating sibling items", () => {
+    const section = createSection();
+    const textBlock = section.contents[0] as WikiBlock;
+    const updatedBlock = updateWikiBlock([section], textBlock.blockIdentifier, {
+      content: "Updated text",
+    });
+    const updatedSection = updateWikiSection(updatedBlock, "sec-root", {
+      title: "Updated Root",
+    });
+    const deleted = deleteWikiContent(updatedSection, textBlock.blockIdentifier);
+
+    expect((updatedBlock[0]?.contents[0] as WikiBlock).content).toBe("Updated text");
+    expect(updatedSection[0]?.title).toBe("Updated Root");
+    expect(deleted[0]?.contents).toEqual([]);
+  });
+
+  it("converts editable contents into the backend SectionContentMapper array shape", () => {
+    const wiki = createMockWikiDetail("aurora-echo");
+    const payload = toWikiSectionContentPayload(wiki.sections);
+
+    expect(payload[0]).toMatchObject({
+      type: "section",
+      title: "Overview",
+      display_order: 10,
+      contents: [
+        {
+          block_type: "text",
+          display_order: 10,
+          content:
+            "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
+        },
+        {
+          type: "section",
+          title: "Style",
+        },
+      ],
+    });
+    expect(payload).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          title: "Members",
+        }),
+      ]),
+    );
+  });
+
+  it("creates stable editor ids for sections and blocks", () => {
+    const section = createSection();
+    const block = section.contents[0] as WikiBlock;
+
+    expect(getWikiContentEditorId(section)).toBe("section:sec-root");
+    expect(getWikiContentEditorId(block)).toBe("block:block-root-text");
+  });
+});

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -41,6 +41,7 @@ export type WikiEditPayload = {
   slug: string;
   language: string;
   version: number;
+  theme_color?: string | null;
   hero_image: {
     src: string;
     alt: string;
@@ -347,6 +348,7 @@ export const toWikiEditPayload = (wiki: WikiDetail): WikiEditPayload => ({
   slug: wiki.slug,
   language: wiki.language,
   version: wiki.version,
+  theme_color: wiki.themeColor ?? null,
   hero_image: wiki.heroImage,
   basic: wiki.basic,
   contents: toWikiSectionContentPayload(wiki.sections),

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -1,0 +1,426 @@
+import type {
+  WikiBlock,
+  WikiBlockType,
+  WikiDetail,
+  WikiSection,
+  WikiSectionContent,
+} from "./types/wiki";
+
+export const WIKI_SECTION_MAX_DEPTH = 3;
+
+export type WikiContentEditorId = `section:${string}` | `block:${string}`;
+
+export type WikiSectionContentPayload =
+  | {
+      type: "section";
+      title: string;
+      display_order: number;
+      contents: WikiSectionContentPayload[];
+    }
+  | {
+      block_type: WikiBlockType;
+      display_order: number;
+      content?: string;
+      image_identifier?: string;
+      image_identifiers?: string[];
+      caption?: string | null;
+      alt?: string | null;
+      provider?: string;
+      embed_id?: string;
+      source?: string | null;
+      list_type?: string;
+      items?: string[];
+      rows?: string[][];
+      headers?: string[] | null;
+      wiki_identifiers?: string[];
+      title?: string | null;
+    };
+
+export type WikiEditPayload = {
+  wiki_identifier: string;
+  slug: string;
+  language: string;
+  version: number;
+  hero_image: {
+    src: string;
+    alt: string;
+  };
+  basic: WikiDetail["basic"];
+  contents: WikiSectionContentPayload[];
+};
+
+const getNextDisplayOrder = (contents: WikiSectionContent[]): number =>
+  contents.reduce((max, content) => Math.max(max, content.displayOrder), 0) + 10;
+
+const createIdentifier = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+export const isWikiSection = (
+  content: WikiSectionContent,
+): content is WikiSection => "sectionIdentifier" in content;
+
+export const isWikiBlock = (content: WikiSectionContent): content is WikiBlock =>
+  "blockIdentifier" in content;
+
+export const getWikiContentEditorId = (
+  content: WikiSectionContent,
+): WikiContentEditorId =>
+  isWikiSection(content)
+    ? `section:${content.sectionIdentifier}`
+    : `block:${content.blockIdentifier}`;
+
+export const normalizeWikiSectionContents = (
+  section: WikiSection,
+): WikiSection => {
+  const childSections = section.children.map(normalizeWikiSectionContents);
+  const existingContents = section.contents.length > 0 ? section.contents : [];
+  const childIds = new Set(childSections.map((child) => child.sectionIdentifier));
+  const retainedContents = existingContents.filter(
+    (content) =>
+      !isWikiSection(content) || !childIds.has(content.sectionIdentifier),
+  );
+
+  return {
+    ...section,
+    type: "section",
+    contents: sortWikiSectionContents([
+      ...retainedContents,
+      ...childSections,
+    ]),
+    children: childSections,
+  };
+};
+
+export const normalizeWikiSectionsForEditing = (
+  sections: WikiSection[],
+): WikiSection[] =>
+  sortWikiSectionContents(sections.map(normalizeWikiSectionContents)).filter(
+    isWikiSection,
+  );
+
+export const sortWikiSectionContents = <T extends WikiSectionContent>(
+  contents: T[],
+): T[] =>
+  [...contents]
+    .sort((left, right) => left.displayOrder - right.displayOrder)
+    .map((content) =>
+      isWikiSection(content)
+        ? ({
+            ...content,
+            contents: sortWikiSectionContents(content.contents),
+            children: sortWikiSectionContents(content.children),
+          } as T)
+        : content,
+    );
+
+export const createWikiBlock = (
+  blockType: WikiBlockType,
+  displayOrder: number,
+): WikiBlock => {
+  const blockIdentifier = createIdentifier(`block-${blockType.replace("_", "-")}`);
+
+  switch (blockType) {
+    case "text":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        content: "New text block",
+      };
+    case "image":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        imageIdentifier: "pending-image",
+        imageSrc:
+          "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 800 480'%3E%3Crect width='800' height='480' fill='%23d7e3f4'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Arial' font-size='32' fill='%23314a68'%3EImage block%3C/text%3E%3C/svg%3E",
+        caption: "New image caption",
+        alt: "Editable image block",
+      };
+    case "image_gallery":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        images: [
+          {
+            imageIdentifier: "pending-gallery-image",
+            imageSrc:
+              "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'%3E%3Crect width='600' height='400' fill='%23f4dfc7'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-family='Arial' font-size='26' fill='%235b4a34'%3EGallery image%3C/text%3E%3C/svg%3E",
+            alt: "Editable gallery image",
+          },
+        ],
+        caption: "New gallery caption",
+      };
+    case "embed":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        provider: "youtube",
+        embedId: "new-embed-id",
+        caption: "New embed caption",
+      };
+    case "quote":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        content: "New quote",
+        source: null,
+      };
+    case "list":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        listType: "bullet",
+        items: ["New item"],
+      };
+    case "table":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        headers: ["Column 1", "Column 2"],
+        rows: [["Value 1", "Value 2"]],
+      };
+    case "profile_card_list":
+      return {
+        blockIdentifier,
+        blockType,
+        displayOrder,
+        wikiIdentifiers: ["aurora-echo"],
+        title: "Related profiles",
+      };
+  }
+};
+
+const mapSections = (
+  sections: WikiSection[],
+  mapper: (section: WikiSection) => WikiSection,
+): WikiSection[] =>
+  sections.map((section) => {
+    const mappedChildren = section.children.length
+      ? mapSections(section.children, mapper)
+      : section.children;
+    const mappedContents = section.contents.map((content) =>
+      isWikiSection(content)
+        ? mapSections([content], mapper)[0] ?? content
+        : content,
+    );
+
+    return mapper({
+      ...section,
+      children: mappedChildren,
+      contents: mappedContents,
+    });
+  });
+
+export const addWikiSection = (
+  sections: WikiSection[],
+  parentSectionIdentifier?: string,
+): [WikiSection[], WikiContentEditorId | null] => {
+  let nextEditorId: WikiContentEditorId | null = null;
+  const createSection = (parentDepth: number, displayOrder: number): WikiSection => {
+    const sectionIdentifier = createIdentifier("section");
+    nextEditorId = `section:${sectionIdentifier}`;
+
+    return {
+      type: "section",
+      sectionIdentifier,
+      title: "New section",
+      displayOrder,
+      depth: parentDepth + 1,
+      contents: [],
+      children: [],
+    };
+  };
+
+  if (!parentSectionIdentifier) {
+    const section = createSection(0, getNextDisplayOrder(sections));
+
+    return [[...sections, section], nextEditorId];
+  }
+
+  const updated = mapSections(sections, (section) => {
+    if (section.sectionIdentifier !== parentSectionIdentifier) {
+      return section;
+    }
+
+    if (section.depth >= WIKI_SECTION_MAX_DEPTH) {
+      return section;
+    }
+
+    const child = createSection(section.depth, getNextDisplayOrder(section.contents));
+
+    return {
+      ...section,
+      contents: [...section.contents, child],
+      children: [...section.children, child],
+    };
+  });
+
+  return [updated, nextEditorId];
+};
+
+export const addWikiBlock = (
+  sections: WikiSection[],
+  sectionIdentifier: string,
+  blockType: WikiBlockType,
+): [WikiSection[], WikiContentEditorId | null] => {
+  let nextEditorId: WikiContentEditorId | null = null;
+  const updated = mapSections(sections, (section) => {
+    if (section.sectionIdentifier !== sectionIdentifier) {
+      return section;
+    }
+
+    const block = createWikiBlock(blockType, getNextDisplayOrder(section.contents));
+    nextEditorId = `block:${block.blockIdentifier}`;
+
+    return {
+      ...section,
+      contents: [...section.contents, block],
+    };
+  });
+
+  return [updated, nextEditorId];
+};
+
+export const updateWikiSection = (
+  sections: WikiSection[],
+  sectionIdentifier: string,
+  changes: Partial<Pick<WikiSection, "title">>,
+): WikiSection[] =>
+  mapSections(sections, (section) =>
+    section.sectionIdentifier === sectionIdentifier
+      ? { ...section, ...changes }
+      : section,
+  );
+
+export const updateWikiBlock = (
+  sections: WikiSection[],
+  blockIdentifier: string,
+  changes: Partial<WikiBlock>,
+): WikiSection[] =>
+  mapSections(sections, (section) => ({
+    ...section,
+    contents: section.contents.map((content) =>
+      isWikiBlock(content) && content.blockIdentifier === blockIdentifier
+        ? ({ ...content, ...changes } as WikiBlock)
+        : content,
+    ),
+  }));
+
+export const deleteWikiContent = (
+  sections: WikiSection[],
+  identifier: string,
+): WikiSection[] =>
+  sections
+    .filter((section) => section.sectionIdentifier !== identifier)
+    .map((section) => ({
+      ...section,
+      children: deleteWikiContent(section.children, identifier),
+      contents: section.contents
+        .filter((content) =>
+          isWikiSection(content)
+            ? content.sectionIdentifier !== identifier
+            : content.blockIdentifier !== identifier,
+        )
+        .map((content) =>
+          isWikiSection(content)
+            ? deleteWikiContent([content], identifier)[0] ?? content
+            : content,
+        ),
+    }));
+
+export const toWikiSectionContentPayload = (
+  sections: WikiSection[],
+): WikiSectionContentPayload[] =>
+  sortWikiSectionContents(sections).map((section) =>
+    toWikiContentPayload(normalizeWikiSectionContents(section)),
+  );
+
+export const toWikiEditPayload = (wiki: WikiDetail): WikiEditPayload => ({
+  wiki_identifier: wiki.wikiIdentifier,
+  slug: wiki.slug,
+  language: wiki.language,
+  version: wiki.version,
+  hero_image: wiki.heroImage,
+  basic: wiki.basic,
+  contents: toWikiSectionContentPayload(wiki.sections),
+});
+
+const toWikiContentPayload = (
+  content: WikiSectionContent,
+): WikiSectionContentPayload => {
+  if (isWikiSection(content)) {
+    return {
+      type: "section",
+      title: content.title,
+      display_order: content.displayOrder,
+      contents: sortWikiSectionContents(content.contents).map(toWikiContentPayload),
+    };
+  }
+
+  switch (content.blockType) {
+    case "text":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        content: content.content,
+      };
+    case "image":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        image_identifier: content.imageIdentifier,
+        caption: content.caption,
+        alt: content.alt,
+      };
+    case "image_gallery":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        image_identifiers: content.images.map((image) => image.imageIdentifier),
+        caption: content.caption,
+      };
+    case "embed":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        provider: content.provider,
+        embed_id: content.embedId,
+        caption: content.caption,
+      };
+    case "quote":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        content: content.content,
+        source: content.source,
+      };
+    case "list":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        list_type: content.listType,
+        items: content.items,
+      };
+    case "table":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        rows: content.rows,
+        headers: content.headers,
+      };
+    case "profile_card_list":
+      return {
+        block_type: content.blockType,
+        display_order: content.displayOrder,
+        wiki_identifiers: content.wikiIdentifiers,
+        title: content.title,
+      };
+  }
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const e2ePort = Number(process.env.E2E_PORT ?? 3100);
+const e2eBaseUrl = `http://127.0.0.1:${e2ePort}`;
+
 export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
@@ -7,13 +10,14 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: "html",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: e2eBaseUrl,
     trace: "on-first-retry",
   },
   webServer: {
-    command: "pnpm exec next dev --hostname 127.0.0.1 --port 3000 --turbopack",
-    url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm build && pnpm exec next start --hostname 127.0.0.1 --port ${e2ePort}`,
+    url: e2eBaseUrl,
+    reuseExistingServer: process.env.PLAYWRIGHT_REUSE_EXISTING_SERVER === "1",
+    timeout: 120_000,
   },
   projects: [
     {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -125,6 +125,52 @@ body {
   }
 }
 
+.wiki-theme-scope[data-theme="light"] {
+  --background: #fffbf7;
+  --foreground: #28456b;
+  --brand-primary: #3560a3;
+  --brand-secondary: #f1a81f;
+  --brand-highlight: #ffd6c2;
+  --surface-base: #fffbf7;
+  --surface-raised: #ffffff;
+  --text-strong: #1d2f49;
+  --text-muted: #667a95;
+  --stroke-subtle: rgba(53, 96, 163, 0.16);
+  --wiki-page-background: var(--wiki-page-background-light);
+  --wiki-header-background: var(--wiki-header-background-light);
+  --wiki-header-text: var(--wiki-header-text-light);
+  --wiki-hero-overlay: var(--wiki-hero-overlay-light);
+  --wiki-hero-accent: var(--wiki-hero-accent-light);
+  --wiki-card-background: var(--wiki-card-background-light);
+  --wiki-card-background-muted: var(--wiki-card-background-muted-light);
+  --wiki-card-border: var(--wiki-card-border-light);
+  --wiki-accent-background: var(--wiki-accent-background-light);
+  --wiki-accent-text: var(--wiki-accent-text-light);
+}
+
+.wiki-theme-scope[data-theme="dark"] {
+  --background: #16223a;
+  --foreground: #fff7ef;
+  --brand-primary: #9fc0f2;
+  --brand-secondary: #ffc85a;
+  --brand-highlight: #4a6492;
+  --surface-base: #16223a;
+  --surface-raised: #21304b;
+  --text-strong: #fff7ef;
+  --text-muted: #d9e3f4;
+  --stroke-subtle: rgba(255, 246, 234, 0.12);
+  --wiki-page-background: var(--wiki-page-background-dark);
+  --wiki-header-background: var(--wiki-header-background-dark);
+  --wiki-header-text: var(--wiki-header-text-dark);
+  --wiki-hero-overlay: var(--wiki-hero-overlay-dark);
+  --wiki-hero-accent: var(--wiki-hero-accent-dark);
+  --wiki-card-background: var(--wiki-card-background-dark);
+  --wiki-card-background-muted: var(--wiki-card-background-muted-dark);
+  --wiki-card-border: var(--wiki-card-border-dark);
+  --wiki-accent-background: var(--wiki-accent-background-dark);
+  --wiki-accent-text: var(--wiki-accent-text-dark);
+}
+
 .section-accordion[open] > summary .section-accordion__chevron {
   transform: rotate(180deg);
 }

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -3,12 +3,19 @@
 import Image from "next/image";
 import {
   getWikiBasicFields,
+  isWikiBlock,
+  isWikiSection,
+  normalizeWikiSectionContents,
   sortWikiSections,
+  sortWikiSectionContents,
+  type WikiBlock,
   type WikiSection,
 } from "@kpool/wiki";
 import { useId, useState } from "react";
 
 import { buildWikiThemeCssVariables } from "./wikiThemePalette";
+import { WikiEmbedFrame } from "./WikiEmbedFrame";
+import { WikiRelatedProfiles } from "./WikiRelatedProfiles";
 import { useWikiDetail } from "./useWikiDetail";
 
 type WikiDetailPageProps = {
@@ -84,7 +91,76 @@ function ChevronIcon() {
   );
 }
 
+function WikiBlockDisplay({ block }: { block: WikiBlock }) {
+  switch (block.blockType) {
+    case "text":
+      return <p className="max-w-3xl text-sm leading-7 text-text-muted">{block.content}</p>;
+    case "image":
+      return (
+        <figure>
+          <div className="relative min-h-64 overflow-hidden rounded-2xl border border-stroke-subtle">
+            <Image alt={block.alt ?? ""} className="object-cover" fill sizes="100vw" src={block.imageSrc} />
+          </div>
+          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+        </figure>
+      );
+    case "image_gallery":
+      return (
+        <figure>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {block.images.map((image) => (
+              <div className="relative min-h-40 overflow-hidden rounded-2xl border border-stroke-subtle" key={image.imageIdentifier}>
+                <Image alt={image.alt ?? ""} className="object-cover" fill sizes="50vw" src={image.imageSrc} />
+              </div>
+            ))}
+          </div>
+          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+        </figure>
+      );
+    case "embed":
+      return <WikiEmbedFrame block={block} />;
+    case "quote":
+      return (
+        <blockquote className="border-l-4 border-text-muted/30 pl-4 text-base leading-8 text-text-strong">
+          {block.content}
+          {block.source ? <cite className="mt-2 block text-sm text-text-muted">{block.source}</cite> : null}
+        </blockquote>
+      );
+    case "list":
+      return block.listType === "numbered" ? (
+        <ol className="list-decimal space-y-2 pl-6 text-sm leading-7 text-text-muted">
+          {block.items.map((item) => <li key={item}>{item}</li>)}
+        </ol>
+      ) : (
+        <ul className="list-disc space-y-2 pl-6 text-sm leading-7 text-text-muted">
+          {block.items.map((item) => <li key={item}>{item}</li>)}
+        </ul>
+      );
+    case "table":
+      return (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            {block.headers ? (
+              <thead>
+                <tr>{block.headers.map((header) => <th className="border-b border-stroke-subtle px-3 py-2" key={header}>{header}</th>)}</tr>
+              </thead>
+            ) : null}
+            <tbody>
+              {block.rows.map((row) => (
+                <tr key={row.join("|")}>{row.map((cell) => <td className="border-b border-stroke-subtle px-3 py-2 text-text-muted" key={cell}>{cell}</td>)}</tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    case "profile_card_list":
+      return <WikiRelatedProfiles block={block} />;
+  }
+}
+
 function SectionAccordion({ section }: { section: WikiSection }) {
+  const contents = sortWikiSectionContents(section.contents);
+
   return (
     <details
       className="section-accordion rounded-[1.75rem] border border-stroke-subtle bg-surface-raised shadow-soft"
@@ -117,19 +193,16 @@ function SectionAccordion({ section }: { section: WikiSection }) {
       </summary>
 
       <div
-        className="border-t border-stroke-subtle px-5 pb-5 pt-4"
+        className="space-y-4 border-t border-stroke-subtle px-5 pb-5 pt-4"
         style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}
       >
-        <p className="max-w-3xl text-sm leading-7 text-text-muted">
-          {section.body}
-        </p>
-        {section.children.length > 0 ? (
-          <div className="mt-5 space-y-4">
-            {section.children.map((child) => (
-              <SectionAccordion key={child.sectionIdentifier} section={child} />
-            ))}
-          </div>
-        ) : null}
+        {contents.map((content) =>
+          isWikiBlock(content) ? (
+            <WikiBlockDisplay block={content} key={content.blockIdentifier} />
+          ) : isWikiSection(content) ? (
+            <SectionAccordion key={content.sectionIdentifier} section={content} />
+          ) : null,
+        )}
       </div>
     </details>
   );
@@ -187,7 +260,7 @@ export function WikiDetailPage({ slug, themeColor }: WikiDetailPageProps) {
 
   const { data } = wikiDetail;
   const basicFields = getWikiBasicFields(data.basic);
-  const sections = sortWikiSections(data.sections);
+  const sections = sortWikiSections(data.sections.map(normalizeWikiSectionContents));
   const themeStyles = buildWikiThemeCssVariables(data.themeColor);
   const themeLabel = data.themeColor?.toUpperCase();
 

--- a/src/app/wiki/[slug]/WikiEmbedFrame.tsx
+++ b/src/app/wiki/[slug]/WikiEmbedFrame.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type { WikiEmbedBlock } from "@kpool/wiki";
+
+const frameSurfaceStyle = {
+  backgroundColor: "var(--wiki-card-background-muted, var(--surface-base))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+function parseUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function getLastPathPart(value: string): string {
+  return value.split("/").filter(Boolean).at(-1) ?? value;
+}
+
+function getYoutubeVideoId(value: string): string {
+  const url = parseUrl(value);
+
+  if (!url) {
+    return value;
+  }
+
+  return (
+    url.searchParams.get("v") ??
+    getLastPathPart(url.pathname)
+  );
+}
+
+function getSpotifyPath(value: string): string {
+  const url = parseUrl(value);
+  const path = url ? url.pathname : value;
+
+  return path.replace(/^\/?embed\//, "").replace(/^\//, "");
+}
+
+function getXPostId(value: string): string {
+  const url = parseUrl(value);
+
+  if (!url) {
+    return value;
+  }
+
+  return getLastPathPart(url.pathname);
+}
+
+function getTiktokVideoId(value: string): string {
+  const url = parseUrl(value);
+
+  if (!url) {
+    return value;
+  }
+
+  const videoMatch = url.pathname.match(/\/video\/([^/?]+)/);
+
+  return videoMatch?.[1] ?? getLastPathPart(url.pathname);
+}
+
+function getEmbedFrame(block: WikiEmbedBlock): {
+  allow: string;
+  src: string;
+  title: string;
+} {
+  const titleCaption = block.caption ? `: ${block.caption}` : "";
+
+  switch (block.provider) {
+    case "youtube": {
+      const videoId = encodeURIComponent(getYoutubeVideoId(block.embedId));
+
+      return {
+        allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share",
+        src: `https://www.youtube-nocookie.com/embed/${videoId}`,
+        title: `YouTube embed${titleCaption}`,
+      };
+    }
+    case "spotify": {
+      const spotifyPath = getSpotifyPath(block.embedId);
+
+      return {
+        allow: "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture",
+        src: `https://open.spotify.com/embed/${spotifyPath}`,
+        title: `Spotify embed${titleCaption}`,
+      };
+    }
+    case "x": {
+      const postId = encodeURIComponent(getXPostId(block.embedId));
+
+      return {
+        allow: "clipboard-write; encrypted-media",
+        src: `https://platform.twitter.com/embed/Tweet.html?id=${postId}`,
+        title: `X embed${titleCaption}`,
+      };
+    }
+    case "tiktok": {
+      const videoId = encodeURIComponent(getTiktokVideoId(block.embedId));
+
+      return {
+        allow: "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+        src: `https://www.tiktok.com/embed/v2/${videoId}`,
+        title: `TikTok embed${titleCaption}`,
+      };
+    }
+  }
+}
+
+export function WikiEmbedFrame({ block }: { block: WikiEmbedBlock }) {
+  const frame = getEmbedFrame(block);
+
+  return (
+    <figure className="overflow-hidden rounded-2xl border border-stroke-subtle" style={frameSurfaceStyle}>
+      <div className="aspect-video w-full bg-surface-base">
+        <iframe
+          allow={frame.allow}
+          allowFullScreen
+          className="h-full w-full"
+          loading="lazy"
+          referrerPolicy="strict-origin-when-cross-origin"
+          src={frame.src}
+          title={frame.title}
+        />
+      </div>
+      {block.caption ? (
+        <figcaption className="border-t border-stroke-subtle px-4 py-3 text-sm text-text-muted">
+          {block.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/src/app/wiki/[slug]/WikiRelatedProfiles.tsx
+++ b/src/app/wiki/[slug]/WikiRelatedProfiles.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  getWikiDetailState,
+  type WikiProfileCardListBlock,
+} from "@kpool/wiki";
+
+const profileCardStyle = {
+  backgroundColor: "var(--wiki-card-background-muted, var(--surface-base))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+type RelatedProfile = {
+  heroImage: {
+    alt: string;
+    src: string;
+  };
+  name: string;
+  slug: string;
+};
+
+function getRelatedProfile(slug: string): RelatedProfile | null {
+  const state = getWikiDetailState(slug);
+
+  if (state.status !== "success") {
+    return null;
+  }
+
+  return {
+    heroImage: state.data.heroImage,
+    name: state.data.basic.name,
+    slug: state.data.slug,
+  };
+}
+
+export function WikiRelatedProfiles({
+  block,
+}: {
+  block: WikiProfileCardListBlock;
+}) {
+  const profiles = block.wikiIdentifiers
+    .map((slug) => getRelatedProfile(slug.trim()))
+    .filter((profile): profile is RelatedProfile => profile !== null);
+
+  if (profiles.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label={block.title ?? "Related profiles"}>
+      {block.title ? (
+        <h3 className="text-base font-semibold text-text-strong">{block.title}</h3>
+      ) : null}
+      <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {profiles.map((profile) => (
+          <Link
+            className="group overflow-hidden rounded-2xl border transition hover:-translate-y-0.5 hover:shadow-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+            href={`/wiki/${profile.slug}`}
+            key={profile.slug}
+            style={profileCardStyle}
+          >
+            <div className="relative aspect-[2/3] overflow-hidden bg-surface-base">
+              <Image
+                alt={profile.heroImage.alt}
+                className="object-cover transition duration-300 group-hover:scale-[1.03]"
+                fill
+                sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                src={profile.heroImage.src}
+              />
+            </div>
+            <div className="px-4 py-3">
+              <p className="text-sm font-semibold text-text-strong">{profile.name}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -29,6 +29,8 @@ type WikiEditPageProps = {
   themeColor?: string;
 };
 
+type WikiPreviewMode = "light" | "dark";
+
 const blockTypes: WikiBlockType[] = [
   "text",
   "image",
@@ -50,6 +52,15 @@ const blockTypeLabels: Record<WikiBlockType, string> = {
   table: "Table",
   profile_card_list: "Profiles",
 };
+
+const themeColorOptions = [
+  "#d94f70",
+  "#00d084",
+  "#4c5cff",
+  "#f1a81f",
+  "#1f9a8a",
+  "#7c3aed",
+];
 
 const mainBackgroundStyle = {
   backgroundColor: "var(--background)",
@@ -106,6 +117,23 @@ function TrashIcon() {
   );
 }
 
+function ChevronLeftIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
 function ImageEditableOverlay() {
   return (
     <span className="absolute left-3 top-3 rounded-full bg-black/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white">
@@ -156,28 +184,155 @@ function WikiSaveButton({
   );
 }
 
-function WikiTopActions({
-  isSaving,
-  onClear,
-  onSave,
+function WikiSubmitButton({
+  disabled,
+  onSubmit,
 }: {
-  isSaving: boolean;
-  onClear: () => void;
-  onSave: () => void;
+  disabled: boolean;
+  onSubmit: () => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <WikiSaveButton disabled={isSaving} onSave={onSave} />
+    <button
+      aria-label="Submit wiki for review"
+      className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:text-text-muted"
+      disabled={disabled}
+      onClick={onSubmit}
+      style={cardSurfaceStyle}
+      type="button"
+    >
+      Submit for review
+    </button>
+  );
+}
+
+function WikiEditSidebar({
+  isBusy,
+  isOpen,
+  onClear,
+  onPreviewModeChange,
+  onSave,
+  onSubmit,
+  onToggle,
+  onUpdateSettings,
+  previewMode,
+  slug,
+  themeColor,
+}: {
+  isBusy: boolean;
+  isOpen: boolean;
+  onClear: () => void;
+  onPreviewModeChange: (mode: WikiPreviewMode) => void;
+  onSave: () => void;
+  onSubmit: () => void;
+  onToggle: () => void;
+  onUpdateSettings: (settings: Partial<Pick<WikiDetail, "slug" | "themeColor">>) => void;
+  previewMode: WikiPreviewMode;
+  slug: string;
+  themeColor: string | null | undefined;
+}) {
+  const customColorValue = themeColor ?? themeColorOptions[2];
+
+  return (
+    <aside
+      className={`fixed bottom-0 right-0 top-20 z-30 w-72 max-w-[calc(100vw-2rem)] transition-transform duration-300 ${
+        isOpen ? "translate-x-0" : "translate-x-full"
+      }`}
+      data-testid="wiki-edit-sidebar"
+    >
       <button
-        aria-label="Clear wiki changes"
-        className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-muted"
-        onClick={onClear}
+        aria-label={isOpen ? "Collapse editor sidebar" : "Expand editor sidebar"}
+        aria-expanded={isOpen}
+        className="absolute -left-11 top-6 z-10 grid h-20 w-11 place-items-center rounded-l-2xl border-y border-l border-stroke-subtle text-text-strong shadow-soft transition hover:bg-brand-highlight/20"
+        onClick={onToggle}
         style={cardSurfaceStyle}
         type="button"
       >
-        Clear
+        <span className={`transition-transform ${isOpen ? "" : "rotate-180"}`}>
+          <ChevronLeftIcon />
+        </span>
       </button>
-    </div>
+
+      <div className="relative h-full overflow-y-auto border border-r-0 border-stroke-subtle p-4 shadow-soft" style={cardSurfaceStyle}>
+        <div className={isOpen ? "block" : "pointer-events-none invisible"}>
+          <div className="grid gap-2">
+            <WikiSaveButton disabled={isBusy} onSave={onSave} />
+            <WikiSubmitButton disabled={isBusy} onSubmit={onSubmit} />
+            <button
+              aria-label="Clear wiki changes"
+              className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-muted"
+              onClick={onClear}
+              style={cardSurfaceMutedStyle}
+              type="button"
+            >
+              Clear
+            </button>
+          </div>
+
+          <div className="mt-5 grid gap-4 border-t border-stroke-subtle pt-5" style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}>
+            <fieldset className="grid gap-2">
+              <legend className="text-sm font-semibold text-text-strong">Preview mode</legend>
+              <div className="grid grid-cols-2 gap-2 rounded-full border border-stroke-subtle bg-surface-base p-1">
+                {(["light", "dark"] as const).map((mode) => (
+                  <button
+                    aria-pressed={previewMode === mode}
+                    className="rounded-full px-3 py-2 text-sm font-semibold text-text-muted transition aria-pressed:bg-surface-raised aria-pressed:text-text-strong aria-pressed:shadow-soft"
+                    key={mode}
+                    onClick={() => onPreviewModeChange(mode)}
+                    type="button"
+                  >
+                    {mode === "light" ? "Light" : "Dark"}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">
+              Slug
+              <input
+                className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
+                onChange={(event) => onUpdateSettings({ slug: event.currentTarget.value })}
+                value={slug}
+              />
+            </label>
+
+            <fieldset className="grid gap-3">
+              <legend className="text-sm font-semibold text-text-strong">Theme color</legend>
+              <div className="grid grid-cols-4 gap-2">
+                <button
+                  aria-pressed={!themeColor}
+                  className="h-9 rounded-xl border border-stroke-subtle bg-surface-base text-xs font-semibold text-text-muted"
+                  onClick={() => onUpdateSettings({ themeColor: null })}
+                  type="button"
+                >
+                  Default
+                </button>
+                {themeColorOptions.map((color) => (
+                  <button
+                    aria-label={`Set theme color ${color}`}
+                    aria-pressed={themeColor?.toLowerCase() === color}
+                    className="h-9 rounded-xl border border-stroke-subtle ring-offset-2 ring-offset-surface-raised aria-pressed:ring-2 aria-pressed:ring-text-strong"
+                    key={color}
+                    onClick={() => onUpdateSettings({ themeColor: color })}
+                    style={{ backgroundColor: color }}
+                    type="button"
+                  />
+                ))}
+              </div>
+              <label className="grid gap-2 text-sm font-semibold text-text-strong">
+                Custom color
+                <input
+                  aria-label="Theme color"
+                  className="h-11 w-full rounded-xl border border-stroke-subtle bg-surface-base p-1"
+                  onChange={(event) => onUpdateSettings({ themeColor: event.currentTarget.value })}
+                  type="color"
+                  value={customColorValue}
+                />
+              </label>
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </aside>
   );
 }
 
@@ -918,15 +1073,19 @@ function StatePanel({ title, message }: { title: string; message: string }) {
 function WikiEditContent({ data }: { data: WikiDetail }) {
   const flipCardId = useId();
   const [isBasicFlipped, setIsBasicFlipped] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [previewMode, setPreviewMode] = useState<WikiPreviewMode>("light");
   const {
     draft,
     editingId,
     saveState,
     clearDraft,
+    requestPublication,
     saveDraft,
     setEditingId,
     updateBasic,
     updateHeroImage,
+    updateSettings,
     updateSection,
     updateBlock,
     addSection,
@@ -944,7 +1103,7 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
     setIsBasicFlipped(true);
     setEditingId("basic");
   };
-  const isSaving = saveState.status === "saving";
+  const isBusy = saveState.status === "saving" || saveState.status === "submitting";
   const clearChanges = () => {
     if (!window.confirm("Discard unsaved wiki changes?")) {
       return;
@@ -955,113 +1114,123 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
   };
 
   return (
-    <main
-      className="wiki-theme-scope min-h-screen px-5 py-6 text-text-strong sm:px-8 sm:py-10"
-      data-testid="wiki-edit-root"
-      style={{
+      <main
+        className="wiki-theme-scope min-h-screen px-5 py-6 text-text-strong sm:px-8 sm:py-10"
+        data-theme={previewMode}
+        data-testid="wiki-edit-root"
+        style={{
         ...themeStyles,
         ...mainBackgroundStyle,
       }}
     >
       <div className="mx-auto flex max-w-6xl flex-col gap-8">
-        <header className="flex flex-wrap items-start justify-between gap-4">
+        <header>
           <div>
             <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
               {draft.basic.name}
             </h1>
           </div>
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {themeLabel ? (
+        </header>
+
+        <div className="flex min-w-0 flex-col gap-8">
+          {themeLabel ? (
+            <div>
               <span className="rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]" data-testid="wiki-edit-theme-badge" style={cardSurfaceStyle}>
                 Theme {themeLabel}
               </span>
-            ) : null}
-            <WikiTopActions
-              isSaving={isSaving}
-              onClear={clearChanges}
-              onSave={saveDraft}
-            />
-          </div>
-        </header>
+            </div>
+          ) : null}
 
-        <section>
-          <HeroBasicFlipCard
-            basic={draft.basic}
-            flipCardId={flipCardId}
-            heroImage={draft.heroImage}
-            isBasicEditing={editingId === "basic"}
-            isFlipped={isBasicFlipped}
-            isHeroEditing={editingId === "hero"}
-            onCancel={closeEditor}
-            onEditBasic={editBasic}
-            onEditHero={editHeroImage}
-            onFlipChange={setIsBasicFlipped}
-            onSaveBasic={(basic) => {
-              updateBasic(basic);
-              closeEditor();
-            }}
-            onSaveHero={(heroImage) => {
-              updateHeroImage(heroImage);
-              closeEditor();
-            }}
-          />
-          <div className="hidden gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
-            <HeroPanel
+          <section>
+            <HeroBasicFlipCard
+              basic={draft.basic}
+              flipCardId={flipCardId}
               heroImage={draft.heroImage}
-              isEditing={editingId === "hero"}
+              isBasicEditing={editingId === "basic"}
+              isFlipped={isBasicFlipped}
+              isHeroEditing={editingId === "hero"}
               onCancel={closeEditor}
-              onEdit={editHeroImage}
-              onSave={(heroImage) => {
+              onEditBasic={editBasic}
+              onEditHero={editHeroImage}
+              onFlipChange={setIsBasicFlipped}
+              onSaveBasic={(basic) => {
+                updateBasic(basic);
+                closeEditor();
+              }}
+              onSaveHero={(heroImage) => {
                 updateHeroImage(heroImage);
                 closeEditor();
               }}
             />
-            <BasicPanel
-              basic={draft.basic}
-              isEditing={editingId === "basic"}
-              onCancel={closeEditor}
-              onEdit={editBasic}
-              onSave={(basic) => {
-                updateBasic(basic);
-                closeEditor();
-              }}
-            />
-          </div>
-        </section>
+            <div className="hidden gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
+              <HeroPanel
+                heroImage={draft.heroImage}
+                isEditing={editingId === "hero"}
+                onCancel={closeEditor}
+                onEdit={editHeroImage}
+                onSave={(heroImage) => {
+                  updateHeroImage(heroImage);
+                  closeEditor();
+                }}
+              />
+              <BasicPanel
+                basic={draft.basic}
+                isEditing={editingId === "basic"}
+                onCancel={closeEditor}
+                onEdit={editBasic}
+                onSave={(basic) => {
+                  updateBasic(basic);
+                  closeEditor();
+                }}
+              />
+            </div>
+          </section>
 
-        <section className="space-y-5">
-          {draft.sections.map((section) => (
-            <SectionEditor
-              editingId={editingId}
-              key={section.sectionIdentifier}
-              onAddBlock={addBlock}
-              onAddSection={addSection}
-              onCancel={closeEditor}
-              onDeleteContent={deleteContent}
-              onEdit={setEditingId}
-              onSaveBlock={(blockIdentifier, changes) => {
-                updateBlock(blockIdentifier, changes);
-                closeEditor();
-              }}
-              onSaveSection={(sectionIdentifier, changes) => {
-                updateSection(sectionIdentifier, changes);
-                closeEditor();
-              }}
-              section={section}
-            />
-          ))}
-          <button
-            className="w-full rounded-[1.5rem] border border-dashed border-stroke-subtle p-5 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
-            onClick={() => addSection()}
-            style={cardSurfaceStyle}
-            type="button"
-          >
-            + Section
-          </button>
-          <div className="flex justify-end">
-            <WikiSaveButton disabled={isSaving} onSave={saveDraft} />
-          </div>
-        </section>
+          <section className="space-y-5">
+            {draft.sections.map((section) => (
+              <SectionEditor
+                editingId={editingId}
+                key={section.sectionIdentifier}
+                onAddBlock={addBlock}
+                onAddSection={addSection}
+                onCancel={closeEditor}
+                onDeleteContent={deleteContent}
+                onEdit={setEditingId}
+                onSaveBlock={(blockIdentifier, changes) => {
+                  updateBlock(blockIdentifier, changes);
+                  closeEditor();
+                }}
+                onSaveSection={(sectionIdentifier, changes) => {
+                  updateSection(sectionIdentifier, changes);
+                  closeEditor();
+                }}
+                section={section}
+              />
+            ))}
+            <button
+              className="w-full rounded-[1.5rem] border border-dashed border-stroke-subtle p-5 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
+              onClick={() => addSection()}
+              style={cardSurfaceStyle}
+              type="button"
+            >
+              + Section
+            </button>
+          </section>
+        </div>
+
+        <WikiEditSidebar
+          isBusy={isBusy}
+          isOpen={isSidebarOpen}
+          onClear={clearChanges}
+          onPreviewModeChange={setPreviewMode}
+          onSave={saveDraft}
+          onSubmit={requestPublication}
+          onToggle={() => setIsSidebarOpen((isOpen) => !isOpen)}
+          onUpdateSettings={updateSettings}
+          previewMode={previewMode}
+          slug={draft.slug}
+          themeColor={draft.themeColor}
+        />
       </div>
     </main>
   );

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -1,0 +1,1096 @@
+"use client";
+
+import Image from "next/image";
+import {
+  getWikiBasicFields,
+  isWikiBlock,
+  isWikiSection,
+  sortWikiSectionContents,
+  WIKI_SECTION_MAX_DEPTH,
+  type WikiBasic,
+  type WikiBlock,
+  type WikiBlockType,
+  type WikiContentEditorId,
+  type WikiDetail,
+  type WikiEmbedProvider,
+  type WikiListType,
+  type WikiSection,
+} from "@kpool/wiki";
+import { useId, useState, type FormEvent } from "react";
+
+import { buildWikiThemeCssVariables } from "../wikiThemePalette";
+import { WikiEmbedFrame } from "../WikiEmbedFrame";
+import { WikiRelatedProfiles } from "../WikiRelatedProfiles";
+import { useWikiDetail } from "../useWikiDetail";
+import { useWikiEditDraft } from "./useWikiEditDraft";
+
+type WikiEditPageProps = {
+  slug: string;
+  themeColor?: string;
+};
+
+const blockTypes: WikiBlockType[] = [
+  "text",
+  "image",
+  "image_gallery",
+  "embed",
+  "quote",
+  "list",
+  "table",
+  "profile_card_list",
+];
+
+const blockTypeLabels: Record<WikiBlockType, string> = {
+  text: "Text",
+  image: "Image",
+  image_gallery: "Gallery",
+  embed: "Embed",
+  quote: "Quote",
+  list: "List",
+  table: "Table",
+  profile_card_list: "Profiles",
+};
+
+const mainBackgroundStyle = {
+  backgroundColor: "var(--background)",
+  backgroundImage:
+    "var(--wiki-page-background, radial-gradient(circle at top, rgba(255,214,194,0.85), transparent 38%), linear-gradient(180deg, var(--background) 0%, #fff 100%))",
+};
+
+const cardSurfaceStyle = {
+  backgroundColor: "var(--wiki-card-background, var(--surface-raised))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+const cardSurfaceMutedStyle = {
+  backgroundColor: "var(--wiki-card-background-muted, var(--surface-base))",
+  borderColor: "var(--wiki-card-border, var(--stroke-subtle))",
+};
+
+function EditIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 20h9" />
+      <path d="m16.5 3.5 4 4L7 21l-4 1 1-4Z" />
+    </svg>
+  );
+}
+
+function TrashIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      viewBox="0 0 24 24"
+    >
+      <path d="M3 6h18" />
+      <path d="M8 6V4h8v2" />
+      <path d="m6 6 1 15h10l1-15" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+    </svg>
+  );
+}
+
+function ImageEditableOverlay() {
+  return (
+    <span className="absolute left-3 top-3 rounded-full bg-black/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-white">
+      Editable image
+    </span>
+  );
+}
+
+function FormActions({ onCancel }: { onCancel: () => void }) {
+  return (
+    <div className="mt-4 flex flex-wrap gap-2">
+      <button
+        className="rounded-full border border-stroke-subtle px-4 py-2 text-sm font-semibold text-text-strong"
+        style={cardSurfaceStyle}
+        type="submit"
+      >
+        Save
+      </button>
+      <button
+        className="rounded-full border border-stroke-subtle px-4 py-2 text-sm font-semibold text-text-muted"
+        onClick={onCancel}
+        type="button"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function WikiSaveButton({
+  disabled,
+  onSave,
+}: {
+  disabled: boolean;
+  onSave: () => void;
+}) {
+  return (
+    <button
+      aria-label="Save wiki changes"
+      className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:text-text-muted"
+      disabled={disabled}
+      onClick={onSave}
+      style={cardSurfaceStyle}
+      type="button"
+    >
+      Save
+    </button>
+  );
+}
+
+function WikiTopActions({
+  isSaving,
+  onClear,
+  onSave,
+}: {
+  isSaving: boolean;
+  onClear: () => void;
+  onSave: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <WikiSaveButton disabled={isSaving} onSave={onSave} />
+      <button
+        aria-label="Clear wiki changes"
+        className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-muted"
+        onClick={onClear}
+        style={cardSurfaceStyle}
+        type="button"
+      >
+        Clear
+      </button>
+    </div>
+  );
+}
+
+const getString = (formData: FormData, name: string): string =>
+  String(formData.get(name) ?? "");
+
+const getLines = (formData: FormData, name: string): string[] =>
+  getString(formData, name)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+function BasicPanel({
+  basic,
+  isEditing,
+  onEdit,
+  onCancel,
+  onSave,
+}: {
+  basic: WikiBasic;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: (basic: WikiBasic) => void;
+}) {
+  const fields = getWikiBasicFields(basic);
+
+  if (isEditing) {
+    return (
+      <form
+        className="rounded-[1.75rem] border border-stroke-subtle p-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+
+          onSave({
+            ...basic,
+            name: getString(formData, "name"),
+            groupType: getString(formData, "groupType"),
+            status: getString(formData, "status"),
+            generation: getString(formData, "generation"),
+            debutDate: getString(formData, "debutDate"),
+            fandomName: getString(formData, "fandomName"),
+            representativeSymbol: getString(formData, "representativeSymbol"),
+            officialColors: getLines(formData, "officialColors"),
+            agencyName: getString(formData, "agencyName") || null,
+          });
+        }}
+        style={cardSurfaceMutedStyle}
+      >
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
+          Basic
+        </p>
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Name
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.name} name="name" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Group Type
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.groupType} name="groupType" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Status
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.status} name="status" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Generation
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.generation} name="generation" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Debut Date
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.debutDate} name="debutDate" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Fandom Name
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.fandomName} name="fandomName" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Representative Symbol
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.representativeSymbol} name="representativeSymbol" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Agency
+            <input className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.agencyName ?? ""} name="agencyName" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong md:col-span-2">
+            Official Colors
+            <textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2" defaultValue={basic.officialColors.join("\n")} name="officialColors" />
+          </label>
+        </div>
+        <FormActions onCancel={onCancel} />
+      </form>
+    );
+  }
+
+  return (
+    <div className="rounded-[1.75rem] border border-stroke-subtle p-6" style={cardSurfaceMutedStyle}>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
+            Basic
+          </p>
+          <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+            Group profile
+          </p>
+        </div>
+        <button
+          aria-label="Edit basic"
+          className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+          onClick={onEdit}
+          style={cardSurfaceStyle}
+          type="button"
+        >
+          <EditIcon />
+        </button>
+      </div>
+      <dl className="mt-6 grid gap-4 md:grid-cols-2">
+        {fields.map((field) => (
+          <div
+            className="rounded-2xl border border-stroke-subtle bg-surface-raised px-4 py-3"
+            key={field.label}
+            style={cardSurfaceStyle}
+          >
+            <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
+              {field.label}
+            </dt>
+            <dd className="mt-1 text-sm leading-6 text-text-strong">{field.value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function HeroPanel({
+  heroImage,
+  isEditing,
+  onEdit,
+  onCancel,
+  onSave,
+}: {
+  heroImage: WikiDetail["heroImage"];
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: (heroImage: WikiDetail["heroImage"]) => void;
+}) {
+  if (isEditing) {
+    return (
+      <form
+        className="rounded-[1.75rem] border border-stroke-subtle p-5"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const formData = new FormData(event.currentTarget);
+          onSave({
+            src: getString(formData, "src"),
+            alt: getString(formData, "alt"),
+          });
+        }}
+        style={cardSurfaceStyle}
+      >
+        <div className="grid gap-4">
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Hero image URL
+            <input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={heroImage.src} name="src" />
+          </label>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">
+            Hero image alt
+            <input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={heroImage.alt} name="alt" />
+          </label>
+        </div>
+        <FormActions onCancel={onCancel} />
+      </form>
+    );
+  }
+
+  return (
+    <div className="relative h-full min-h-[22rem] overflow-hidden rounded-[1.75rem] border border-stroke-subtle" style={cardSurfaceStyle}>
+      <Image
+        alt={heroImage.alt}
+        className="object-cover"
+        fill
+        sizes="(min-width: 1024px) 55vw, 100vw"
+        src={heroImage.src}
+      />
+      <ImageEditableOverlay />
+      <button
+        aria-label="Edit hero image"
+        className="absolute right-3 top-3 z-30 rounded-full border border-white/40 bg-black/60 p-3 text-white"
+        onClick={onEdit}
+        type="button"
+      >
+        <EditIcon />
+      </button>
+    </div>
+  );
+}
+
+function HeroBasicFlipCard({
+  heroImage,
+  basic,
+  isFlipped,
+  flipCardId,
+  isHeroEditing,
+  isBasicEditing,
+  onFlipChange,
+  onEditHero,
+  onEditBasic,
+  onCancel,
+  onSaveHero,
+  onSaveBasic,
+}: {
+  heroImage: WikiDetail["heroImage"];
+  basic: WikiBasic;
+  isFlipped: boolean;
+  flipCardId: string;
+  isHeroEditing: boolean;
+  isBasicEditing: boolean;
+  onFlipChange: (isFlipped: boolean) => void;
+  onEditHero: () => void;
+  onEditBasic: () => void;
+  onCancel: () => void;
+  onSaveHero: (heroImage: WikiDetail["heroImage"]) => void;
+  onSaveBasic: (basic: WikiBasic) => void;
+}) {
+  const fields = getWikiBasicFields(basic);
+
+  return (
+    <div className="grid gap-4 lg:hidden">
+      <input
+        checked={isFlipped}
+        className="sr-only"
+        data-testid="wiki-edit-flip-input"
+        id={flipCardId}
+        onChange={(event) => onFlipChange(event.currentTarget.checked)}
+        type="checkbox"
+      />
+      <div
+        aria-label="Flip wiki edit card"
+        className="block"
+        data-testid="wiki-edit-flip-trigger"
+        role="group"
+      >
+        <div className="relative h-[34rem] [perspective:1400px]">
+          <div
+            className={`relative h-full rounded-[2rem] shadow-soft transition duration-700 [transform-style:preserve-3d] ${
+              isFlipped ? "[transform:rotateY(180deg)]" : ""
+            }`}
+            data-testid="wiki-edit-flip-card"
+          >
+            <div className="absolute inset-0 overflow-hidden rounded-[2rem] [backface-visibility:hidden]">
+              <HeroPanel
+                heroImage={heroImage}
+                isEditing={isHeroEditing}
+                onCancel={onCancel}
+                onEdit={onEditHero}
+                onSave={onSaveHero}
+              />
+            </div>
+            {!isHeroEditing ? (
+              <label
+                aria-label="Flip wiki edit card to basic details"
+                className={`absolute inset-0 z-20 rounded-[1.75rem] ${
+                  isFlipped ? "pointer-events-none" : "cursor-pointer"
+                }`}
+                data-testid="wiki-edit-flip-front-toggle"
+                htmlFor={flipCardId}
+              />
+            ) : null}
+
+            <div
+              className={`absolute inset-0 z-20 flex h-full flex-col overflow-hidden rounded-[2rem] border border-stroke-subtle bg-surface-raised p-5 [backface-visibility:hidden] [transform:rotateY(180deg)] ${
+                isFlipped ? "pointer-events-auto" : "pointer-events-none"
+              }`}
+              onClick={() => {
+                if (!isBasicEditing) {
+                  onFlipChange(false);
+                }
+              }}
+              style={cardSurfaceStyle}
+            >
+              {isBasicEditing ? (
+                <div
+                  className="min-h-0 flex-1 overflow-y-auto pr-1"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                <BasicPanel
+                  basic={basic}
+                  isEditing={isBasicEditing}
+                  onCancel={onCancel}
+                  onEdit={onEditBasic}
+                  onSave={onSaveBasic}
+                />
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-text-muted">
+                        Basic
+                      </p>
+                      <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
+                        Group profile
+                      </p>
+                    </div>
+                    <button
+                      aria-label="Edit basic"
+                      className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onEditBasic();
+                      }}
+                      style={cardSurfaceMutedStyle}
+                      type="button"
+                    >
+                      <EditIcon />
+                    </button>
+                  </div>
+                  <div className="mt-5 min-h-0 flex-1 overflow-y-auto pr-1">
+                    <dl className="grid gap-4">
+                      {fields.map((field) => (
+                        <div
+                          className="rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-3"
+                          key={field.label}
+                          style={cardSurfaceMutedStyle}
+                        >
+                          <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
+                            {field.label}
+                          </dt>
+                          <dd className="mt-1 text-sm leading-6 text-text-strong">{field.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-center text-sm text-text-muted">
+        <span className={isFlipped ? "hidden" : ""}>
+          Tap the card to flip to the basic details.
+        </span>
+        <span className={isFlipped ? "inline" : "hidden"}>
+          Tap outside the form area to return to the cover image.
+        </span>
+      </p>
+    </div>
+  );
+}
+
+function SectionForm({
+  section,
+  onCancel,
+  onSave,
+}: {
+  section: WikiSection;
+  onCancel: () => void;
+  onSave: (changes: Pick<WikiSection, "title">) => void;
+}) {
+  return (
+    <form
+      className="grid gap-4"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        onSave({
+          title: getString(formData, "title"),
+        });
+      }}
+    >
+      <label className="grid gap-2 text-sm font-semibold text-text-strong">
+        Section title
+        <input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={section.title} name="title" />
+      </label>
+      <FormActions onCancel={onCancel} />
+    </form>
+  );
+}
+
+function BlockDisplay({ block }: { block: WikiBlock }) {
+  switch (block.blockType) {
+    case "text":
+      return <p className="text-sm leading-7 text-text-muted">{block.content}</p>;
+    case "image":
+      return (
+        <figure>
+          <div className="relative min-h-64 overflow-hidden rounded-2xl border border-stroke-subtle">
+            <Image alt={block.alt ?? ""} className="object-cover" fill sizes="100vw" src={block.imageSrc} />
+            <ImageEditableOverlay />
+          </div>
+          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+        </figure>
+      );
+    case "image_gallery":
+      return (
+        <figure>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {block.images.map((image) => (
+              <div className="relative min-h-40 overflow-hidden rounded-2xl border border-stroke-subtle" key={image.imageIdentifier}>
+                <Image alt={image.alt ?? ""} className="object-cover" fill sizes="50vw" src={image.imageSrc} />
+                <ImageEditableOverlay />
+              </div>
+            ))}
+          </div>
+          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+        </figure>
+      );
+    case "embed":
+      return <WikiEmbedFrame block={block} />;
+    case "quote":
+      return (
+        <blockquote className="border-l-4 border-text-muted/30 pl-4 text-base leading-8 text-text-strong">
+          {block.content}
+          {block.source ? <cite className="mt-2 block text-sm text-text-muted">{block.source}</cite> : null}
+        </blockquote>
+      );
+    case "list":
+      return block.listType === "numbered" ? (
+        <ol className="list-decimal space-y-2 pl-6 text-sm leading-7 text-text-muted">
+          {block.items.map((item) => <li key={item}>{item}</li>)}
+        </ol>
+      ) : (
+        <ul className="list-disc space-y-2 pl-6 text-sm leading-7 text-text-muted">
+          {block.items.map((item) => <li key={item}>{item}</li>)}
+        </ul>
+      );
+    case "table":
+      return (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            {block.headers ? (
+              <thead>
+                <tr>{block.headers.map((header) => <th className="border-b border-stroke-subtle px-3 py-2" key={header}>{header}</th>)}</tr>
+              </thead>
+            ) : null}
+            <tbody>
+              {block.rows.map((row) => (
+                <tr key={row.join("|")}>{row.map((cell) => <td className="border-b border-stroke-subtle px-3 py-2 text-text-muted" key={cell}>{cell}</td>)}</tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    case "profile_card_list":
+      return <WikiRelatedProfiles block={block} />;
+  }
+}
+
+function BlockForm({
+  block,
+  onCancel,
+  onSave,
+}: {
+  block: WikiBlock;
+  onCancel: () => void;
+  onSave: (changes: Partial<WikiBlock>) => void;
+}) {
+  const submit = (
+    event: FormEvent<HTMLFormElement>,
+    getChanges: (formData: FormData) => Partial<WikiBlock>,
+  ) => {
+    event.preventDefault();
+    onSave(getChanges(new FormData(event.currentTarget)));
+  };
+
+  switch (block.blockType) {
+    case "text":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ content: getString(data, "content") }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">Text<textarea className="min-h-28 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.content} name="content" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "image":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ imageIdentifier: getString(data, "imageIdentifier"), imageSrc: getString(data, "imageSrc"), caption: getString(data, "caption") || null, alt: getString(data, "alt") || null }))}>
+          <div className="grid gap-3">
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Image identifier<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.imageIdentifier} name="imageIdentifier" /></label>
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Image URL<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.imageSrc} name="imageSrc" /></label>
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Alt<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.alt ?? ""} name="alt" /></label>
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+          </div>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "image_gallery":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ images: getLines(data, "images").map((line, index) => ({ imageIdentifier: line, imageSrc: block.images[index]?.imageSrc ?? block.images[0]?.imageSrc ?? "", alt: block.images[index]?.alt ?? line })), caption: getString(data, "caption") || null }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">Image identifiers<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.images.map((image) => image.imageIdentifier).join("\n")} name="images" /></label>
+          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "embed":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ provider: getString(data, "provider") as WikiEmbedProvider, embedId: getString(data, "embedId"), caption: getString(data, "caption") || null }))}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Provider<select className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.provider} name="provider"><option value="youtube">youtube</option><option value="spotify">spotify</option><option value="x">x</option><option value="tiktok">tiktok</option></select></label>
+            <label className="grid gap-2 text-sm font-semibold text-text-strong">Embed ID<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.embedId} name="embedId" /></label>
+            <label className="grid gap-2 text-sm font-semibold text-text-strong sm:col-span-2">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+          </div>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "quote":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ content: getString(data, "content"), source: getString(data, "source") || null }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">Quote<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.content} name="content" /></label>
+          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Source<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.source ?? ""} name="source" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "list":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ listType: getString(data, "listType") as WikiListType, items: getLines(data, "items") }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">List type<select className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.listType} name="listType"><option value="bullet">bullet</option><option value="numbered">numbered</option></select></label>
+          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Items<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.items.join("\n")} name="items" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "table":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ headers: getLines(data, "headers"), rows: getLines(data, "rows").map((row) => row.split(",").map((cell) => cell.trim())) }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">Headers<textarea className="min-h-20 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={(block.headers ?? []).join("\n")} name="headers" /></label>
+          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Rows<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.rows.map((row) => row.join(", ")).join("\n")} name="rows" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+    case "profile_card_list":
+      return (
+        <form onSubmit={(event) => submit(event, (data) => ({ title: getString(data, "title") || null, wikiIdentifiers: getLines(data, "wikiIdentifiers") }))}>
+          <label className="grid gap-2 text-sm font-semibold text-text-strong">Title<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.title ?? ""} name="title" /></label>
+          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Wiki slugs<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.wikiIdentifiers.join("\n")} name="wikiIdentifiers" /></label>
+          <FormActions onCancel={onCancel} />
+        </form>
+      );
+  }
+}
+
+function BlockEditorItem({
+  block,
+  isEditing,
+  onEdit,
+  onCancel,
+  onSave,
+  onDelete,
+}: {
+  block: WikiBlock;
+  isEditing: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: (changes: Partial<WikiBlock>) => void;
+  onDelete: () => void;
+}) {
+  const controls = (
+    <div className="flex gap-2">
+      <button aria-label={`Edit ${block.blockType} block`} className="rounded-full border border-stroke-subtle p-2" onClick={onEdit} type="button"><EditIcon /></button>
+      <button aria-label={`Delete ${block.blockType} block`} className="rounded-full border border-status-danger/30 p-2 text-status-danger transition hover:bg-status-danger/10" onClick={onDelete} type="button"><TrashIcon /></button>
+    </div>
+  );
+
+  if (isEditing) {
+    return (
+      <article className="rounded-2xl border border-stroke-subtle p-4" data-testid={`wiki-edit-block-${block.blockIdentifier}`} style={cardSurfaceMutedStyle}>
+        <div className="mb-3 flex justify-end">
+          {controls}
+        </div>
+        <BlockForm block={block} onCancel={onCancel} onSave={onSave} />
+      </article>
+    );
+  }
+
+  return (
+    <article className="group relative" data-testid={`wiki-edit-block-${block.blockIdentifier}`}>
+      <div className="absolute right-0 top-0 z-10 flex gap-2 rounded-full bg-surface-raised/90 p-1 shadow-soft opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100">
+        {controls}
+      </div>
+      <BlockDisplay block={block} />
+    </article>
+  );
+}
+
+function AddContentControls({
+  section,
+  onAddSection,
+  onAddBlock,
+}: {
+  section: WikiSection;
+  onAddSection: (parentSectionIdentifier: string) => void;
+  onAddBlock: (sectionIdentifier: string, blockType: WikiBlockType) => void;
+}) {
+  const canAddSection = section.depth < WIKI_SECTION_MAX_DEPTH;
+  const [isBlockMenuOpen, setIsBlockMenuOpen] = useState(false);
+
+  return (
+    <div className="rounded-2xl border border-dashed border-stroke-subtle p-4" data-testid={`wiki-edit-add-section-${section.sectionIdentifier}`}>
+      <div className="flex flex-wrap items-start gap-2">
+        <button
+          className="rounded-full border border-stroke-subtle px-4 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:text-text-muted"
+          disabled={!canAddSection}
+          onClick={() => onAddSection(section.sectionIdentifier)}
+          title={canAddSection ? "Add section" : "Max depth reached"}
+          type="button"
+        >
+          + Section
+        </button>
+        <div className="relative">
+          <button
+            aria-expanded={isBlockMenuOpen}
+            className="rounded-full border border-stroke-subtle px-4 py-2 text-sm font-semibold text-text-strong"
+            onClick={() => setIsBlockMenuOpen((isOpen) => !isOpen)}
+            type="button"
+          >
+            + Block
+          </button>
+          {isBlockMenuOpen ? (
+            <div className="absolute left-0 z-20 mt-2 grid min-w-44 gap-1 rounded-2xl border border-stroke-subtle bg-surface-raised p-2 shadow-soft" style={cardSurfaceStyle}>
+              {blockTypes.map((blockType) => (
+                <button
+                  className="rounded-xl px-3 py-2 text-left text-sm font-semibold text-text-muted transition hover:bg-brand-highlight/20 hover:text-text-strong"
+                  key={blockType}
+                  onClick={() => {
+                    onAddBlock(section.sectionIdentifier, blockType);
+                    setIsBlockMenuOpen(false);
+                  }}
+                  type="button"
+                >
+                  {blockTypeLabels[blockType]}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        {!canAddSection ? (
+          <span className="px-2 py-2 text-sm text-text-muted">Max depth reached</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function SectionEditor({
+  section,
+  editingId,
+  onEdit,
+  onCancel,
+  onSaveSection,
+  onSaveBlock,
+  onAddSection,
+  onAddBlock,
+  onDeleteContent,
+}: {
+  section: WikiSection;
+  editingId: string | null;
+  onEdit: (id: WikiContentEditorId) => void;
+  onCancel: () => void;
+  onSaveSection: (sectionIdentifier: string, changes: Pick<WikiSection, "title">) => void;
+  onSaveBlock: (blockIdentifier: string, changes: Partial<WikiBlock>) => void;
+  onAddSection: (parentSectionIdentifier: string) => void;
+  onAddBlock: (sectionIdentifier: string, blockType: WikiBlockType) => void;
+  onDeleteContent: (identifier: string) => void;
+}) {
+  const contents = sortWikiSectionContents(section.contents);
+  const sectionEditorId: WikiContentEditorId = `section:${section.sectionIdentifier}`;
+
+  return (
+    <details className="rounded-[1.75rem] border border-stroke-subtle shadow-soft" data-testid={`wiki-edit-section-${section.sectionIdentifier}`} open style={cardSurfaceStyle}>
+      <summary className="flex list-none items-start gap-3 p-5 text-left">
+        <span className="min-w-0 flex-1">
+          <span className="block text-2xl font-semibold tracking-[-0.03em] text-text-strong">{section.title}</span>
+        </span>
+        <button aria-label={`Edit section ${section.title}`} className="rounded-full border border-stroke-subtle p-3 text-text-strong" onClick={(event) => { event.preventDefault(); onEdit(sectionEditorId); }} style={cardSurfaceMutedStyle} type="button"><EditIcon /></button>
+        <button aria-label={`Delete section ${section.title}`} className="rounded-full border border-status-danger/30 p-3 text-status-danger transition hover:bg-status-danger/10" onClick={(event) => { event.preventDefault(); onDeleteContent(section.sectionIdentifier); }} type="button"><TrashIcon /></button>
+      </summary>
+      <div className="space-y-6 border-t border-stroke-subtle px-5 pb-5 pt-5" style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}>
+        {editingId === sectionEditorId ? (
+          <SectionForm
+            onCancel={onCancel}
+            onSave={(changes) => onSaveSection(section.sectionIdentifier, changes)}
+            section={section}
+          />
+        ) : null}
+
+        {contents.map((content) =>
+          isWikiBlock(content) ? (
+            <BlockEditorItem
+              block={content}
+              isEditing={editingId === `block:${content.blockIdentifier}`}
+              key={content.blockIdentifier}
+              onCancel={onCancel}
+              onDelete={() => onDeleteContent(content.blockIdentifier)}
+              onEdit={() => onEdit(`block:${content.blockIdentifier}`)}
+              onSave={(changes) => onSaveBlock(content.blockIdentifier, changes)}
+            />
+          ) : isWikiSection(content) ? (
+            <SectionEditor
+              editingId={editingId}
+              key={content.sectionIdentifier}
+              onAddBlock={onAddBlock}
+              onAddSection={onAddSection}
+              onCancel={onCancel}
+              onDeleteContent={onDeleteContent}
+              onEdit={onEdit}
+              onSaveBlock={onSaveBlock}
+              onSaveSection={onSaveSection}
+              section={content}
+            />
+          ) : null,
+        )}
+
+        <AddContentControls
+          onAddBlock={onAddBlock}
+          onAddSection={onAddSection}
+          section={section}
+        />
+      </div>
+    </details>
+  );
+}
+
+function StatePanel({ title, message }: { title: string; message: string }) {
+  return (
+    <main className="min-h-screen bg-surface-base px-6 py-12 text-text-strong sm:px-10">
+      <div className="mx-auto max-w-5xl rounded-[2rem] border border-stroke-subtle bg-surface-raised p-8 shadow-soft">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-text-muted">
+          {title}
+        </p>
+        <p className="mt-4 text-lg leading-7 text-text-muted">{message}</p>
+      </div>
+    </main>
+  );
+}
+
+function WikiEditContent({ data }: { data: WikiDetail }) {
+  const flipCardId = useId();
+  const [isBasicFlipped, setIsBasicFlipped] = useState(false);
+  const {
+    draft,
+    editingId,
+    saveState,
+    clearDraft,
+    saveDraft,
+    setEditingId,
+    updateBasic,
+    updateHeroImage,
+    updateSection,
+    updateBlock,
+    addSection,
+    addBlock,
+    deleteContent,
+  } = useWikiEditDraft(data);
+  const themeStyles = buildWikiThemeCssVariables(draft.themeColor);
+  const themeLabel = draft.themeColor?.toUpperCase();
+  const closeEditor = () => setEditingId(null);
+  const editHeroImage = () => {
+    setIsBasicFlipped(false);
+    setEditingId("hero");
+  };
+  const editBasic = () => {
+    setIsBasicFlipped(true);
+    setEditingId("basic");
+  };
+  const isSaving = saveState.status === "saving";
+  const clearChanges = () => {
+    if (!window.confirm("Discard unsaved wiki changes?")) {
+      return;
+    }
+
+    setIsBasicFlipped(false);
+    clearDraft();
+  };
+
+  return (
+    <main
+      className="wiki-theme-scope min-h-screen px-5 py-6 text-text-strong sm:px-8 sm:py-10"
+      data-testid="wiki-edit-root"
+      style={{
+        ...themeStyles,
+        ...mainBackgroundStyle,
+      }}
+    >
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
+              {draft.basic.name}
+            </h1>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {themeLabel ? (
+              <span className="rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]" data-testid="wiki-edit-theme-badge" style={cardSurfaceStyle}>
+                Theme {themeLabel}
+              </span>
+            ) : null}
+            <WikiTopActions
+              isSaving={isSaving}
+              onClear={clearChanges}
+              onSave={saveDraft}
+            />
+          </div>
+        </header>
+
+        <section>
+          <HeroBasicFlipCard
+            basic={draft.basic}
+            flipCardId={flipCardId}
+            heroImage={draft.heroImage}
+            isBasicEditing={editingId === "basic"}
+            isFlipped={isBasicFlipped}
+            isHeroEditing={editingId === "hero"}
+            onCancel={closeEditor}
+            onEditBasic={editBasic}
+            onEditHero={editHeroImage}
+            onFlipChange={setIsBasicFlipped}
+            onSaveBasic={(basic) => {
+              updateBasic(basic);
+              closeEditor();
+            }}
+            onSaveHero={(heroImage) => {
+              updateHeroImage(heroImage);
+              closeEditor();
+            }}
+          />
+          <div className="hidden gap-6 lg:grid lg:grid-cols-[1.1fr_0.9fr]">
+            <HeroPanel
+              heroImage={draft.heroImage}
+              isEditing={editingId === "hero"}
+              onCancel={closeEditor}
+              onEdit={editHeroImage}
+              onSave={(heroImage) => {
+                updateHeroImage(heroImage);
+                closeEditor();
+              }}
+            />
+            <BasicPanel
+              basic={draft.basic}
+              isEditing={editingId === "basic"}
+              onCancel={closeEditor}
+              onEdit={editBasic}
+              onSave={(basic) => {
+                updateBasic(basic);
+                closeEditor();
+              }}
+            />
+          </div>
+        </section>
+
+        <section className="space-y-5">
+          {draft.sections.map((section) => (
+            <SectionEditor
+              editingId={editingId}
+              key={section.sectionIdentifier}
+              onAddBlock={addBlock}
+              onAddSection={addSection}
+              onCancel={closeEditor}
+              onDeleteContent={deleteContent}
+              onEdit={setEditingId}
+              onSaveBlock={(blockIdentifier, changes) => {
+                updateBlock(blockIdentifier, changes);
+                closeEditor();
+              }}
+              onSaveSection={(sectionIdentifier, changes) => {
+                updateSection(sectionIdentifier, changes);
+                closeEditor();
+              }}
+              section={section}
+            />
+          ))}
+          <button
+            className="w-full rounded-[1.5rem] border border-dashed border-stroke-subtle p-5 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
+            onClick={() => addSection()}
+            style={cardSurfaceStyle}
+            type="button"
+          >
+            + Section
+          </button>
+          <div className="flex justify-end">
+            <WikiSaveButton disabled={isSaving} onSave={saveDraft} />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export function WikiEditPage({ slug, themeColor }: WikiEditPageProps) {
+  const wikiDetail = useWikiDetail(slug, { themeColor });
+
+  if (wikiDetail.status === "loading") {
+    return (
+      <StatePanel
+        message="Preparing the wiki editor..."
+        title="Loading Wiki Editor"
+      />
+    );
+  }
+
+  if (wikiDetail.status === "error") {
+    return <StatePanel message={wikiDetail.message} title="Unable to load wiki" />;
+  }
+
+  if (wikiDetail.status === "empty") {
+    return (
+      <StatePanel
+        message="This resource does not have a wiki draft to edit at the moment."
+        title="No wiki draft"
+      />
+    );
+  }
+
+  return <WikiEditContent data={wikiDetail.data} />;
+}

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -34,8 +34,18 @@ describe("WikiEditPage", () => {
 
     expect(screen.getByRole("heading", { name: "Aurora Echo" })).toBeInTheDocument();
     expect(screen.queryByText("Saved")).not.toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Save wiki changes" })).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit wiki for review" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Clear wiki changes" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Slug")).toHaveValue("aurora-echo");
+    expect(screen.getByRole("group", { name: "Preview mode" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Default" })).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Theme color" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse editor sidebar" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByTestId("wiki-edit-root")).toHaveAttribute("data-theme", "light");
     expect(screen.getAllByTestId("wiki-edit-flip-input")[0]).not.toBeChecked();
     expect(screen.getAllByText("Editable image").length).toBeGreaterThan(0);
     expect(screen.getByTestId("wiki-edit-section-sec-overview")).toBeInTheDocument();
@@ -81,6 +91,49 @@ describe("WikiEditPage", () => {
     fireEvent.click(addControls.getByRole("button", { name: "Quote" }));
 
     expect(screen.getByLabelText("Quote")).toBeInTheDocument();
+  });
+
+  it("updates slug and theme color settings from the sidebar", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.change(screen.getByLabelText("Slug"), {
+      target: { value: "aurora-echo-jp" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Set theme color #4c5cff" }));
+
+    expect(screen.getByLabelText("Slug")).toHaveValue("aurora-echo-jp");
+    expect(screen.getByTestId("wiki-edit-theme-badge")).toHaveTextContent("Theme #4C5CFF");
+  });
+
+  it("switches the wiki preview between light and dark modes", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Dark" }));
+
+    expect(screen.getByTestId("wiki-edit-root")).toHaveAttribute("data-theme", "dark");
+    expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Light" }));
+
+    expect(screen.getByTestId("wiki-edit-root")).toHaveAttribute("data-theme", "light");
+  });
+
+  it("collapses and expands the editor sidebar", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse editor sidebar" }));
+
+    expect(screen.getByTestId("wiki-edit-sidebar")).toHaveClass("translate-x-full");
+    expect(screen.getByRole("button", { name: "Expand editor sidebar" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   it("clears draft changes back to the loaded wiki", () => {

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -1,0 +1,164 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createMockWikiDetail } from "@kpool/wiki";
+
+import { useWikiDetail, type WikiDetailState } from "../useWikiDetail";
+import { WikiEditPage } from "./WikiEditPage";
+
+vi.mock("../useWikiDetail", () => ({
+  useWikiDetail: vi.fn(),
+}));
+
+const mockedUseWikiDetail = vi.mocked(useWikiDetail);
+
+const successState: WikiDetailState = {
+  status: "success",
+  data: createMockWikiDetail("aurora-echo"),
+};
+
+describe("WikiEditPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    mockedUseWikiDetail.mockReset();
+  });
+
+  it("renders the editable wiki layout with image overlays and save state", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    expect(screen.getByRole("heading", { name: "Aurora Echo" })).toBeInTheDocument();
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Save wiki changes" })).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Clear wiki changes" })).toBeInTheDocument();
+    expect(screen.getAllByTestId("wiki-edit-flip-input")[0]).not.toBeChecked();
+    expect(screen.getAllByText("Editable image").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("wiki-edit-section-sec-overview")).toBeInTheDocument();
+    expect(screen.getByTestId("wiki-edit-block-block-discography-quote")).toBeInTheDocument();
+    expect(screen.getByTitle("YouTube embed: Stage video")).toHaveAttribute(
+      "src",
+      "https://www.youtube-nocookie.com/embed/low-tide-high-lights",
+    );
+    expect(screen.getByRole("link", { name: /Aurora Echo/i })).toHaveAttribute(
+      "href",
+      "/wiki/aurora-echo",
+    );
+  });
+
+  it("flips the mobile edit card to reveal basic details", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    const [flipInput] = screen.getAllByTestId("wiki-edit-flip-input");
+    const [flipButton] = screen.getAllByTestId("wiki-edit-flip-front-toggle");
+    const [flipCard] = screen.getAllByTestId("wiki-edit-flip-card");
+
+    fireEvent.click(flipButton);
+
+    expect(flipInput).toBeChecked();
+    expect(flipCard).toHaveClass("[transform:rotateY(180deg)]");
+    expect(screen.getAllByText("North Harbor Entertainment")[0]).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByText("North Harbor Entertainment")[0]);
+
+    expect(flipInput).not.toBeChecked();
+    expect(flipCard).not.toHaveClass("[transform:rotateY(180deg)]");
+  });
+
+  it("adds a block inside a section and opens the new block editor", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview"));
+    fireEvent.click(addControls.getByText("+ Block"));
+    fireEvent.click(addControls.getByRole("button", { name: "Quote" }));
+
+    expect(screen.getByLabelText("Quote")).toBeInTheDocument();
+  });
+
+  it("clears draft changes back to the loaded wiki", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview"));
+    fireEvent.click(addControls.getByText("+ Block"));
+    fireEvent.click(addControls.getByRole("button", { name: "Quote" }));
+
+    expect(screen.getByLabelText("Quote")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear wiki changes" }));
+
+    expect(screen.queryByLabelText("Quote")).not.toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalledWith("Discard unsaved wiki changes?");
+
+    confirmSpy.mockRestore();
+  });
+
+  it("keeps draft changes when clear is canceled", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview"));
+    fireEvent.click(addControls.getByText("+ Block"));
+    fireEvent.click(addControls.getByRole("button", { name: "Quote" }));
+    fireEvent.click(screen.getByRole("button", { name: "Clear wiki changes" }));
+
+    expect(screen.getByLabelText("Quote")).toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalledWith("Discard unsaved wiki changes?");
+
+    confirmSpy.mockRestore();
+  });
+
+  it("edits related profile blocks by wiki slug", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    const profileBlock = screen.getByTestId("wiki-edit-block-block-discography-profiles");
+    fireEvent.click(
+      within(profileBlock).getByRole("button", {
+        name: "Edit profile_card_list block",
+      }),
+    );
+
+    expect(screen.getByLabelText("Wiki slugs")).toHaveValue("aurora-echo");
+  });
+
+  it("shows max depth instead of child section creation at depth 3", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    expect(
+      screen.getByTestId("wiki-edit-add-section-sec-discography-highlights-chart"),
+    ).toHaveTextContent("Max depth reached");
+  });
+
+  it("renders loading, error, and empty states", () => {
+    mockedUseWikiDetail.mockReturnValue({ status: "loading" });
+    const { rerender } = render(
+      React.createElement(WikiEditPage, { slug: "loading" }),
+    );
+
+    expect(screen.getByText("Loading Wiki Editor")).toBeInTheDocument();
+
+    mockedUseWikiDetail.mockReturnValue({ status: "error", message: "Broken" });
+    rerender(React.createElement(WikiEditPage, { slug: "error" }));
+    expect(screen.getByText("Broken")).toBeInTheDocument();
+
+    mockedUseWikiDetail.mockReturnValue({ status: "empty" });
+    rerender(React.createElement(WikiEditPage, { slug: "empty" }));
+    expect(screen.getByText("No wiki draft")).toBeInTheDocument();
+  });
+});

--- a/src/app/wiki/[slug]/edit/page.tsx
+++ b/src/app/wiki/[slug]/edit/page.tsx
@@ -1,0 +1,20 @@
+import { WikiEditPage } from "./WikiEditPage";
+
+type WikiEditRouteProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+  searchParams: Promise<{
+    themeColor?: string | string[];
+  }>;
+};
+
+const getThemeColor = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
+
+export default async function Page({ params, searchParams }: WikiEditRouteProps) {
+  const { slug } = await params;
+  const { themeColor } = await searchParams;
+
+  return <WikiEditPage slug={slug} themeColor={getThemeColor(themeColor)} />;
+}

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -1,0 +1,172 @@
+"use client";
+
+import {
+  addWikiBlock,
+  addWikiSection,
+  deleteWikiContent,
+  normalizeWikiSectionsForEditing,
+  toWikiEditPayload,
+  updateWikiBlock,
+  updateWikiSection,
+  type WikiBlock,
+  type WikiBlockType,
+  type WikiContentEditorId,
+  type WikiDetail,
+  type WikiEditPayload,
+} from "@kpool/wiki";
+import { useMemo, useState } from "react";
+
+type WikiSaveState =
+  | {
+      status: "dirty";
+      message: string;
+      payload: WikiEditPayload;
+    }
+  | {
+      status: "saved";
+      message: string;
+      payload: WikiEditPayload;
+    }
+  | {
+      status: "saving";
+      message: string;
+      payload: WikiEditPayload;
+    }
+  | {
+      status: "failed";
+      message: string;
+      payload: WikiEditPayload;
+    };
+
+type WikiEditDraftOptions = {
+  saveAdapter?: (payload: WikiEditPayload) => { ok: true } | { ok: false };
+};
+
+const optimisticSaveAdapter = () => ({ ok: true }) as const;
+
+const createInitialDraft = (wiki: WikiDetail): WikiDetail => ({
+  ...wiki,
+  sections: normalizeWikiSectionsForEditing(wiki.sections),
+});
+
+export const useWikiEditDraft = (
+  wiki: WikiDetail,
+  options?: WikiEditDraftOptions,
+) => {
+  const initialDraft = useMemo(() => createInitialDraft(wiki), [wiki]);
+  const [draft, setDraft] = useState<WikiDetail>(initialDraft);
+  const [editingId, setEditingId] = useState<WikiContentEditorId | "basic" | "hero" | null>(
+    null,
+  );
+  const [saveState, setSaveState] = useState<WikiSaveState>({
+    status: "saved",
+    message: "Saved",
+    payload: toWikiEditPayload(initialDraft),
+  });
+  const saveAdapter = options?.saveAdapter ?? optimisticSaveAdapter;
+
+  const commitDraft = (nextDraft: WikiDetail) => {
+    const payload = toWikiEditPayload(nextDraft);
+
+    setDraft(nextDraft);
+    setSaveState({
+      status: "dirty",
+      message: "Unsaved changes",
+      payload,
+    });
+  };
+
+  const saveDraft = () => {
+    const payload = toWikiEditPayload(draft);
+
+    setSaveState({
+      status: "saving",
+      message: "Saving changes",
+      payload,
+    });
+
+    queueMicrotask(() => {
+      const result = saveAdapter(payload);
+
+      setSaveState({
+        status: result.ok ? "saved" : "failed",
+        message: result.ok ? "Saved" : "Save failed",
+        payload,
+      });
+    });
+  };
+
+  const clearDraft = () => {
+    setDraft(initialDraft);
+    setEditingId(null);
+    setSaveState({
+      status: "saved",
+      message: "Saved",
+      payload: toWikiEditPayload(initialDraft),
+    });
+  };
+
+  return {
+    draft,
+    editingId,
+    saveState,
+    clearDraft,
+    saveDraft,
+    setEditingId,
+    updateBasic: (basic: WikiDetail["basic"]) =>
+      commitDraft({
+        ...draft,
+        basic,
+      }),
+    updateHeroImage: (heroImage: WikiDetail["heroImage"]) =>
+      commitDraft({
+        ...draft,
+        heroImage,
+      }),
+    updateSection: (
+      sectionIdentifier: string,
+      changes: Parameters<typeof updateWikiSection>[2],
+    ) =>
+      commitDraft({
+        ...draft,
+        sections: updateWikiSection(draft.sections, sectionIdentifier, changes),
+      }),
+    updateBlock: (blockIdentifier: string, changes: Partial<WikiBlock>) =>
+      commitDraft({
+        ...draft,
+        sections: updateWikiBlock(draft.sections, blockIdentifier, changes),
+      }),
+    addSection: (parentSectionIdentifier?: string) => {
+      const [sections, nextEditingId] = addWikiSection(
+        draft.sections,
+        parentSectionIdentifier,
+      );
+
+      commitDraft({
+        ...draft,
+        sections,
+      });
+      setEditingId(nextEditingId);
+    },
+    addBlock: (sectionIdentifier: string, blockType: WikiBlockType) => {
+      const [sections, nextEditingId] = addWikiBlock(
+        draft.sections,
+        sectionIdentifier,
+        blockType,
+      );
+
+      commitDraft({
+        ...draft,
+        sections,
+      });
+      setEditingId(nextEditingId);
+    },
+    deleteContent: (identifier: string) => {
+      commitDraft({
+        ...draft,
+        sections: deleteWikiContent(draft.sections, identifier),
+      });
+      setEditingId(null);
+    },
+  };
+};

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -33,6 +33,11 @@ type WikiSaveState =
       payload: WikiEditPayload;
     }
   | {
+      status: "submitting";
+      message: string;
+      payload: WikiEditPayload;
+    }
+  | {
       status: "failed";
       message: string;
       payload: WikiEditPayload;
@@ -40,9 +45,10 @@ type WikiSaveState =
 
 type WikiEditDraftOptions = {
   saveAdapter?: (payload: WikiEditPayload) => { ok: true } | { ok: false };
+  submitAdapter?: (payload: WikiEditPayload) => { ok: true } | { ok: false };
 };
 
-const optimisticSaveAdapter = () => ({ ok: true }) as const;
+const optimisticActionAdapter = () => ({ ok: true }) as const;
 
 const createInitialDraft = (wiki: WikiDetail): WikiDetail => ({
   ...wiki,
@@ -63,7 +69,8 @@ export const useWikiEditDraft = (
     message: "Saved",
     payload: toWikiEditPayload(initialDraft),
   });
-  const saveAdapter = options?.saveAdapter ?? optimisticSaveAdapter;
+  const saveAdapter = options?.saveAdapter ?? optimisticActionAdapter;
+  const submitAdapter = options?.submitAdapter ?? optimisticActionAdapter;
 
   const commitDraft = (nextDraft: WikiDetail) => {
     const payload = toWikiEditPayload(nextDraft);
@@ -106,11 +113,32 @@ export const useWikiEditDraft = (
     });
   };
 
+  const requestPublication = () => {
+    const payload = toWikiEditPayload(draft);
+
+    setSaveState({
+      status: "submitting",
+      message: "Submitting for review",
+      payload,
+    });
+
+    queueMicrotask(() => {
+      const result = submitAdapter(payload);
+
+      setSaveState({
+        status: result.ok ? "saved" : "failed",
+        message: result.ok ? "Submitted for review" : "Submit failed",
+        payload,
+      });
+    });
+  };
+
   return {
     draft,
     editingId,
     saveState,
     clearDraft,
+    requestPublication,
     saveDraft,
     setEditingId,
     updateBasic: (basic: WikiDetail["basic"]) =>
@@ -122,6 +150,11 @@ export const useWikiEditDraft = (
       commitDraft({
         ...draft,
         heroImage,
+      }),
+    updateSettings: (settings: Partial<Pick<WikiDetail, "slug" | "themeColor">>) =>
+      commitDraft({
+        ...draft,
+        ...settings,
       }),
     updateSection: (
       sectionIdentifier: string,

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -24,7 +24,6 @@ const successState: WikiDetailState = {
       src: "data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1200 900'%3E%3Crect width='1200' height='900' fill='%233560a3'/%3E%3C/svg%3E",
       alt: "Aurora Echo hero image",
     },
-    summary: "Aurora Echo summary",
     basic: {
       name: "Aurora Echo",
       normalizedName: "aurora-echo",
@@ -41,19 +40,50 @@ const successState: WikiDetailState = {
     },
     sections: [
       {
+        type: "section",
         sectionIdentifier: "members",
         title: "Members",
         displayOrder: 20,
         depth: 1,
-        body: "Members body",
+        contents: [
+          {
+            blockIdentifier: "members-text",
+            blockType: "text",
+            displayOrder: 10,
+            content: "Members body",
+          },
+          {
+            blockIdentifier: "members-profiles",
+            blockType: "profile_card_list",
+            displayOrder: 20,
+            wikiIdentifiers: ["aurora-echo"],
+            title: "Related profiles",
+          },
+        ],
         children: [],
       },
       {
+        type: "section",
         sectionIdentifier: "overview",
         title: "Overview",
         displayOrder: 10,
         depth: 1,
-        body: "Overview body",
+        contents: [
+          {
+            blockIdentifier: "overview-text",
+            blockType: "text",
+            displayOrder: 10,
+            content: "Overview body",
+          },
+          {
+            blockIdentifier: "overview-embed",
+            blockType: "embed",
+            displayOrder: 20,
+            provider: "youtube",
+            embedId: "abc123",
+            caption: "Overview video",
+          },
+        ],
         children: [],
       },
     ],
@@ -74,6 +104,15 @@ describe("WikiDetailPage", () => {
     expect(screen.getAllByText("Aurora Echo")[0]).toBeInTheDocument();
     expect(screen.getByText("Overview")).toBeInTheDocument();
     expect(screen.getByText("Members")).toBeInTheDocument();
+    expect(screen.getByText("Overview body")).toBeInTheDocument();
+    expect(screen.getByTitle("YouTube embed: Overview video")).toHaveAttribute(
+      "src",
+      "https://www.youtube-nocookie.com/embed/abc123",
+    );
+    expect(screen.getByRole("link", { name: /Aurora Echo/i })).toHaveAttribute(
+      "href",
+      "/wiki/aurora-echo",
+    );
     expect(screen.getAllByLabelText(/Edit section/i)).toHaveLength(2);
     expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
   });

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -41,3 +41,42 @@ test("wiki detail page shows the empty state", async ({ page }) => {
 
   await expect(page.getByText("No public wiki yet")).toBeVisible();
 });
+
+test("wiki edit page supports inline edits and nested content controls", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/wiki/aurora-echo/edit?themeColor=%234c5cff");
+
+  await expect(page.getByRole("heading", { name: "Aurora Echo" })).toBeVisible();
+  await expect(page.getByTestId("wiki-edit-theme-badge")).toHaveText(
+    "Theme #4C5CFF",
+  );
+  await expect(page.getByText("Saved")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Clear wiki changes" })).toBeVisible();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(page.getByText("Editable image").first()).toBeVisible();
+  const editFlipInput = page.getByTestId("wiki-edit-flip-input");
+  const editFlipButton = page.getByTestId("wiki-edit-flip-front-toggle");
+  const editFlipCard = page.getByTestId("wiki-edit-flip-card");
+  await expect(editFlipInput).not.toBeChecked();
+  await editFlipButton.click();
+  await expect(editFlipInput).toBeChecked();
+  await expect(editFlipCard.getByText("North Harbor Entertainment")).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/wiki/aurora-echo/edit?themeColor=%234c5cff");
+  await expect(page.getByText("Saved")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(2);
+
+  const overviewAddControls = page.getByTestId("wiki-edit-add-section-sec-overview");
+  await overviewAddControls.getByText("+ Block").click();
+  await overviewAddControls.getByRole("button", { name: "Quote" }).click();
+  await expect(page.getByRole("textbox", { name: "Quote" })).toBeVisible();
+
+  await expect(
+    page.getByTestId("wiki-edit-add-section-sec-discography-highlights-chart"),
+  ).toContainText("Max depth reached");
+});

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -53,8 +53,20 @@ test("wiki edit page supports inline edits and nested content controls", async (
     "Theme #4C5CFF",
   );
   await expect(page.getByText("Saved")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: "Submit wiki for review" })).toHaveCount(1);
   await expect(page.getByRole("button", { name: "Clear wiki changes" })).toBeVisible();
+  await expect(page.getByLabel("Slug")).toHaveValue("aurora-echo");
+  await expect(page.getByRole("group", { name: "Preview mode" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Default" })).toBeVisible();
+  await expect(page.getByRole("group", { name: "Theme color" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Collapse editor sidebar" })).toHaveAttribute(
+    "aria-expanded",
+    "true",
+  );
+  await page.getByRole("button", { name: "Dark" }).click();
+  await expect(page.getByTestId("wiki-edit-root")).toHaveAttribute("data-theme", "dark");
+  await page.getByRole("button", { name: "Collapse editor sidebar" }).click();
 
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(page.getByText("Editable image").first()).toBeVisible();
@@ -69,7 +81,8 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/wiki/aurora-echo/edit?themeColor=%234c5cff");
   await expect(page.getByText("Saved")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(2);
+  await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(1);
+  await expect(page.getByRole("button", { name: "Submit wiki for review" })).toHaveCount(1);
 
   const overviewAddControls = page.getByTestId("wiki-edit-add-section-sec-overview");
   await overviewAddControls.getByText("+ Block").click();


### PR DESCRIPTION
## 📝 変更内容

- `/wiki/[slug]/edit` に Wiki 編集ページを追加し、ヒーロー画像・基本情報・セクション・各種ブロックをインラインで編集できる UI を実装
- `@kpool/wiki` に編集用モデルを追加し、セクション正規化、ブロック追加・更新・削除、API 送信用 payload 変換を実装
- Wiki 詳細ページ側も block/content ベースの描画に対応し、embed・関連プロフィール・画像ギャラリーなどの表示を追加
- ユニットテストと E2E テストを追加し、Playwright は `next start` ベースの本番相当構成で実行するよう更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

- Issue #18 の Wiki 編集ページ要件に対応するため
- 既存の Wiki 詳細データ構造をそのまま編集画面でも扱えるようにし、将来の保存 API 接続へ繋げやすくするため
- 詳細ページと編集ページで同じ block/section 構造を描画できるようにして、表示差分を減らすため

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Wiki 編集ページで preview mode の切り替え、サイドバー開閉、theme color 変更、slug 編集ができることを確認
- セクション配下への block 追加、depth 3 での section 追加抑止、関連プロフィール block 編集ができることを確認
- モバイル表示でフリップ UI から hero/basic 情報へアクセスできることを確認

## 🔍 レビューのポイント

- `packages/wiki/src/wikiEditModel.ts` の payload 変換がバックエンド期待 shape と揃っているか
- 編集ページの block renderer と詳細ページの block renderer で責務分離や再利用の切り方が妥当か
- Playwright を `next build && next start` ベースに変えた影響で、既存 E2E 運用に問題がないか

## 📖 関連情報

### 関連Issue・タスク

Closes #18

## ⚠️ 注意事項

- `pnpm build` は sandbox 内だと Turbopack が子プロセス生成時に `Operation not permitted` で失敗したため、権限付きで実行して確認しています
- 保存・申請処理は現状 optimistic な adapter を使った UI 実装で、実 API 接続は未対応です

## 📸 スクリーンショット・デモ

- なし

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
