### PR TITLE
feat: Wikiテキストブロックにインライン装飾ツールバーを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   "dependencies": {
     "@kpool/types": "workspace:*",
     "@kpool/wiki": "workspace:*",
+    "@radix-ui/react-icons": "^1.3.2",
+    "@tiptap/extension-link": "^3.22.3",
+    "@tiptap/react": "^3.22.3",
+    "@tiptap/starter-kit": "^3.22.3",
     "@zodios/core": "10.9.6",
     "next": "16.2.3",
     "react": "19.2.5",

--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   addWikiBlock,
   addWikiSection,
+  createWikiBlock,
   deleteWikiContent,
   getWikiContentEditorId,
   toWikiSectionContentPayload,
@@ -65,6 +66,14 @@ describe("wikiEditModel", () => {
       }),
     );
     expect(editId).toMatch(/^block:/);
+  });
+
+  it("creates new text blocks with empty content", () => {
+    expect(createWikiBlock("text", 10)).toMatchObject({
+      blockType: "text",
+      content: "",
+      displayOrder: 10,
+    });
   });
 
   it("updates and deletes section content without mutating sibling items", () => {

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -126,7 +126,7 @@ export const createWikiBlock = (
         blockIdentifier,
         blockType,
         displayOrder,
-        content: "New text block",
+        content: "",
       };
     case "image":
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,18 @@ importers:
       '@kpool/wiki':
         specifier: workspace:*
         version: link:packages/wiki
+      '@radix-ui/react-icons':
+        specifier: ^1.3.2
+        version: 1.3.2(react@19.2.5)
+      '@tiptap/extension-link':
+        specifier: ^3.22.3
+        version: 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/react':
+        specifier: ^3.22.3
+        version: 3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tiptap/starter-kit':
+        specifier: ^3.22.3
+        version: 3.22.3
       '@zodios/core':
         specifier: 10.9.6
         version: 10.9.6(axios@1.15.0)(zod@3.25.76)
@@ -446,6 +458,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -739,6 +760,14 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/react-icons@1.3.2':
+    resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
+    peerDependencies:
+      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -1062,6 +1091,155 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tiptap/core@3.22.3':
+    resolution: {integrity: sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==}
+    peerDependencies:
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-blockquote@3.22.3':
+    resolution: {integrity: sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-bold@3.22.3':
+    resolution: {integrity: sha512-tysipHla2zCWr8XNIWRaW9O+7i7/SoEqnRqSRUUi2ailcJjlia+RBy3RykhkgyThrQDStu5KGBS/UvrXwA+O1A==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-bubble-menu@3.22.3':
+    resolution: {integrity: sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-bullet-list@3.22.3':
+    resolution: {integrity: sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-code-block@3.22.3':
+    resolution: {integrity: sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-code@3.22.3':
+    resolution: {integrity: sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-document@3.22.3':
+    resolution: {integrity: sha512-MCSr1PFPtTd++lA3H1RNgqAczAE59XXJ5wUFIQf2F+/0DPY5q2SU4g5QsNJVxPPft5mrNT4C6ty8xBPrALFEdA==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-dropcursor@3.22.3':
+    resolution: {integrity: sha512-taXq9Tl5aybdFbptJtFRHX9LFJzbXphAbPp4/vutFyTrBu5meXDxuS+B9pEmE+Or0XcolTlW2nDZB0Tqnr18JQ==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.22.3
+
+  '@tiptap/extension-floating-menu@3.22.3':
+    resolution: {integrity: sha512-0f8b4KZ3XKai8GXWseIYJGdOfQr3evtFbBo3U08zy2aYzMMXWG0zEF7qe5/oiYp2aZ95edjjITnEceviTsZkIg==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-gapcursor@3.22.3':
+    resolution: {integrity: sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.22.3
+
+  '@tiptap/extension-hard-break@3.22.3':
+    resolution: {integrity: sha512-J0v8I99y9tbvVmgKYKzKP/JYNsWaZYS7avn4rzLft2OhnyTfwt3OoY8DtpHmmi6apSUaCtoWHWta/TmoEfK1nQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-heading@3.22.3':
+    resolution: {integrity: sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-horizontal-rule@3.22.3':
+    resolution: {integrity: sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-italic@3.22.3':
+    resolution: {integrity: sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-link@3.22.3':
+    resolution: {integrity: sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-list-item@3.22.3':
+    resolution: {integrity: sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-list-keymap@3.22.3':
+    resolution: {integrity: sha512-pKuyj5llu35zd/s2u/H9aydKZjmPRAIK5P1q/YXULhhCNln2RnmuRfQ5NklAqTD3yGciQ2lxDwwf7J6iw3ergA==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-list@3.22.3':
+    resolution: {integrity: sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-ordered-list@3.22.3':
+    resolution: {integrity: sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-paragraph@3.22.3':
+    resolution: {integrity: sha512-oO7rhfyhEuwm+50s9K3GZPjYyEEEvFAvm1wXopvZnhbkBLydIWImBfrZoC5IQh4/sRDlTIjosV2C+ji5y0tUSg==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-strike@3.22.3':
+    resolution: {integrity: sha512-jY2InoUlKkuk5KHoIDGdML1OCA2n6PRHAtxwHNkAmiYh0Khf0zaVPGFpx4dgQrN7W5Q1WE6oBZnjrvy6qb7w0g==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-text@3.22.3':
+    resolution: {integrity: sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-underline@3.22.3':
+    resolution: {integrity: sha512-Ch6CBWRa5w90yYSPUW6x9Py9JdrXMqk3pZ9OIlMYD8A7BqyZGfiHerX7XDMYDS09KjyK3U9XH60/zxYOzXdDLA==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extensions@3.22.3':
+    resolution: {integrity: sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+
+  '@tiptap/pm@3.22.3':
+    resolution: {integrity: sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==}
+
+  '@tiptap/react@3.22.3':
+    resolution: {integrity: sha512-6MNr6z0PxwfJFs+BKhHcvPNvY+UV1PXgqzTiTM4Z9guml84iVZxv7ZOCSj1dFYTr3Bf1MiOs4hT1yvBFlTfIaQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+      '@tiptap/pm': ^3.22.3
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.22.3':
+    resolution: {integrity: sha512-vdW/Oo1fdwTL1VOQ5YYbTov00ANeHLquBVEZyL/EkV7Xv5io9rXQsCysJfTSHhiQlyr2MtWFB4+CPGuwXjQWOQ==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -1098,6 +1276,15 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
+
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
@@ -1114,6 +1301,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
@@ -1542,6 +1732,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1665,6 +1858,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1855,6 +2052,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -2340,6 +2541,12 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2375,12 +2582,19 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -2506,6 +2720,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2591,9 +2808,71 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-menu@1.3.2:
+    resolution: {integrity: sha512-6VgUJTYod0nMBlCaYJGhXGLu7Gt4AvcwcOq0YfJCY/6Uh+3S7UsWhpy6rJFCBFOmonq1hD8KyWOtZhkppd4YPg==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2671,6 +2950,9 @@ packages:
     resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -2957,6 +3239,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -3092,6 +3377,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -3477,6 +3765,20 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+    optional: true
+
+  '@floating-ui/utils@0.2.11':
+    optional: true
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3683,6 +3985,12 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@radix-ui/react-icons@1.3.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -3967,6 +4275,183 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tiptap/core@3.22.3(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-blockquote@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-bold@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-bubble-menu@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-code-block@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-code@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-document@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-dropcursor@3.22.3(@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extensions': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-floating-menu@3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.22.3(@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extensions': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-hard-break@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-heading@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-horizontal-rule@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-italic@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-link@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-list-keymap@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-ordered-list@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-paragraph@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-strike@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-text@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-underline@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+
+  '@tiptap/pm@3.22.3':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.4
+      prosemirror-menu: 1.3.2
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/react@3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-floating-menu': 3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.22.3':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/extension-blockquote': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-bold': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-bullet-list': 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-code': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-code-block': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-document': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-dropcursor': 3.22.3(@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-gapcursor': 3.22.3(@tiptap/extensions@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-hard-break': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-heading': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-horizontal-rule': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-italic': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-link': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-list-item': 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-list-keymap': 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-ordered-list': 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-paragraph': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-strike': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-text': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extension-underline': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
+      '@tiptap/extensions': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -4010,6 +4495,15 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
+
   '@types/mdx@2.0.13': {}
 
   '@types/node@25.6.0':
@@ -4025,6 +4519,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4484,6 +4980,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  crelt@1.0.6: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4595,6 +5093,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -4950,6 +5450,8 @@ snapshots:
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -5413,6 +5915,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.2: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -5447,9 +5955,20 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -5582,6 +6101,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  orderedmap@2.1.1: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -5661,7 +6182,112 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+      prosemirror-model: 1.25.4
+
+  prosemirror-menu@1.3.2:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
   proxy-from-env@2.1.0: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -5774,6 +6400,8 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
+
+  rope-sequence@1.3.4: {}
 
   run-applescript@7.1.0: {}
 
@@ -6126,6 +6754,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  uc.micro@2.1.0: {}
+
   unbox-primitive@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -6259,6 +6889,8 @@ snapshots:
       jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -72,6 +72,35 @@ describe("WikiEditPage", () => {
     expect(screen.getByLabelText("Quote")).toBeInTheDocument();
   });
 
+  it("shows the formatting toolbar only while editing a text block", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    expect(screen.queryByRole("button", { name: "Bold" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit text block" })[0]);
+
+    expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Italic" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert link" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Strike" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Link destination")).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Insert link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
+
+    expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Cancel" }).at(-1)!);
+
+    expect(screen.queryByRole("button", { name: "Bold" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit quote block" })[0]);
+
+    expect(screen.queryByRole("button", { name: "Bold" })).not.toBeInTheDocument();
+  });
+
   it("clears draft changes back to the loaded wiki", () => {
     mockedUseWikiDetail.mockReturnValue(successState);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);

--- a/src/app/wiki/[slug]/wikiThemePalette.test.ts
+++ b/src/app/wiki/[slug]/wikiThemePalette.test.ts
@@ -35,6 +35,7 @@ describe("wikiThemePalette", () => {
       ),
     ).toBeGreaterThanOrEqual(4.5);
     expect(lightPalette.pageBackground).toContain("radial-gradient");
+    expect(lightPalette.pageBackground).toContain("linear-gradient");
     expect(darkPalette.pageBackground).toContain("linear-gradient");
   });
 

--- a/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
@@ -58,4 +58,60 @@ describe("WikiBlockDisplay", () => {
 
     expect(screen.getByText("Main visual")).toBeInTheDocument();
   });
+
+  it("renders supported inline markdown inside text blocks", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "text-1",
+          blockType: "text",
+          content:
+            "**bold** _italic_ ~~strike~~ [site](https://example.com)",
+          displayOrder: 10,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("bold", { selector: "strong" })).toBeInTheDocument();
+    expect(screen.getByText("italic", { selector: "em" })).toBeInTheDocument();
+    expect(screen.getByText("strike", { selector: "del" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "site" })).toHaveAttribute(
+      "href",
+      "https://example.com",
+    );
+    expect(screen.getByRole("link", { name: "site" })).toHaveAttribute("target", "_blank");
+  });
+
+  it("shows invalid markdown as plain text", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "text-2",
+          blockType: "text",
+          content: "Broken [link](not a url",
+          displayOrder: 20,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Broken [link](not a url")).toBeInTheDocument();
+  });
+
+  it("renders line breaks inside text blocks", () => {
+    const { container } = render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "text-3",
+          blockType: "text",
+          content: "first line\nsecond line",
+          displayOrder: 30,
+        }}
+      />,
+    );
+    const textBlock = container.querySelector("p");
+
+    expect(textBlock).not.toBeNull();
+    expect(textBlock).toHaveTextContent("first linesecond line");
+    expect(container.querySelector("br")).not.toBeNull();
+  });
 });

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { Fragment } from "react";
 import Image from "next/image";
 import { type WikiBlock } from "@kpool/wiki";
 
 import { WikiEmbedFrame } from "../../../app/wiki/[slug]/WikiEmbedFrame";
 import { WikiRelatedProfiles } from "../../../app/wiki/[slug]/WikiRelatedProfiles";
+import { parseInlineMarkdown } from "../editing";
 import { ImageEditableOverlay } from "../icons";
 
 type WikiBlockDisplayProps = {
@@ -16,11 +18,55 @@ type WikiBlockDisplayProps = {
 export function WikiBlockDisplay({
   block,
   showEditableImageOverlay = false,
-  textClassName = "text-sm leading-7 text-text-muted",
+  textClassName = "text-sm leading-7 text-text-strong",
 }: WikiBlockDisplayProps) {
+  const renderInlineTokens = (content: string | ReturnType<typeof parseInlineMarkdown>) => {
+    const tokens = typeof content === "string" ? parseInlineMarkdown(content) : content;
+
+    return tokens.map((token, index) => {
+      switch (token.kind) {
+        case "strong":
+          return <strong key={`strong-${index}`}>{renderInlineTokens(token.children)}</strong>;
+        case "emphasis":
+          return <em key={`em-${index}`}>{renderInlineTokens(token.children)}</em>;
+        case "strikethrough":
+          return <del key={`del-${index}`}>{renderInlineTokens(token.children)}</del>;
+        case "link":
+          return (
+            <a
+              className="text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800"
+              href={token.href}
+              key={`link-${index}`}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {renderInlineTokens(token.children)}
+            </a>
+          );
+        case "text":
+          return (
+            <Fragment key={`text-${index}`}>
+              {token.text.split("\n").map((line, lineIndex) => (
+                <Fragment key={`text-${index}-line-${lineIndex}`}>
+                  {lineIndex > 0 ? <br /> : null}
+                  {line}
+                </Fragment>
+              ))}
+            </Fragment>
+          );
+      }
+    });
+  };
+
+  const renderTextBlock = (content: string) => (
+    <p className={textClassName}>
+      {renderInlineTokens(content)}
+    </p>
+  );
+
   switch (block.blockType) {
     case "text":
-      return <p className={textClassName}>{block.content}</p>;
+      return renderTextBlock(block.content);
     case "image":
       return (
         <figure>
@@ -56,11 +102,11 @@ export function WikiBlockDisplay({
       );
     case "list":
       return block.listType === "numbered" ? (
-        <ol className="list-decimal space-y-2 pl-6 text-sm leading-7 text-text-muted">
+        <ol className="list-decimal space-y-2 pl-6 text-sm leading-7 text-text-strong">
           {block.items.map((item) => <li key={item}>{item}</li>)}
         </ol>
       ) : (
-        <ul className="list-disc space-y-2 pl-6 text-sm leading-7 text-text-muted">
+        <ul className="list-disc space-y-2 pl-6 text-sm leading-7 text-text-strong">
           {block.items.map((item) => <li key={item}>{item}</li>)}
         </ul>
       );
@@ -75,7 +121,7 @@ export function WikiBlockDisplay({
             ) : null}
             <tbody>
               {block.rows.map((row) => (
-                <tr key={row.join("|")}>{row.map((cell) => <td className="border-b border-stroke-subtle px-3 py-2 text-text-muted" key={cell}>{cell}</td>)}</tr>
+                <tr key={row.join("|")}>{row.map((cell) => <td className="border-b border-stroke-subtle px-3 py-2 text-text-strong" key={cell}>{cell}</td>)}</tr>
               ))}
             </tbody>
           </table>

--- a/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
+++ b/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
@@ -8,17 +8,17 @@ import { WikiBlockForm } from "./index";
 describe("WikiBlockForm", () => {
   afterEach(() => cleanup());
 
-  it("submits text block changes", () => {
+  it("submits text block content", () => {
     const onSave = vi.fn();
 
     render(<WikiBlockForm block={wikiStoryTextBlock} onCancel={() => {}} onSave={onSave} />);
 
-    fireEvent.change(screen.getByLabelText("Text"), {
-      target: { value: "Updated body" },
-    });
     fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
 
-    expect(onSave).toHaveBeenCalledWith({ content: "Updated body" });
+    expect(onSave).toHaveBeenCalledWith({
+      content:
+        "The group balances brisk digital singles with a smaller number of concept-heavy mini albums.",
+    });
   });
 
   it("submits parsed table rows", () => {
@@ -36,5 +36,15 @@ describe("WikiBlockForm", () => {
         rows: [["Album", "2024"]],
       }),
     );
+  });
+
+  it("opens the link editor from the toolbar", () => {
+    render(<WikiBlockForm block={wikiStoryTextBlock} onCancel={() => {}} onSave={() => {}} />);
+
+    expect(screen.queryByLabelText("Link destination")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
+
+    expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
   });
 });

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -1,13 +1,24 @@
 "use client";
 
-import { type FormEvent } from "react";
+import { Link2Icon } from "@radix-ui/react-icons";
+import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
+import Link from "@tiptap/extension-link";
+import StarterKit from "@tiptap/starter-kit";
+import { type FormEvent, type MouseEvent, useState } from "react";
 import {
   type WikiBlock,
   type WikiEmbedProvider,
   type WikiListType,
+  type WikiTextBlock,
 } from "@kpool/wiki";
 
-import { getLines, getString } from "../editing";
+import {
+  getLines,
+  getString,
+  inlineMarkdownToTiptapHtml,
+  serializeTiptapJsonToInlineMarkdown,
+} from "../editing";
+import { cardSurfaceStyle } from "../styles";
 import { WikiFormActions } from "../WikiFormActions";
 
 type WikiBlockFormProps = {
@@ -15,6 +26,215 @@ type WikiBlockFormProps = {
   onCancel: () => void;
   onSave: (changes: Partial<WikiBlock>) => void;
 };
+
+type TextBlockFormProps = {
+  block: WikiTextBlock;
+  onCancel: () => void;
+  onSave: (changes: Partial<WikiBlock>) => void;
+};
+
+function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
+  const editorLabelId = `wiki-text-label-${block.blockIdentifier}`;
+  const [linkUrl, setLinkUrl] = useState("");
+  const [isLinkEditorOpen, setIsLinkEditorOpen] = useState(false);
+  const editor = useEditor({
+    content: inlineMarkdownToTiptapHtml(block.content),
+    editorProps: {
+      attributes: {
+        "aria-labelledby": editorLabelId,
+        class:
+          "min-h-32 whitespace-pre-wrap break-words px-3 py-3 outline-none before:text-text-muted empty:before:content-['Write_something…'] [&_a]:text-sky-700 [&_a]:underline [&_a]:decoration-sky-500 [&_a]:underline-offset-2",
+        role: "textbox",
+      },
+      handleKeyDown(view, event) {
+        if (event.key !== "Enter" || event.isComposing) {
+          return false;
+        }
+
+        const hardBreak = view.state.schema.nodes.hardBreak;
+
+        if (!hardBreak) {
+          return false;
+        }
+
+        event.preventDefault();
+        view.dispatch(view.state.tr.replaceSelectionWith(hardBreak.create()).scrollIntoView());
+        return true;
+      },
+    },
+    extensions: [
+      StarterKit.configure({
+        blockquote: false,
+        bulletList: false,
+        code: false,
+        codeBlock: false,
+        heading: false,
+        horizontalRule: false,
+        link: false,
+        listItem: false,
+        orderedList: false,
+      }),
+      Link.configure({
+        autolink: false,
+        linkOnPaste: false,
+        openOnClick: false,
+      }),
+    ],
+    immediatelyRender: false,
+  });
+  const editorState = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => ({
+      isBoldActive: currentEditor?.isActive("bold") ?? false,
+      isItalicActive: currentEditor?.isActive("italic") ?? false,
+      isStrikeActive: currentEditor?.isActive("strike") ?? false,
+      isLinkActive: currentEditor?.isActive("link") ?? false,
+    }),
+  }) ?? {
+    isBoldActive: false,
+    isItalicActive: false,
+    isStrikeActive: false,
+    isLinkActive: false,
+  };
+
+  const getMarkdownContent = () =>
+    editor ? serializeTiptapJsonToInlineMarkdown(editor.getJSON()) : block.content;
+
+  const applyFormat = (format: "bold" | "italic" | "strike" | "link") => {
+    if (!editor) {
+      return;
+    }
+
+    if (format === "link") {
+      const href = linkUrl.trim();
+
+      if (!href) {
+        return;
+      }
+
+      editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+      setIsLinkEditorOpen(false);
+      setLinkUrl("");
+      return;
+    }
+
+    if (format === "bold") {
+      editor.chain().focus().toggleBold().run();
+      return;
+    }
+
+    if (format === "italic") {
+      editor.chain().focus().toggleItalic().run();
+      return;
+    }
+
+    editor.chain().focus().toggleStrike().run();
+  };
+
+  const openLinkEditor = () => setIsLinkEditorOpen(true);
+
+  const closeLinkEditor = () => {
+    setIsLinkEditorOpen(false);
+    setLinkUrl("");
+    editor?.commands.focus();
+  };
+
+  const preserveSelection = (event: MouseEvent<HTMLButtonElement>) => event.preventDefault();
+  const getToolbarButtonClassName = (isActive: boolean, typographyClassName: string) =>
+    [
+      "rounded-md border px-2 py-1 text-sm transition",
+      isActive
+        ? "border-stroke-strong bg-surface-base text-text-strong shadow-sm"
+        : "border-transparent text-text-strong hover:border-stroke-subtle hover:bg-surface-base",
+      typographyClassName,
+    ].join(" ");
+  const getIconButtonClassName = (isActive: boolean) =>
+    [
+      "rounded-md border p-1.5 transition",
+      isActive
+        ? "border-stroke-strong bg-surface-base text-text-strong shadow-sm"
+        : "border-transparent text-text-strong hover:border-stroke-subtle hover:bg-surface-base",
+    ].join(" ");
+
+  return (
+    <form onSubmit={(event) => {
+      event.preventDefault();
+      onSave({ content: getMarkdownContent() });
+    }}
+    >
+      <div className="grid gap-2">
+        <label className="text-sm font-semibold text-text-strong" id={editorLabelId}>
+          Text
+        </label>
+        <div className="overflow-hidden rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
+          <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle px-3 py-2">
+            <button
+              aria-label="Bold"
+              aria-pressed={editorState.isBoldActive}
+              className={getToolbarButtonClassName(editorState.isBoldActive, "font-bold")}
+              onClick={() => applyFormat("bold")}
+              onMouseDown={preserveSelection}
+              type="button"
+            >
+              B
+            </button>
+            <button
+              aria-label="Italic"
+              aria-pressed={editorState.isItalicActive}
+              className={getToolbarButtonClassName(editorState.isItalicActive, "italic")}
+              onClick={() => applyFormat("italic")}
+              onMouseDown={preserveSelection}
+              type="button"
+            >
+              I
+            </button>
+            <button
+              aria-label="Strike"
+              aria-pressed={editorState.isStrikeActive}
+              className={getToolbarButtonClassName(editorState.isStrikeActive, "line-through")}
+              onClick={() => applyFormat("strike")}
+              onMouseDown={preserveSelection}
+              type="button"
+            >
+              S
+            </button>
+            <span aria-hidden="true" className="h-5 w-px bg-stroke-subtle" />
+            <button
+              aria-expanded={isLinkEditorOpen}
+              aria-label="Insert link"
+              aria-pressed={editorState.isLinkActive}
+              className={getIconButtonClassName(editorState.isLinkActive)}
+              onClick={openLinkEditor}
+              onMouseDown={preserveSelection}
+              type="button"
+            >
+              <Link2Icon aria-hidden="true" className="size-4" />
+            </button>
+          </div>
+          {isLinkEditorOpen ? (
+            <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle bg-surface-base px-3 py-2">
+              <label className="sr-only" htmlFor={`wiki-link-${block.blockIdentifier}`}>
+                Link destination
+              </label>
+              <input
+                className="min-w-0 flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal"
+                id={`wiki-link-${block.blockIdentifier}`}
+                onChange={(event) => setLinkUrl(event.target.value)}
+                placeholder="Paste a link"
+                type="url"
+                value={linkUrl}
+              />
+              <button className="rounded-md border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:opacity-50" disabled={!linkUrl.trim()} onClick={() => applyFormat("link")} onMouseDown={(event) => event.preventDefault()} type="button">Apply</button>
+              <button className="rounded-md px-2 py-2 text-sm text-text-muted transition hover:bg-surface-base" onClick={closeLinkEditor} type="button">Cancel</button>
+            </div>
+          ) : null}
+          <EditorContent editor={editor} />
+        </div>
+      </div>
+      <WikiFormActions onCancel={onCancel} />
+    </form>
+  );
+}
 
 export function WikiBlockForm({
   block,
@@ -31,12 +251,7 @@ export function WikiBlockForm({
 
   switch (block.blockType) {
     case "text":
-      return (
-        <form onSubmit={(event) => submit(event, (data) => ({ content: getString(data, "content") }))}>
-          <label className="grid gap-2 text-sm font-semibold text-text-strong">Text<textarea className="min-h-28 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.content} name="content" /></label>
-          <WikiFormActions onCancel={onCancel} />
-        </form>
-      );
+      return <WikiTextBlockForm block={block} onCancel={onCancel} onSave={onSave} />;
     case "image":
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ imageIdentifier: getString(data, "imageIdentifier"), imageSrc: getString(data, "imageSrc"), caption: getString(data, "caption") || null, alt: getString(data, "alt") || null }))}>

--- a/src/components/Wiki/WikiSectionEditor/index.tsx
+++ b/src/components/Wiki/WikiSectionEditor/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "@kpool/wiki";
 
 import { getString } from "../editing";
-import { EditIcon, TrashIcon } from "../icons";
+import { ChevronIcon, EditIcon, TrashIcon } from "../icons";
 import { WikiAddContentControls } from "../WikiAddContentControls";
 import { WikiBlockEditorItem } from "../WikiBlockEditorItem";
 import { WikiFormActions } from "../WikiFormActions";
@@ -73,8 +73,14 @@ export function WikiSectionEditor({
   const sectionEditorId: WikiContentEditorId = `section:${section.sectionIdentifier}`;
 
   return (
-    <details className="rounded-[1.75rem] border border-stroke-subtle shadow-soft" data-testid={`wiki-edit-section-${section.sectionIdentifier}`} open style={cardSurfaceStyle}>
-      <summary className="flex list-none items-start gap-3 p-5 text-left">
+    <details className="section-accordion rounded-[1.75rem] border border-stroke-subtle shadow-soft" data-testid={`wiki-edit-section-${section.sectionIdentifier}`} open style={cardSurfaceStyle}>
+      <summary className="flex list-none items-center gap-3 p-5 text-left">
+        <span
+          className="section-accordion__chevron rounded-full border border-stroke-subtle p-2 text-text-muted transition-transform"
+          style={cardSurfaceMutedStyle}
+        >
+          <ChevronIcon />
+        </span>
         <span className="min-w-0 flex-1">
           <span className="block text-2xl font-semibold tracking-[-0.03em] text-text-strong">{section.title}</span>
         </span>

--- a/src/components/Wiki/editing.test.ts
+++ b/src/components/Wiki/editing.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyInlineMarkdownFormat,
+  parseInlineMarkdown,
+} from "./editing";
+
+describe("applyInlineMarkdownFormat", () => {
+  it("wraps the selected text in bold markers", () => {
+    expect(
+      applyInlineMarkdownFormat({
+        content: "Aurora Echo",
+        format: "bold",
+        selectionEnd: 12,
+        selectionStart: 7,
+      }),
+    ).toEqual({
+      content: "Aurora **Echo**",
+      selectionEnd: 15,
+      selectionStart: 15,
+    });
+  });
+
+  it("inserts a markdown link with the provided url", () => {
+    expect(
+      applyInlineMarkdownFormat({
+        content: "Aurora Echo",
+        format: "link",
+        selectionEnd: 6,
+        selectionStart: 0,
+        url: "https://example.com",
+      }),
+    ).toEqual({
+      content: "[Aurora](https://example.com) Echo",
+      selectionEnd: 29,
+      selectionStart: 29,
+    });
+  });
+
+  it("inserts placeholder text when adding a link without a selection", () => {
+    expect(
+      applyInlineMarkdownFormat({
+        content: "",
+        format: "link",
+        selectionEnd: 0,
+        selectionStart: 0,
+        url: "https://example.com",
+      }),
+    ).toEqual({
+      content: "[link](https://example.com)",
+      selectionEnd: 27,
+      selectionStart: 27,
+    });
+  });
+
+  it("allows wrapping existing markdown with another format", () => {
+    expect(
+      applyInlineMarkdownFormat({
+        content: "**Echo**",
+        format: "italic",
+        selectionEnd: 8,
+        selectionStart: 0,
+      }),
+    ).toEqual({
+      content: "_**Echo**_",
+      selectionEnd: 10,
+      selectionStart: 10,
+    });
+  });
+});
+
+describe("parseInlineMarkdown", () => {
+  it("parses the supported inline markdown tokens", () => {
+    expect(
+      parseInlineMarkdown("**bold** _italic_ ~~strike~~ [site](https://example.com)"),
+    ).toEqual([
+      { children: [{ kind: "text", text: "bold" }], kind: "strong" },
+      { kind: "text", text: " " },
+      { children: [{ kind: "text", text: "italic" }], kind: "emphasis" },
+      { kind: "text", text: " " },
+      { children: [{ kind: "text", text: "strike" }], kind: "strikethrough" },
+      { kind: "text", text: " " },
+      {
+        children: [{ kind: "text", text: "site" }],
+        href: "https://example.com",
+        kind: "link",
+      },
+    ]);
+  });
+
+  it("parses nested inline markdown tokens", () => {
+    expect(parseInlineMarkdown("**_bold italic_**")).toEqual([
+      {
+        children: [
+          {
+            children: [{ kind: "text", text: "bold italic" }],
+            kind: "emphasis",
+          },
+        ],
+        kind: "strong",
+      },
+    ]);
+  });
+
+  it("keeps invalid markdown as plain text", () => {
+    expect(parseInlineMarkdown("Broken [link](not a url")).toEqual([
+      { kind: "text", text: "Broken [link](not a url" },
+    ]);
+  });
+});

--- a/src/components/Wiki/editing.ts
+++ b/src/components/Wiki/editing.ts
@@ -41,3 +41,259 @@ export const getLines = (formData: FormData, name: string): string[] =>
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean);
+
+export type InlineMarkdownFormat = "bold" | "italic" | "link" | "strike";
+
+type ApplyInlineMarkdownFormatInput = {
+  content: string;
+  format: InlineMarkdownFormat;
+  selectionStart: number;
+  selectionEnd: number;
+  url?: string;
+};
+
+export type InlineMarkdownToken =
+  | { kind: "text"; text: string }
+  | { kind: "strong"; children: InlineMarkdownToken[] }
+  | { kind: "emphasis"; children: InlineMarkdownToken[] }
+  | { kind: "strikethrough"; children: InlineMarkdownToken[] }
+  | { kind: "link"; children: InlineMarkdownToken[]; href: string };
+
+const markdownWrapMap: Record<Exclude<InlineMarkdownFormat, "link">, string> = {
+  bold: "**",
+  italic: "_",
+  strike: "~~",
+};
+
+const clampSelection = (value: string, selection: number): number =>
+  Math.min(Math.max(selection, 0), value.length);
+
+const getSelectionRange = (
+  content: string,
+  selectionStart: number,
+  selectionEnd: number,
+): [number, number] => {
+  const start = clampSelection(content, Math.min(selectionStart, selectionEnd));
+  const end = clampSelection(content, Math.max(selectionStart, selectionEnd));
+
+  return [start, end];
+};
+
+const buildWrappedSelection = (
+  content: string,
+  selectionStart: number,
+  selectionEnd: number,
+  wrapper: string,
+) => {
+  const [start, end] = getSelectionRange(content, selectionStart, selectionEnd);
+  const selectedText = content.slice(start, end);
+  const replacement = `${wrapper}${selectedText}${wrapper}`;
+
+  return {
+    content: `${content.slice(0, start)}${replacement}${content.slice(end)}`,
+    selectionEnd: start + replacement.length,
+    selectionStart: start + replacement.length,
+  };
+};
+
+export const applyInlineMarkdownFormat = ({
+  content,
+  format,
+  selectionStart,
+  selectionEnd,
+  url,
+}: ApplyInlineMarkdownFormatInput) => {
+  if (format === "link") {
+    const href = url?.trim();
+
+    if (!href) {
+      return { content, selectionStart, selectionEnd };
+    }
+
+    const [start, end] = getSelectionRange(content, selectionStart, selectionEnd);
+    const selectedText = content.slice(start, end) || "link";
+    const replacement = `[${selectedText}](${href})`;
+
+    return {
+      content: `${content.slice(0, start)}${replacement}${content.slice(end)}`,
+      selectionEnd: start + replacement.length,
+      selectionStart: start + replacement.length,
+    };
+  }
+
+  return buildWrappedSelection(
+    content,
+    selectionStart,
+    selectionEnd,
+    markdownWrapMap[format],
+  );
+};
+
+const findClosingMarker = (content: string, marker: string, fromIndex: number): number =>
+  content.indexOf(marker, fromIndex);
+
+const parseLinkToken = (content: string, startIndex: number): { node: InlineMarkdownToken; nextIndex: number } | null => {
+  const textEnd = content.indexOf("]", startIndex + 1);
+
+  if (textEnd < 0 || content[textEnd + 1] !== "(") {
+    return null;
+  }
+
+  const hrefEnd = content.indexOf(")", textEnd + 2);
+
+  if (hrefEnd < 0) {
+    return null;
+  }
+
+  const href = content.slice(textEnd + 2, hrefEnd);
+
+  if (!/^https?:\/\/\S+$/.test(href)) {
+    return null;
+  }
+
+  const text = content.slice(startIndex + 1, textEnd);
+
+  return {
+    nextIndex: hrefEnd + 1,
+    node: {
+      children: parseInlineMarkdown(text),
+      href,
+      kind: "link",
+    },
+  };
+};
+
+const parseWrappedToken = (
+  content: string,
+  startIndex: number,
+  marker: string,
+  kind: Extract<InlineMarkdownToken["kind"], "strong" | "emphasis" | "strikethrough">,
+): { node: InlineMarkdownToken; nextIndex: number } | null => {
+  const contentStart = startIndex + marker.length;
+  const closingIndex = findClosingMarker(content, marker, contentStart);
+
+  if (closingIndex < 0 || closingIndex === contentStart) {
+    return null;
+  }
+
+  return {
+    nextIndex: closingIndex + marker.length,
+    node: {
+      children: parseInlineMarkdown(content.slice(contentStart, closingIndex)),
+      kind,
+    },
+  };
+};
+
+export const parseInlineMarkdown = (content: string): InlineMarkdownToken[] => {
+  const tokens: InlineMarkdownToken[] = [];
+  let cursor = 0;
+  let textBuffer = "";
+
+  const flushText = () => {
+    if (!textBuffer) {
+      return;
+    }
+
+    tokens.push({ kind: "text", text: textBuffer });
+    textBuffer = "";
+  };
+
+  while (cursor < content.length) {
+    const slice = content.slice(cursor);
+    const token =
+      (slice.startsWith("**") && parseWrappedToken(content, cursor, "**", "strong")) ||
+      (slice.startsWith("~~") && parseWrappedToken(content, cursor, "~~", "strikethrough")) ||
+      (slice.startsWith("_") && parseWrappedToken(content, cursor, "_", "emphasis")) ||
+      (slice.startsWith("[") && parseLinkToken(content, cursor));
+
+    if (token) {
+      flushText();
+      tokens.push(token.node);
+      cursor = token.nextIndex;
+      continue;
+    }
+
+    textBuffer += content[cursor];
+    cursor += 1;
+  }
+
+  flushText();
+
+  return tokens;
+};
+
+type TiptapMark = {
+  attrs?: {
+    href?: string;
+  };
+  type?: string;
+};
+
+type TiptapNode = {
+  content?: TiptapNode[];
+  marks?: TiptapMark[];
+  text?: string;
+  type?: string;
+};
+
+const escapeHtml = (text: string): string =>
+  text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+const inlineTokensToHtml = (tokens: InlineMarkdownToken[]): string =>
+  tokens
+    .map((token) => {
+      switch (token.kind) {
+        case "text":
+          return escapeHtml(token.text).replaceAll("\n", "<br>");
+        case "strong":
+          return `<strong>${inlineTokensToHtml(token.children)}</strong>`;
+        case "emphasis":
+          return `<em>${inlineTokensToHtml(token.children)}</em>`;
+        case "strikethrough":
+          return `<del>${inlineTokensToHtml(token.children)}</del>`;
+        case "link":
+          return `<a href="${escapeHtml(token.href)}">${inlineTokensToHtml(token.children)}</a>`;
+      }
+    })
+    .join("");
+
+export const inlineMarkdownToTiptapHtml = (content: string): string =>
+  `<p>${inlineTokensToHtml(parseInlineMarkdown(content))}</p>`;
+
+const applyMarksToText = (text: string, marks: TiptapMark[] = []): string =>
+  marks.reduce((current, mark) => {
+    switch (mark.type) {
+      case "bold":
+        return `**${current}**`;
+      case "italic":
+        return `_${current}_`;
+      case "strike":
+        return `~~${current}~~`;
+      case "link":
+        return `[${current}](${mark.attrs?.href ?? ""})`;
+      default:
+        return current;
+    }
+  }, text);
+
+const serializeTiptapNode = (node: TiptapNode): string => {
+  switch (node.type) {
+    case "doc":
+      return (node.content ?? []).map(serializeTiptapNode).join("");
+    case "paragraph":
+      return (node.content ?? []).map(serializeTiptapNode).join("");
+    case "hardBreak":
+      return "\n";
+    case "text":
+      return applyMarksToText(node.text ?? "", node.marks);
+    default:
+      return (node.content ?? []).map(serializeTiptapNode).join("");
+  }
+};
+
+export const serializeTiptapJsonToInlineMarkdown = (node: TiptapNode): string =>
+  serializeTiptapNode(node);

--- a/src/components/Wiki/icons.tsx
+++ b/src/components/Wiki/icons.tsx
@@ -58,7 +58,7 @@ export function ChevronIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="section-accordion__chevron h-4 w-4 transition-transform"
+      className="h-4 w-4"
       fill="none"
       stroke="currentColor"
       strokeLinecap="round"

--- a/src/components/Wiki/styles.ts
+++ b/src/components/Wiki/styles.ts
@@ -1,7 +1,7 @@
 export const mainBackgroundStyle = {
   backgroundColor: "var(--background)",
   backgroundImage:
-    "var(--wiki-page-background, radial-gradient(circle at top, rgba(255,214,194,0.85), transparent 38%), linear-gradient(180deg, var(--background) 0%, #fff 100%))",
+    "var(--wiki-page-background, radial-gradient(circle at top, rgba(255,214,194,0.85), transparent 38%), linear-gradient(180deg, var(--background) 0%, var(--surface-raised) 100%))",
 };
 
 export const cardSurfaceStyle = {

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -83,11 +83,58 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(page.getByText("Saved")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(1);
   await expect(page.getByRole("button", { name: "Submit wiki for review" })).toHaveCount(1);
+  await page.getByRole("button", { name: "Collapse editor sidebar" }).click();
 
   const overviewAddControls = page.getByTestId("wiki-edit-add-section-sec-overview");
   await overviewAddControls.getByText("+ Block").click();
   await overviewAddControls.getByRole("button", { name: "Quote" }).click();
   await expect(page.getByRole("textbox", { name: "Quote" })).toBeVisible();
+
+  const overviewTextBlock = page.getByTestId("wiki-edit-block-block-overview-text");
+  await overviewTextBlock.getByRole("button", { name: "Edit text block" }).click();
+  await expect(page.getByRole("button", { name: "Bold" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Insert link" })).toBeVisible();
+  const textEditor = page.getByRole("textbox", { name: "Text" });
+  await textEditor.evaluate((node: HTMLElement) => {
+    const selection = window.getSelection();
+    const findFirstTextNode = (current: Node): Text | null => {
+      if (current.nodeType === Node.TEXT_NODE) {
+        return current as Text;
+      }
+
+      for (const child of current.childNodes) {
+        const textNode = findFirstTextNode(child);
+
+        if (textNode) {
+          return textNode;
+        }
+      }
+
+      return null;
+    };
+    const firstTextNode = findFirstTextNode(node);
+
+    if (!selection || !firstTextNode) {
+      return;
+    }
+
+    const range = document.createRange();
+    range.setStart(firstTextNode, 0);
+    range.setEnd(firstTextNode, Math.min(6, firstTextNode.textContent?.length ?? 0));
+    selection.removeAllRanges();
+    selection.addRange(range);
+  });
+  await page.getByRole("button", { name: "Insert link" }).click();
+  await page.getByLabel("Link destination").fill("https://example.com");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByRole("button", { name: "Bold" })).toHaveCount(0);
+  await expect(
+    overviewTextBlock.getByRole("link", { name: "Aurora" }),
+  ).toHaveAttribute("href", "https://example.com");
+  await expect(
+    overviewTextBlock.getByRole("link", { name: "Aurora" }),
+  ).toHaveAttribute("target", "_blank");
 
   await expect(
     page.getByTestId("wiki-edit-add-section-sec-discography-highlights-chart"),


### PR DESCRIPTION
## 📝 変更内容

- Wiki テキストブロックの編集UIを `textarea` から Tiptap ベースのリッチテキスト入力に変更
- 太字、斜体、打ち消し線、リンク挿入のツールバーを追加
- 表示側でインラインMarkdownを解釈し、装飾・リンク・改行を反映
- 新規テキストブロックの初期内容を空文字に変更
- unit test / page test / e2e test を追加して編集バーと表示挙動をカバー

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki のテキストブロック編集時に最低限のインライン装飾をその場で付けられるようにし、プレビューと編集体験の差を減らすためです。既存のプレーンテキスト入力ではリンクや強調表現を直感的に扱えなかったため、編集UIと表示ロジックを合わせて拡張しています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Wiki 編集画面でテキストブロックを編集したときだけ装飾ツールバーが表示されること
- リンク挿入後に保存し、詳細表示側で外部リンクとして描画されること
- Quote ブロック編集時にはテキスト装飾ツールバーが表示されないこと

## 🔍 レビューのポイント

- Tiptap JSON とインラインMarkdownの相互変換方針が妥当か
- `parseInlineMarkdown` の対応範囲でWiki表示要件を満たせているか
- テキストブロックだけに編集ツールバーが出るUI制御に抜け漏れがないか

## 📖 関連情報

### 関連Issue・タスク

Closes #35

## ⚠️ 注意事項

- `@tiptap/react`、`@tiptap/starter-kit`、`@tiptap/extension-link`、`@radix-ui/react-icons` を追加しています
- `.codex/tmp/` と `public/kpool.ico` は今回の PR 対象外です

## 📸 スクリーンショット・デモ

- UI 変更の確認内容は上記の動作確認に記載

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
