### PR TITLE
feat: 編集Wikiのコードモードを追加

### DIFF
--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -6,6 +6,8 @@ import {
   createWikiBlock,
   deleteWikiContent,
   getWikiContentEditorId,
+  parseWikiSectionsFromCode,
+  serializeWikiSectionsToCode,
   toWikiSectionContentPayload,
   updateWikiBlock,
   updateWikiSection,
@@ -129,5 +131,120 @@ describe("wikiEditModel", () => {
 
     expect(getWikiContentEditorId(section)).toBe("section:sec-root");
     expect(getWikiContentEditorId(block)).toBe("block:block-root-text");
+  });
+
+  it("round-trips structured sections through code mode into a stable canonical code form", () => {
+    const wiki = createMockWikiDetail("aurora-echo");
+    const code = serializeWikiSectionsToCode(wiki.sections);
+    const parsed = parseWikiSectionsFromCode(code);
+
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(serializeWikiSectionsToCode(parsed.sections)).toBe(code);
+    expect(code).toContain("[[image|id:img-discography-stage|src:");
+    expect(code).toContain("== Highlights ==");
+  });
+
+  it("parses namu-like headings, lists, tables, and unknown macros as editable content", () => {
+    const parsed = parseWikiSectionsFromCode([
+      "= Overview =",
+      "",
+      "Aurora Echo keeps a fast release cycle.",
+      "",
+      "[[분류:테스트]]",
+      "",
+      "* Debut single",
+      "* Follow-up single",
+      "",
+      "== Highlights ==",
+      "",
+      "|| !Release || !Year ||",
+      "|| Low Tide, High Lights || 2022 ||",
+    ].join("\n"));
+
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(toWikiSectionContentPayload(parsed.sections)).toEqual([
+      {
+        type: "section",
+        title: "Overview",
+        display_order: 10,
+        contents: [
+          {
+            block_type: "text",
+            display_order: 10,
+            content: "Aurora Echo keeps a fast release cycle.",
+          },
+          {
+            block_type: "text",
+            display_order: 20,
+            content: "[[분류:테스트]]",
+          },
+          {
+            block_type: "list",
+            display_order: 30,
+            list_type: "bullet",
+            items: ["Debut single", "Follow-up single"],
+          },
+          {
+            type: "section",
+            title: "Highlights",
+            display_order: 40,
+            contents: [
+              {
+                block_type: "table",
+                display_order: 10,
+                headers: ["Release", "Year"],
+                rows: [["Low Tide, High Lights", "2022"]],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("returns a parse error when headings skip levels or exceed the supported depth", () => {
+    expect(
+      parseWikiSectionsFromCode(["= Overview =", "", "=== Broken ==="].join("\n")),
+    ).toEqual({
+      ok: false,
+      message: "Heading depth cannot skip levels. Add the missing parent section first.",
+    });
+
+    expect(
+      parseWikiSectionsFromCode([
+        "= Overview =",
+        "",
+        "== Style ==",
+        "",
+        "==== Too Deep ====",
+      ].join("\n")),
+    ).toEqual({
+      ok: false,
+      message: "Code mode supports headings up to depth 3.",
+    });
+  });
+
+  it("returns a parse error for malformed structured macros", () => {
+    expect(
+      parseWikiSectionsFromCode([
+        "= Overview =",
+        "",
+        "[[image|id:cover|src:https://example.com/image.png",
+      ].join("\n")),
+    ).toEqual({
+      ok: false,
+      message:
+        "Code mode could not parse a structured block. Fix the macro syntax or clear the draft.",
+    });
   });
 });

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -2,6 +2,7 @@ import type {
   WikiBlock,
   WikiBlockType,
   WikiDetail,
+  WikiEmbedProvider,
   WikiSection,
   WikiSectionContent,
 } from "./types/wiki";
@@ -50,8 +51,667 @@ export type WikiEditPayload = {
   contents: WikiSectionContentPayload[];
 };
 
+export type WikiCodeParseResult =
+  | {
+      ok: true;
+      sections: WikiSection[];
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+const DISPLAY_ORDER_STEP = 10;
+
+const escapeCodeValue = (value: string): string =>
+  value.replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll(",", "\\,");
+
+const encodeCodeUri = (value: string): string => encodeURIComponent(value);
+
+const decodeCodeUri = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const unescapeCodeValue = (value: string): string => {
+  let unescaped = "";
+  let isEscaped = false;
+
+  for (const character of value) {
+    if (isEscaped) {
+      unescaped += character;
+      isEscaped = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      isEscaped = true;
+      continue;
+    }
+
+    unescaped += character;
+  }
+
+  if (isEscaped) {
+    unescaped += "\\";
+  }
+
+  return unescaped;
+};
+
+const splitEscaped = (value: string, delimiter: string): string[] => {
+  const parts: string[] = [];
+  let current = "";
+  let isEscaped = false;
+
+  for (const character of value) {
+    if (isEscaped) {
+      current += character;
+      isEscaped = false;
+      continue;
+    }
+
+    if (character === "\\") {
+      isEscaped = true;
+      continue;
+    }
+
+    if (character === delimiter) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (isEscaped) {
+    current += "\\";
+  }
+
+  parts.push(current);
+
+  return parts;
+};
+
+const headingPattern = /^(=+)\s*(.*?)\s*\1$/;
+
+const getHeadingDepth = (line: string): number | null => {
+  const match = line.match(headingPattern);
+
+  if (!match) {
+    return null;
+  }
+
+  return match[1].length;
+};
+
+const getHeadingTitle = (line: string): string | null => {
+  const match = line.match(headingPattern);
+
+  return match?.[2]?.trim() ?? null;
+};
+
+const serializeCodeMacro = (name: string, values: string[]): string =>
+  `[[${name}${values.length > 0 ? `|${values.join("|")}` : ""}]]`;
+
+const serializeCodeField = (key: string, value: string | null | undefined): string | null =>
+  value == null ? null : `${key}:${escapeCodeValue(value)}`;
+
+const serializeTableRow = (cells: string[], isHeader = false): string =>
+  `|| ${cells.map((cell) => `${isHeader ? "!" : ""}${cell}`).join(" || ")} ||`;
+
+const serializeWikiBlockToCode = (block: WikiBlock): string => {
+  switch (block.blockType) {
+    case "text":
+      return block.content;
+    case "image":
+      return serializeCodeMacro("image", [
+        `id:${escapeCodeValue(block.imageIdentifier)}`,
+        `src:${encodeCodeUri(block.imageSrc)}`,
+        serializeCodeField("caption", block.caption),
+        serializeCodeField("alt", block.alt),
+      ].filter((value): value is string => Boolean(value)));
+    case "image_gallery":
+      return serializeCodeMacro("gallery", [
+        `images:${block.images
+          .map((image) =>
+            [
+              escapeCodeValue(image.imageIdentifier),
+              encodeCodeUri(image.imageSrc),
+              escapeCodeValue(image.alt ?? ""),
+            ].join("@"),
+          )
+          .join(",")}`,
+        serializeCodeField("caption", block.caption),
+      ].filter((value): value is string => Boolean(value)));
+    case "embed":
+      return serializeCodeMacro("embed", [
+        `provider:${escapeCodeValue(block.provider)}`,
+        `id:${escapeCodeValue(block.embedId)}`,
+        serializeCodeField("caption", block.caption),
+      ].filter((value): value is string => Boolean(value)));
+    case "quote":
+      return [
+        ...block.content.split("\n").map((line) => `> ${line}`),
+        ...(block.source ? [`> -- ${block.source}`] : []),
+      ].join("\n");
+    case "list":
+      return block.items
+        .map((item, index) =>
+          block.listType === "numbered" ? `${index + 1}. ${item}` : `* ${item}`,
+        )
+        .join("\n");
+    case "table":
+      return [
+        ...(block.headers ? [serializeTableRow(block.headers, true)] : []),
+        ...block.rows.map((row) => serializeTableRow(row)),
+      ].join("\n");
+    case "profile_card_list":
+      return serializeCodeMacro("profiles", [
+        `ids:${block.wikiIdentifiers.map(escapeCodeValue).join(",")}`,
+        serializeCodeField("title", block.title),
+      ].filter((value): value is string => Boolean(value)));
+  }
+};
+
+const serializeWikiSectionToCode = (section: WikiSection): string => {
+  const normalizedSection = normalizeWikiSectionContents(section);
+  const heading = `${"=".repeat(normalizedSection.depth)} ${normalizedSection.title} ${"=".repeat(normalizedSection.depth)}`;
+  const sortedContents = sortWikiSectionContents(normalizedSection.contents);
+  const contents = [
+    ...sortedContents
+      .filter(isWikiBlock)
+      .map(serializeWikiBlockToCode),
+    ...sortedContents
+      .filter(isWikiSection)
+      .map(serializeWikiSectionToCode),
+  ];
+
+  return [heading, ...contents.filter(Boolean)].join("\n\n");
+};
+
+export const serializeWikiSectionsToCode = (sections: WikiSection[]): string =>
+  sortWikiSectionContents(sections)
+    .map(serializeWikiSectionToCode)
+    .join("\n\n")
+    .trim();
+
+const parseTableCells = (line: string): string[] =>
+  line
+    .trim()
+    .replace(/^(\|\|)\s*/, "")
+    .replace(/\s*(\|\|)$/, "")
+    .split("||")
+    .map((cell) => cell.trim());
+
+const createParseError = (message: string): WikiCodeParseResult => ({
+  ok: false,
+  message,
+});
+
+const parseCodeField = (part: string): [string, string] | null => {
+  const dividerIndex = part.indexOf(":");
+
+  if (dividerIndex <= 0) {
+    return null;
+  }
+
+  return [
+    part.slice(0, dividerIndex).trim(),
+    part.slice(dividerIndex + 1).trim(),
+  ];
+};
+
+const parseCodeMacro = (
+  line: string,
+): { name: string; fields: Record<string, string> } | null => {
+  if (!line.startsWith("[[")) {
+    return null;
+  }
+
+  if (!line.endsWith("]]")) {
+    return { name: "__invalid__", fields: {} };
+  }
+
+  const rawContent = line.slice(2, -2).trim();
+  const [name, ...parts] = splitEscaped(rawContent, "|");
+  const fields = parts.reduce<Record<string, string>>((result, part) => {
+    const field = parseCodeField(part);
+
+    if (!field) {
+      return result;
+    }
+
+    result[field[0]] = field[1];
+    return result;
+  }, {});
+
+  return { name: name.trim(), fields };
+};
+
+type WikiCodeBlocksParseResult =
+  | {
+      ok: true;
+      blocks: WikiBlock[];
+    }
+  | {
+      ok: false;
+      message: string;
+    };
+
+const createBlockParseError = (message: string): WikiCodeBlocksParseResult => ({
+  ok: false,
+  message,
+});
+
+const isSupportedCodeMacro = (name: string): boolean =>
+  ["image", "gallery", "embed", "profiles"].includes(name);
+
+const isListLine = (line: string): boolean =>
+  /^\*\s+/.test(line.trim()) || /^\d+\.\s+/.test(line.trim());
+
+const isQuoteLine = (line: string): boolean => line.trim().startsWith(">");
+
+const isTableLine = (line: string): boolean => line.trim().startsWith("||");
+
+const isStructuredMacroLine = (line: string): boolean => {
+  const macro = parseCodeMacro(line.trim());
+
+  return Boolean(
+    macro && (macro.name === "__invalid__" || isSupportedCodeMacro(macro.name)),
+  );
+};
+
+const isStructuredBlockStart = (line: string): boolean =>
+  isStructuredMacroLine(line) ||
+  isQuoteLine(line) ||
+  isListLine(line) ||
+  isTableLine(line);
+
+const parseCodeBlocks = (lines: string[]): WikiCodeBlocksParseResult => {
+  const blocks: WikiBlock[] = [];
+  let cursor = 0;
+
+  const addBlock = (block: Record<string, unknown> & { blockType: WikiBlockType }) => {
+    blocks.push({
+      ...block,
+      blockIdentifier: createIdentifier(`block-${block.blockType.replaceAll("_", "-")}`),
+      displayOrder: (blocks.length + 1) * DISPLAY_ORDER_STEP,
+    } as WikiBlock);
+  };
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    const trimmedLine = line.trim();
+
+    if (!trimmedLine) {
+      cursor += 1;
+      continue;
+    }
+
+    if (isQuoteLine(line)) {
+      const quoteLines: string[] = [];
+
+      while (cursor < lines.length && isQuoteLine(lines[cursor])) {
+        quoteLines.push(lines[cursor].trim().replace(/^>\s?/, ""));
+        cursor += 1;
+      }
+
+      const maybeSource = quoteLines.at(-1)?.match(/^--\s+(.+)$/)?.[1] ?? null;
+      const contentLines = maybeSource ? quoteLines.slice(0, -1) : quoteLines;
+
+      addBlock({
+        blockType: "quote",
+        content: contentLines.join("\n"),
+        source: maybeSource,
+      });
+      continue;
+    }
+
+    if (isListLine(line)) {
+      const isNumbered = /^\d+\.\s+/.test(trimmedLine);
+      const items: string[] = [];
+
+      while (
+        cursor < lines.length &&
+        (isNumbered
+          ? /^\d+\.\s+/.test(lines[cursor].trim())
+          : /^\*\s+/.test(lines[cursor].trim()))
+      ) {
+        items.push(
+          lines[cursor]
+            .trim()
+            .replace(isNumbered ? /^\d+\.\s+/ : /^\*\s+/, ""),
+        );
+        cursor += 1;
+      }
+
+      addBlock({
+        blockType: "list",
+        items,
+        listType: isNumbered ? "numbered" : "bullet",
+      });
+      continue;
+    }
+
+    if (isTableLine(line)) {
+      const rows: string[][] = [];
+
+      while (cursor < lines.length && isTableLine(lines[cursor])) {
+        rows.push(parseTableCells(lines[cursor]));
+        cursor += 1;
+      }
+
+      const firstRow = rows[0] ?? [];
+      const hasHeaders = firstRow.length > 0 && firstRow.every((cell) => cell.startsWith("!"));
+
+      addBlock({
+        blockType: "table",
+        headers: hasHeaders ? firstRow.map((cell) => cell.slice(1).trim()) : null,
+        rows: (hasHeaders ? rows.slice(1) : rows).map((row) =>
+          row.map((cell) => cell.trim()),
+        ),
+      });
+      continue;
+    }
+
+    if (isStructuredMacroLine(line)) {
+      const macro = parseCodeMacro(trimmedLine);
+
+      if (macro?.name === "__invalid__") {
+        return createBlockParseError(
+          "Code mode could not parse a structured block. Fix the macro syntax or clear the draft.",
+        );
+      }
+
+      if (macro && isSupportedCodeMacro(macro.name)) {
+        if (macro.name === "image") {
+          if (!macro.fields.id || !macro.fields.src) {
+            return createBlockParseError("Image blocks require both id and src.");
+          }
+
+          addBlock({
+            blockType: "image",
+            alt: macro.fields.alt ? unescapeCodeValue(macro.fields.alt) : null,
+            caption: macro.fields.caption ? unescapeCodeValue(macro.fields.caption) : null,
+            imageIdentifier: unescapeCodeValue(macro.fields.id),
+            imageSrc: decodeCodeUri(macro.fields.src),
+          });
+          cursor += 1;
+          continue;
+        }
+
+        if (macro.name === "gallery") {
+          const rawImages = macro.fields.images;
+
+          if (!rawImages) {
+            return createBlockParseError("Gallery blocks require at least one image entry.");
+          }
+
+          const images = splitEscaped(rawImages, ",").map((entry) => {
+            const [imageIdentifier, imageSrc, alt = ""] = splitEscaped(entry, "@");
+
+            if (!imageIdentifier || !imageSrc) {
+              return null;
+            }
+
+            return {
+              alt: alt ? unescapeCodeValue(alt) : null,
+              imageIdentifier: unescapeCodeValue(imageIdentifier),
+              imageSrc: decodeCodeUri(imageSrc),
+            };
+          });
+
+          if (images.some((image) => image == null)) {
+            return createBlockParseError(
+              "Gallery image entries must include both identifier and src.",
+            );
+          }
+
+          addBlock({
+            blockType: "image_gallery",
+            caption: macro.fields.caption ? unescapeCodeValue(macro.fields.caption) : null,
+            images: images.filter((image) => image != null),
+          });
+          cursor += 1;
+          continue;
+        }
+
+        if (macro.name === "embed") {
+          if (!macro.fields.provider || !macro.fields.id) {
+            return createBlockParseError("Embed blocks require provider and id.");
+          }
+
+          addBlock({
+            blockType: "embed",
+            caption: macro.fields.caption ? unescapeCodeValue(macro.fields.caption) : null,
+            embedId: unescapeCodeValue(macro.fields.id),
+            provider: unescapeCodeValue(macro.fields.provider) as WikiEmbedProvider,
+          });
+          cursor += 1;
+          continue;
+        }
+
+        const identifiers = (macro.fields.ids ?? "")
+          .split(",")
+          .map(unescapeCodeValue)
+          .filter(Boolean);
+
+        addBlock({
+          blockType: "profile_card_list",
+          title: macro.fields.title ? unescapeCodeValue(macro.fields.title) : null,
+          wikiIdentifiers: identifiers,
+        });
+        cursor += 1;
+        continue;
+      }
+    }
+
+    const textLines: string[] = [];
+
+    while (cursor < lines.length) {
+      const currentLine = lines[cursor];
+
+      if (!currentLine.trim()) {
+        break;
+      }
+
+      if (isStructuredBlockStart(currentLine)) {
+        break;
+      }
+
+      textLines.push(currentLine);
+      cursor += 1;
+    }
+
+    addBlock({
+      blockType: "text",
+      content: textLines.join("\n"),
+    });
+  }
+
+  return {
+    ok: true,
+    blocks,
+  };
+};
+
+const appendBlocksToSection = (
+  section: WikiSection,
+  blocks: WikiBlock[],
+): WikiSection => {
+  const existingCount = section.contents.length;
+  const normalizedBlocks = blocks.map((block, index) => ({
+    ...block,
+    displayOrder: (existingCount + index + 1) * DISPLAY_ORDER_STEP,
+  }));
+
+  return {
+    ...section,
+    contents: [...section.contents, ...normalizedBlocks],
+  };
+};
+
+export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => {
+  const normalizedCode = code.replaceAll("\r\n", "\n");
+
+  if (!normalizedCode.trim()) {
+    return {
+      ok: true,
+      sections: [],
+    };
+  }
+
+  const lines = normalizedCode.split("\n");
+  const rootSections: WikiSection[] = [];
+  let sectionStack: WikiSection[] = [];
+  let pendingLines: string[] = [];
+
+  const replaceSectionInStack = (nextSection: WikiSection) => {
+    const depthIndex = nextSection.depth - 1;
+    sectionStack = sectionStack.map((section, index) =>
+      index === depthIndex ? nextSection : section,
+    );
+
+    if (nextSection.depth === 1) {
+      const rootIndex = rootSections.findIndex(
+        (section) => section.sectionIdentifier === nextSection.sectionIdentifier,
+      );
+
+      if (rootIndex >= 0) {
+        rootSections[rootIndex] = nextSection;
+      }
+
+      return;
+    }
+
+    const parent = sectionStack[depthIndex - 1];
+
+    if (!parent) {
+      return;
+    }
+
+    const nextParent = {
+      ...parent,
+      children: parent.children.map((child) =>
+        child.sectionIdentifier === nextSection.sectionIdentifier ? nextSection : child,
+      ),
+      contents: parent.contents.map((content) =>
+        isWikiSection(content) && content.sectionIdentifier === nextSection.sectionIdentifier
+          ? nextSection
+          : content,
+      ),
+    };
+
+    replaceSectionInStack(nextParent);
+  };
+
+  const flushPendingLines = (): WikiCodeParseResult | null => {
+    const currentSection = sectionStack.at(-1);
+
+    if (!currentSection || pendingLines.every((line) => !line.trim())) {
+      pendingLines = [];
+      return null;
+    }
+
+    const parsedBlocks = parseCodeBlocks(pendingLines);
+
+    if (!parsedBlocks.ok) {
+      return createParseError(parsedBlocks.message);
+    }
+
+    replaceSectionInStack(appendBlocksToSection(currentSection, parsedBlocks.blocks));
+    pendingLines = [];
+    return null;
+  };
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    const headingDepth = getHeadingDepth(trimmedLine);
+
+    if (headingDepth) {
+      const flushResult = flushPendingLines();
+
+      if (flushResult) {
+        return flushResult;
+      }
+
+      if (headingDepth > WIKI_SECTION_MAX_DEPTH) {
+        return createParseError(
+          `Code mode supports headings up to depth ${WIKI_SECTION_MAX_DEPTH}.`,
+        );
+      }
+
+      if (headingDepth > sectionStack.length + 1) {
+        return createParseError(
+          "Heading depth cannot skip levels. Add the missing parent section first.",
+        );
+      }
+
+      const title = getHeadingTitle(trimmedLine);
+
+      if (!title) {
+        return createParseError("Section headings must include a title.");
+      }
+
+      sectionStack = sectionStack.slice(0, headingDepth - 1);
+      const parent = sectionStack.at(-1);
+      const nextSection: WikiSection = {
+        type: "section",
+        sectionIdentifier: createIdentifier("section"),
+        title,
+        displayOrder: getNextDisplayOrder(parent ? parent.contents : rootSections),
+        depth: headingDepth,
+        contents: [],
+        children: [],
+      };
+
+      if (parent) {
+        const nextParent = {
+          ...parent,
+          children: [...parent.children, nextSection],
+          contents: [...parent.contents, nextSection],
+        };
+
+        replaceSectionInStack(nextParent);
+      } else {
+        rootSections.push(nextSection);
+      }
+
+      sectionStack = [...sectionStack, nextSection];
+      continue;
+    }
+
+    if (!sectionStack.length && trimmedLine) {
+      return createParseError(
+        "Add a top-level heading like = Overview = before writing section content.",
+      );
+    }
+
+    if (sectionStack.length) {
+      pendingLines.push(line);
+    }
+  }
+
+  const flushResult = flushPendingLines();
+
+  if (flushResult) {
+    return flushResult;
+  }
+
+  return {
+    ok: true,
+    sections: normalizeWikiSectionsForEditing(rootSections),
+  };
+};
+
 const getNextDisplayOrder = (contents: WikiSectionContent[]): number =>
-  contents.reduce((max, content) => Math.max(max, content.displayOrder), 0) + 10;
+  contents.reduce((max, content) => Math.max(max, content.displayOrder), 0) +
+  DISPLAY_ORDER_STEP;
 
 const createIdentifier = (prefix: string): string =>
   `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -4,8 +4,10 @@ import { useId, useState } from "react";
 import { type WikiDetail } from "@kpool/wiki";
 
 import {
+  type WikiEditorMode,
   type WikiPreviewMode,
   WikiBasicPanel,
+  WikiCodeEditor,
   WikiEditSidebar,
   WikiHeroBasicFlipCard,
   WikiHeroPanel,
@@ -26,9 +28,13 @@ type WikiEditPageProps = {
 function WikiEditContent({ data }: { data: WikiDetail }) {
   const flipCardId = useId();
   const [isBasicFlipped, setIsBasicFlipped] = useState(false);
+  const [editorMode, setEditorMode] = useState<WikiEditorMode>("gui");
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [previewMode, setPreviewMode] = useState<WikiPreviewMode>("light");
   const {
+    canPersist,
+    code,
+    codeParseError,
     draft,
     editingId,
     saveState,
@@ -36,6 +42,7 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
     requestPublication,
     saveDraft,
     setEditingId,
+    updateCode,
     updateBasic,
     updateHeroImage,
     updateSettings,
@@ -139,41 +146,53 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
             </div>
           </section>
 
-          <section className="space-y-5">
-            {draft.sections.map((section) => (
-              <WikiSectionEditor
-                editingId={editingId}
-                key={section.sectionIdentifier}
-                onAddBlock={addBlock}
-                onAddSection={addSection}
-                onCancel={closeEditor}
-                onDeleteContent={deleteContent}
-                onEdit={setEditingId}
-                onSaveBlock={(blockIdentifier, changes) => {
-                  updateBlock(blockIdentifier, changes);
-                  closeEditor();
-                }}
-                onSaveSection={(sectionIdentifier, changes) => {
-                  updateSection(sectionIdentifier, changes);
-                  closeEditor();
-                }}
-                section={section}
-              />
-            ))}
-            <button
-              className="w-full rounded-[1.5rem] border border-dashed border-stroke-subtle p-5 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
-              onClick={() => addSection()}
-              style={cardSurfaceStyle}
-              type="button"
-            >
-              + Section
-            </button>
-          </section>
+          {editorMode === "gui" ? (
+            <section className="space-y-5">
+              {draft.sections.map((section) => (
+                <WikiSectionEditor
+                  editingId={editingId}
+                  key={section.sectionIdentifier}
+                  onAddBlock={addBlock}
+                  onAddSection={addSection}
+                  onCancel={closeEditor}
+                  onDeleteContent={deleteContent}
+                  onEdit={setEditingId}
+                  onSaveBlock={(blockIdentifier, changes) => {
+                    updateBlock(blockIdentifier, changes);
+                    closeEditor();
+                  }}
+                  onSaveSection={(sectionIdentifier, changes) => {
+                    updateSection(sectionIdentifier, changes);
+                    closeEditor();
+                  }}
+                  section={section}
+                />
+              ))}
+              <button
+                className="w-full rounded-[1.5rem] border border-dashed border-stroke-subtle p-5 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
+                onClick={() => addSection()}
+                style={cardSurfaceStyle}
+                type="button"
+              >
+                + Section
+              </button>
+            </section>
+          ) : (
+            <WikiCodeEditor
+              code={code}
+              errorMessage={codeParseError}
+              onChange={updateCode}
+              onClear={clearChanges}
+            />
+          )}
         </div>
 
         <WikiEditSidebar
+          canPersist={canPersist}
+          editorMode={editorMode}
           isBusy={isBusy}
           isOpen={isSidebarOpen}
+          onEditorModeChange={setEditorMode}
           onClear={clearChanges}
           onPreviewModeChange={setPreviewMode}
           onSave={saveDraft}

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -37,6 +37,8 @@ describe("WikiEditPage", () => {
     expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Submit wiki for review" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Clear wiki changes" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "gui" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "code" })).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByLabelText("Slug")).toHaveValue("aurora-echo");
     expect(screen.getByRole("group", { name: "Preview mode" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Default" })).toBeInTheDocument();
@@ -134,6 +136,59 @@ describe("WikiEditPage", () => {
 
     expect(screen.getByLabelText("Quote")).toBeInTheDocument();
     expect(confirmSpy).toHaveBeenCalledWith("Discard unsaved wiki changes?");
+
+    confirmSpy.mockRestore();
+  });
+
+  it("switches to code mode and reflects valid edits back into gui mode", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+    fireEvent.change(screen.getByLabelText("Wiki code"), {
+      target: {
+        value: [
+          "= Overview =",
+          "",
+          "Updated overview from code mode.",
+          "",
+          "== Style Guide ==",
+          "",
+          "A new nested section.",
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "gui" }));
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Style Guide")).toBeInTheDocument();
+    expect(screen.getByText("Updated overview from code mode.")).toBeInTheDocument();
+  });
+
+  it("shows a parse error for invalid code and clears back to the last loaded draft", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+    fireEvent.change(screen.getByLabelText("Wiki code"), {
+      target: {
+        value: ["= Overview =", "", "[[image|id:cover]"].join("\n"),
+      },
+    });
+
+    expect(screen.getByTestId("wiki-code-error")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear invalid code" }));
+
+    expect(confirmSpy).toHaveBeenCalledWith("Discard unsaved wiki changes?");
+    expect(screen.queryByTestId("wiki-code-error")).not.toBeInTheDocument();
+    expect((screen.getByLabelText("Wiki code") as HTMLTextAreaElement).value).toContain(
+      "= Overview =",
+    );
 
     confirmSpy.mockRestore();
   });

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -5,6 +5,8 @@ import {
   addWikiSection,
   deleteWikiContent,
   normalizeWikiSectionsForEditing,
+  parseWikiSectionsFromCode,
+  serializeWikiSectionsToCode,
   toWikiEditPayload,
   updateWikiBlock,
   updateWikiSection,
@@ -55,12 +57,17 @@ const createInitialDraft = (wiki: WikiDetail): WikiDetail => ({
   sections: normalizeWikiSectionsForEditing(wiki.sections),
 });
 
+const getCodeFromSections = (sections: WikiDetail["sections"]): string =>
+  serializeWikiSectionsToCode(sections);
+
 export const useWikiEditDraft = (
   wiki: WikiDetail,
   options?: WikiEditDraftOptions,
 ) => {
   const initialDraft = useMemo(() => createInitialDraft(wiki), [wiki]);
   const [draft, setDraft] = useState<WikiDetail>(initialDraft);
+  const [code, setCode] = useState(() => getCodeFromSections(initialDraft.sections));
+  const [codeParseError, setCodeParseError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<WikiContentEditorId | "basic" | "hero" | null>(
     null,
   );
@@ -72,10 +79,12 @@ export const useWikiEditDraft = (
   const saveAdapter = options?.saveAdapter ?? optimisticActionAdapter;
   const submitAdapter = options?.submitAdapter ?? optimisticActionAdapter;
 
-  const commitDraft = (nextDraft: WikiDetail) => {
+  const commitDraft = (nextDraft: WikiDetail, nextCode = getCodeFromSections(nextDraft.sections)) => {
     const payload = toWikiEditPayload(nextDraft);
 
     setDraft(nextDraft);
+    setCode(nextCode);
+    setCodeParseError(null);
     setSaveState({
       status: "dirty",
       message: "Unsaved changes",
@@ -105,6 +114,8 @@ export const useWikiEditDraft = (
 
   const clearDraft = () => {
     setDraft(initialDraft);
+    setCode(getCodeFromSections(initialDraft.sections));
+    setCodeParseError(null);
     setEditingId(null);
     setSaveState({
       status: "saved",
@@ -134,6 +145,9 @@ export const useWikiEditDraft = (
   };
 
   return {
+    canPersist: !codeParseError,
+    code,
+    codeParseError,
     draft,
     editingId,
     saveState,
@@ -141,6 +155,28 @@ export const useWikiEditDraft = (
     requestPublication,
     saveDraft,
     setEditingId,
+    updateCode: (nextCode: string) => {
+      setCode(nextCode);
+      const parsed = parseWikiSectionsFromCode(nextCode);
+
+      if (!parsed.ok) {
+        setCodeParseError(parsed.message);
+        setSaveState({
+          status: "dirty",
+          message: "Unsaved changes",
+          payload: toWikiEditPayload(draft),
+        });
+        return;
+      }
+
+      commitDraft(
+        {
+          ...draft,
+          sections: parsed.sections,
+        },
+        nextCode,
+      );
+    },
     updateBasic: (basic: WikiDetail["basic"]) =>
       commitDraft({
         ...draft,

--- a/src/components/Wiki/WikiCodeEditor/index.tsx
+++ b/src/components/Wiki/WikiCodeEditor/index.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { cardSurfaceMutedStyle, cardSurfaceStyle } from "../styles";
+
+type WikiCodeEditorProps = {
+  code: string;
+  errorMessage: string | null;
+  onChange: (value: string) => void;
+  onClear: () => void;
+};
+
+export function WikiCodeEditor({
+  code,
+  errorMessage,
+  onChange,
+  onClear,
+}: WikiCodeEditorProps) {
+  return (
+    <section
+      className="rounded-[1.75rem] border border-stroke-subtle p-5 shadow-soft"
+      data-testid="wiki-code-editor"
+      style={cardSurfaceStyle}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 className="text-2xl font-semibold tracking-[-0.03em] text-text-strong">
+            Code mode
+          </h2>
+          <p className="max-w-3xl text-sm text-text-muted">
+            Edit the whole section tree with headings like
+            {" "}
+            <code>= Overview =</code>
+            {" "}
+            and
+            {" "}
+            <code>== Style ==</code>
+            .
+          </p>
+        </div>
+        {errorMessage ? (
+          <button
+            className="rounded-full border border-status-danger/30 px-4 py-2 text-sm font-semibold text-status-danger transition hover:bg-status-danger/10"
+            onClick={onClear}
+            type="button"
+          >
+            Clear invalid code
+          </button>
+        ) : null}
+      </div>
+
+      {errorMessage ? (
+        <div
+          className="mt-4 rounded-2xl border border-status-danger/30 px-4 py-3 text-sm text-status-danger"
+          data-testid="wiki-code-error"
+          role="alert"
+          style={cardSurfaceMutedStyle}
+        >
+          {errorMessage}
+        </div>
+      ) : (
+        <div
+          className="mt-4 rounded-2xl border border-stroke-subtle px-4 py-3 text-sm text-text-muted"
+          style={cardSurfaceMutedStyle}
+        >
+          Supported blocks: plain text, quotes with <code>&gt;</code>, lists, tables,
+          and structured macros for image, gallery, embed, and profiles.
+        </div>
+      )}
+
+      <label className="mt-4 grid gap-2 text-sm font-semibold text-text-strong">
+        Wiki code
+        <textarea
+          aria-label="Wiki code"
+          className="min-h-[56rem] w-full rounded-[1.5rem] border border-stroke-subtle bg-surface-base px-4 py-4 font-mono text-sm leading-7 outline-none"
+          data-testid="wiki-code-textarea"
+          onChange={(event) => onChange(event.currentTarget.value)}
+          spellCheck={false}
+          value={code}
+        />
+      </label>
+    </section>
+  );
+}

--- a/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.stories.tsx
+++ b/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.stories.tsx
@@ -8,8 +8,11 @@ const meta = {
   title: "Wiki/WikiEditSidebar",
   component: WikiEditSidebar,
   args: {
+    canPersist: true,
+    editorMode: "gui",
     isBusy: false,
     isOpen: true,
+    onEditorModeChange: noop,
     onClear: noop,
     onPreviewModeChange: noop,
     onSave: noop,
@@ -34,6 +37,7 @@ export const Default: Story = {
   args: {},
   render: (args) => {
     function StoryComponent() {
+      const [editorMode, setEditorMode] = useState(args.editorMode);
       const [isOpen, setIsOpen] = useState(args.isOpen);
       const [previewMode, setPreviewMode] = useState(args.previewMode);
       const [slug, setSlug] = useState(args.slug);
@@ -42,8 +46,11 @@ export const Default: Story = {
       return (
         <div className="min-h-screen bg-background">
           <WikiEditSidebar
+            canPersist={args.canPersist}
+            editorMode={editorMode}
             isBusy={args.isBusy}
             isOpen={isOpen}
+            onEditorModeChange={setEditorMode}
             onClear={() => {
               setSlug(wikiStoryDetail.slug);
               setThemeColor(wikiStoryDetail.themeColor);

--- a/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.test.tsx
+++ b/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.test.tsx
@@ -7,6 +7,7 @@ import { WikiEditSidebar } from "./index";
 
 describe("WikiEditSidebar", () => {
   it("fires sidebar actions and setting updates", () => {
+    const onEditorModeChange = vi.fn();
     const onClear = vi.fn();
     const onPreviewModeChange = vi.fn();
     const onSave = vi.fn();
@@ -16,8 +17,11 @@ describe("WikiEditSidebar", () => {
 
     render(
       <WikiEditSidebar
+        canPersist
+        editorMode="gui"
         isBusy={false}
         isOpen
+        onEditorModeChange={onEditorModeChange}
         onClear={onClear}
         onPreviewModeChange={onPreviewModeChange}
         onSave={onSave}
@@ -33,6 +37,7 @@ describe("WikiEditSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
     fireEvent.click(screen.getByRole("button", { name: "Submit wiki for review" }));
     fireEvent.click(screen.getByRole("button", { name: "Clear wiki changes" }));
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
     fireEvent.click(screen.getByRole("button", { name: "Dark" }));
     fireEvent.click(screen.getByRole("button", { name: "Collapse editor sidebar" }));
     fireEvent.change(screen.getByLabelText("Slug"), {
@@ -42,6 +47,7 @@ describe("WikiEditSidebar", () => {
     expect(onSave).toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalled();
     expect(onClear).toHaveBeenCalled();
+    expect(onEditorModeChange).toHaveBeenCalledWith("code");
     expect(onPreviewModeChange).toHaveBeenCalledWith("dark");
     expect(onToggle).toHaveBeenCalled();
     expect(onUpdateSettings).toHaveBeenCalledWith({ slug: "new-slug" });

--- a/src/components/Wiki/WikiEditSidebar/index.tsx
+++ b/src/components/Wiki/WikiEditSidebar/index.tsx
@@ -2,7 +2,7 @@
 
 import { type WikiDetail } from "@kpool/wiki";
 
-import { type WikiPreviewMode, themeColorOptions } from "../editing";
+import { type WikiEditorMode, type WikiPreviewMode, themeColorOptions } from "../editing";
 import { ChevronLeftIcon } from "../icons";
 import { cardSurfaceMutedStyle, cardSurfaceStyle } from "../styles";
 
@@ -49,8 +49,11 @@ function WikiSubmitButton({
 }
 
 type WikiEditSidebarProps = {
+  canPersist: boolean;
+  editorMode: WikiEditorMode;
   isBusy: boolean;
   isOpen: boolean;
+  onEditorModeChange: (mode: WikiEditorMode) => void;
   onClear: () => void;
   onPreviewModeChange: (mode: WikiPreviewMode) => void;
   onSave: () => void;
@@ -63,8 +66,11 @@ type WikiEditSidebarProps = {
 };
 
 export function WikiEditSidebar({
+  canPersist,
+  editorMode,
   isBusy,
   isOpen,
+  onEditorModeChange,
   onClear,
   onPreviewModeChange,
   onSave,
@@ -76,6 +82,7 @@ export function WikiEditSidebar({
   themeColor,
 }: WikiEditSidebarProps) {
   const customColorValue = themeColor ?? themeColorOptions[2];
+  const isActionDisabled = isBusy || !canPersist;
 
   return (
     <aside
@@ -100,8 +107,8 @@ export function WikiEditSidebar({
       <div className="relative h-full overflow-y-auto border border-r-0 border-stroke-subtle p-4 shadow-soft" style={cardSurfaceStyle}>
         <div className={isOpen ? "block" : "pointer-events-none invisible"}>
           <div className="grid gap-2">
-            <WikiSaveButton disabled={isBusy} onSave={onSave} />
-            <WikiSubmitButton disabled={isBusy} onSubmit={onSubmit} />
+            <WikiSaveButton disabled={isActionDisabled} onSave={onSave} />
+            <WikiSubmitButton disabled={isActionDisabled} onSubmit={onSubmit} />
             <button
               aria-label="Clear wiki changes"
               className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-muted"
@@ -114,6 +121,23 @@ export function WikiEditSidebar({
           </div>
 
           <div className="mt-5 grid gap-4 border-t border-stroke-subtle pt-5" style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}>
+            <fieldset className="grid gap-2">
+              <legend className="text-sm font-semibold text-text-strong">Editor mode</legend>
+              <div className="grid grid-cols-2 gap-2 rounded-full border border-stroke-subtle bg-surface-base p-1">
+                {(["gui", "code"] as const).map((mode) => (
+                  <button
+                    aria-pressed={editorMode === mode}
+                    className="rounded-full px-3 py-2 text-sm font-semibold uppercase tracking-[0.12em] text-text-muted transition aria-pressed:bg-surface-raised aria-pressed:text-text-strong aria-pressed:shadow-soft"
+                    key={mode}
+                    onClick={() => onEditorModeChange(mode)}
+                    type="button"
+                  >
+                    {mode}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
             <fieldset className="grid gap-2">
               <legend className="text-sm font-semibold text-text-strong">Preview mode</legend>
               <div className="grid grid-cols-2 gap-2 rounded-full border border-stroke-subtle bg-surface-base p-1">

--- a/src/components/Wiki/editing.ts
+++ b/src/components/Wiki/editing.ts
@@ -1,6 +1,7 @@
 import { type WikiBlockType } from "@kpool/wiki";
 
 export type WikiPreviewMode = "light" | "dark";
+export type WikiEditorMode = "gui" | "code";
 
 export const blockTypes: WikiBlockType[] = [
   "text",

--- a/src/components/Wiki/index.ts
+++ b/src/components/Wiki/index.ts
@@ -4,6 +4,7 @@ export { WikiBasicPanel } from "./WikiBasicPanel/index";
 export { WikiBlockDisplay } from "./WikiBlockDisplay/index";
 export { WikiBlockEditorItem } from "./WikiBlockEditorItem/index";
 export { WikiBlockForm } from "./WikiBlockForm/index";
+export { WikiCodeEditor } from "./WikiCodeEditor/index";
 export { WikiEditSidebar } from "./WikiEditSidebar/index";
 export { WikiHeroBasicFlipCard } from "./WikiHeroBasicFlipCard/index";
 export { WikiHeroPanel } from "./WikiHeroPanel/index";

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -83,6 +83,37 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(page.getByText("Saved")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(1);
   await expect(page.getByRole("button", { name: "Submit wiki for review" })).toHaveCount(1);
+
+  await page.getByRole("button", { name: "code" }).click();
+  await expect(page.getByTestId("wiki-code-editor")).toBeVisible();
+  await page.getByLabel("Wiki code").fill(
+    [
+      "= Overview =",
+      "",
+      "Updated overview from code mode.",
+      "",
+      "== Style Guide ==",
+      "",
+      "A new nested section.",
+      "",
+      "= Members =",
+      "",
+      "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
+    ].join("\n"),
+  );
+  await page.getByRole("button", { name: "gui" }).click();
+  await expect(page.getByText("Style Guide")).toBeVisible();
+  await expect(page.getByText("Updated overview from code mode.")).toBeVisible();
+
+  await page.getByRole("button", { name: "code" }).click();
+  await page.getByLabel("Wiki code").fill("= Overview =\n\n[[image|id:cover]");
+  await expect(page.getByTestId("wiki-code-error")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Save wiki changes" })).toBeDisabled();
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Clear wiki changes" }).click();
+  await expect(page.getByTestId("wiki-code-error")).toHaveCount(0);
+  await expect(page.getByLabel("Wiki code")).toHaveValue(/= Overview =/);
+  await page.getByRole("button", { name: "gui" }).click();
   await page.getByRole("button", { name: "Collapse editor sidebar" }).click();
 
   const overviewAddControls = page.getByTestId("wiki-edit-add-section-sec-overview");


### PR DESCRIPTION
## 📝 変更内容

Wiki 編集画面に `gui` / `code` の編集モード切り替えを追加しました。
コードモードではセクション構造を見出しベースのテキストとして編集でき、GUI 編集内容との相互変換に対応しています。
あわせて、コードのパース失敗時はエラーを表示し、保存・申請を無効化するようにしました。
ユニットテストと画面テスト、E2E テストも追加しています。

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

既存の Wiki 編集 UI だけでは、複数セクションや構造化ブロックをまとめて編集したいケースで操作量が多くなっていました。
見出しベースのコードモードを追加することで、GUI 操作に加えて一括編集しやすい入力経路を提供しつつ、既存データ構造との整合性も維持したかったためです。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Wiki 編集画面で `gui` / `code` を切り替えられること
- code モードで見出しベースの編集結果が gui モードへ反映されること
- 不正な構文入力時にエラーが表示され、保存・申請が無効化されること
- `Clear wiki changes` で直前の有効な状態へ戻せること

## 🔍 レビューのポイント

- `packages/wiki/src/wikiEditModel.ts` のコード表現と既存 Wiki 構造の相互変換仕様
- コードモードで不正入力した際の保存抑止と復旧導線
- GUI モードと code モードの切り替え時に draft 状態が崩れないこと

## 📖 関連情報

### 関連Issue・タスク

Closes #37

## ⚠️ 注意事項

- 破壊的変更や追加の環境変数はありません
- コードモードで対応している構造は plain text / quote / list / table / image / gallery / embed / profiles です

## 📸 スクリーンショット・デモ

- スクリーンショット未添付。動作確認内容を記載

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [ ] 破壊的変更がある場合は適切に文書化した
