### PR TITLE
feat: コードモードのナムウィキ互換性を拡張

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,14 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   transpilePackages: ["@kpool/types", "@kpool/wiki"],
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "upload.wikimedia.org",
+      },
+    ],
+  },
   turbopack: {
     root: rootDir,
   },

--- a/packages/wiki/src/getWikiDetailState.test.ts
+++ b/packages/wiki/src/getWikiDetailState.test.ts
@@ -22,4 +22,50 @@ describe("getWikiDetailState", () => {
       },
     });
   });
+
+  it("returns a dedicated TWICE namuwiki compatibility demo mock", () => {
+    const state = getWikiDetailState("twice");
+
+    expect(state).toMatchObject({
+      status: "success",
+      data: {
+        slug: "twice",
+        basic: {
+          name: "TWICE",
+        },
+      },
+    });
+
+    if (state.status !== "success") {
+      return;
+    }
+
+    expect(state.data.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Overview",
+        }),
+        expect.objectContaining({
+          title: "Members",
+        }),
+        expect.objectContaining({
+          title: "History",
+        }),
+      ]),
+    );
+  });
+
+  it("returns dedicated TWICE member mocks for related profile cards", () => {
+    const state = getWikiDetailState("nayeon-twice");
+
+    expect(state).toMatchObject({
+      status: "success",
+      data: {
+        slug: "nayeon-twice",
+        basic: {
+          name: "나연",
+        },
+      },
+    });
+  });
 });

--- a/packages/wiki/src/mockWikiDetail.ts
+++ b/packages/wiki/src/mockWikiDetail.ts
@@ -22,11 +22,426 @@ type CreateMockWikiDetailOptions = {
   themeColor?: string;
 };
 
+const createNamuCompatibilitySections = (): WikiDetail["sections"] => [
+  {
+    type: "section",
+    sectionIdentifier: "sec-namu-overview",
+    title: "Overview",
+    displayOrder: 10,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-namu-overview-text",
+        blockType: "text",
+        displayOrder: 10,
+        content: [
+          "Aurora Echo keeps a fast release cycle.",
+          "",
+          "[[문서|대표 문서]]",
+          "",
+          "[[분류:테스트]]",
+          "",
+          "[* 주석 예시]",
+          "",
+          "[include(틀:Discography)]",
+          "",
+          "[br]",
+        ].join("\n"),
+      },
+      {
+        blockIdentifier: "block-namu-overview-list",
+        blockType: "list",
+        displayOrder: 20,
+        listType: "bullet",
+        items: ["Debut single", "Follow-up single"],
+      },
+      {
+        blockIdentifier: "block-namu-overview-embed",
+        blockType: "embed",
+        displayOrder: 30,
+        provider: "youtube",
+        embedId: "a0bc6Ownyt0",
+        caption: "Supported media include demo",
+      },
+    ],
+    children: [
+      {
+        type: "section",
+        sectionIdentifier: "sec-namu-overview-highlights",
+        title: "Highlights",
+        displayOrder: 10,
+        depth: 2,
+        contents: [
+          {
+            blockIdentifier: "block-namu-overview-highlights-table",
+            blockType: "table",
+            displayOrder: 10,
+            headers: ["Release", "Year"],
+            headerCells: [{ content: "Release" }, { content: "Year" }],
+            rowCells: [[{ content: "Aurora Echo", colspan: 2 }]],
+            rows: [["Aurora Echo"]],
+            tableWidth: 320,
+          },
+        ],
+        children: [],
+      },
+    ],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-namu-members",
+    title: "Members",
+    displayOrder: 20,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-namu-members-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
+      },
+    ],
+    children: [],
+  },
+];
+
+const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-overview",
+    title: "Overview",
+    displayOrder: 10,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-overview-text",
+        blockType: "text",
+        displayOrder: 10,
+        content: [
+          "TWICE는 SIXTEEN을 통해 결성된 9인조 다국적 걸그룹이다.",
+          "",
+          "팀명은 귀로 한 번, 눈으로 한 번 감동을 준다는 의미를 담고 있다.",
+          "",
+          "[[나연(TWICE)|나연]] · [[정연(TWICE)|정연]] · [[모모(TWICE)|모모]] · [[사나(TWICE)|사나]] · [[지효|지효]] · [[미나(TWICE)|미나]] · [[다현|다현]] · [[채영|채영]] · [[쯔위|쯔위]]",
+          "",
+          "[* 오디션 프로그램 SIXTEEN을 통해 결성되었다.]",
+          "",
+          "[[분류:TWICE]]",
+          "",
+          "[br]",
+        ].join("\n"),
+      },
+      {
+        blockIdentifier: "block-twice-overview-embed",
+        blockType: "embed",
+        displayOrder: 20,
+        provider: "youtube",
+        embedId: "c7rCyll5AeY",
+        caption: "TWICE \"CHEER UP\" M/V",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-members",
+    title: "Members",
+    displayOrder: 20,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-members-profiles",
+        blockType: "profile_card_list",
+        displayOrder: 10,
+        wikiIdentifiers: [
+          "nayeon-twice",
+          "jeongyeon-twice",
+          "momo-twice",
+          "sana-twice",
+          "jihyo",
+          "mina-twice",
+          "dahyun",
+          "chaeyoung",
+          "tzuyu",
+        ],
+        title: "TWICE Members",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-history",
+    title: "History",
+    displayOrder: 30,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-history-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "2015년 데뷔 이후 한국과 일본을 중심으로 활동을 이어 왔으며, 대표곡으로는 \"CHEER UP\", \"TT\", \"FANCY\" 등이 있다.",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-discography",
+    title: "Discography",
+    displayOrder: 40,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-discography-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "한국 및 일본 음반 전개가 모두 큰 비중을 차지하며, 정규/미니/싱글/베스트 앨범 축이 나뉘어 전개된다.",
+      },
+      {
+        blockIdentifier: "block-twice-discography-include",
+        blockType: "text",
+        displayOrder: 20,
+        content: "[include(틀:TWICE/음반)]",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-activities",
+    title: "Activities",
+    displayOrder: 50,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-activities-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "한국 활동, 일본 활동, 월드투어, 유닛 및 솔로 활동이 병렬적으로 정리되는 편이며 시기별 정리와 하위 문서 분리가 잦다.",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-records",
+    title: "Records",
+    displayOrder: 60,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-records-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "음원과 음반 양쪽에서 강한 성과를 남긴 팀으로 평가되며, 나무위키에서는 관련 기록 틀을 별도로 끼워 넣는 구조가 자주 보인다.",
+      },
+      {
+        blockIdentifier: "block-twice-records-include",
+        blockType: "text",
+        displayOrder: 20,
+        content: "[include(틀:TWICE의 기록)]",
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: "sec-twice-media",
+    title: "Media",
+    displayOrder: 70,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: "block-twice-media-text",
+        blockType: "text",
+        displayOrder: 10,
+        content:
+          "뮤직비디오, 리얼리티, 광고, 화보, SNS 활동 등이 방대한 편이라 관련 하위 문서나 목록성 서술로 분리되는 경우가 많다.",
+      },
+    ],
+    children: [],
+  },
+];
+
+const twiceMemberProfiles = [
+  {
+    slug: "nayeon-twice",
+    name: "나연",
+    normalizedName: "nayeon-twice",
+    emoji: "🐰",
+    symbol: "Pastel microphone",
+    colors: ["Sky Blue", "Ivory"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/4/45/251120_NAYEON.png",
+    heroImageAlt: "나연 promotional image",
+    overview:
+      "TWICE의 맏언니이자 리드보컬 포지션으로 널리 알려져 있으며, 솔로 활동도 전개하고 있다.",
+  },
+  {
+    slug: "jeongyeon-twice",
+    name: "정연",
+    normalizedName: "jeongyeon-twice",
+    emoji: "🐶",
+    symbol: "Mint spotlight",
+    colors: ["Mint", "White"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/260306_Twice_Hamilton_Jeongyeon_%ED%8A%B8%EC%99%80%EC%9D%B4%EC%8A%A4_%EC%A0%95%EC%97%B0_%287%29_%28cropped%29.jpg/250px-260306_Twice_Hamilton_Jeongyeon_%ED%8A%B8%EC%99%80%EC%9D%B4%EC%8A%A4_%EC%A0%95%EC%97%B0_%287%29_%28cropped%29.jpg",
+    heroImageAlt: "ジョンヨン portrait image",
+    overview:
+      "TWICE의 보컬 라인을 담당하는 멤버로, 안정적인 무대 소화력과 중저음 톤으로 평가된다.",
+  },
+  {
+    slug: "momo-twice",
+    name: "모모",
+    normalizedName: "momo-twice",
+    emoji: "🍑",
+    symbol: "Dance line marker",
+    colors: ["Peach", "Black"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/TWICE_MOMO_April_2024.jpg/960px-TWICE_MOMO_April_2024.jpg",
+    heroImageAlt: "모모 portrait image",
+    overview:
+      "TWICE의 메인댄서로 널리 인식되며, 퍼포먼스 중심 서술에서 비중이 크다.",
+  },
+  {
+    slug: "sana-twice",
+    name: "사나",
+    normalizedName: "sana-twice",
+    emoji: "🫧",
+    symbol: "Soft pink ribbon",
+    colors: ["Soft Pink", "Cream"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/62/Sana_Minatozaki_%E6%B9%8A%EF%A8%91_%E7%B4%97%E5%A4%8F_20250118_07.jpg/250px-Sana_Minatozaki_%E6%B9%8A%EF%A8%91_%E7%B4%97%E5%A4%8F_20250118_07.jpg",
+    heroImageAlt: "サナ portrait image",
+    overview:
+      "표정 연기와 예능감, 무대 장악력으로 자주 언급되는 TWICE의 일본인 멤버다.",
+  },
+  {
+    slug: "jihyo",
+    name: "지효",
+    normalizedName: "jihyo",
+    emoji: "🌟",
+    symbol: "Leader badge",
+    colors: ["Goldenrod", "Black"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/ja/thumb/4/4c/251127_Park_Jihyo.PNG/250px-251127_Park_Jihyo.PNG",
+    heroImageAlt: "ジヒョ portrait image",
+    overview:
+      "TWICE의 리더이자 메인보컬로, 그룹 활동과 별개로 솔로 커리어도 갖고 있다.",
+  },
+  {
+    slug: "mina-twice",
+    name: "미나",
+    normalizedName: "mina-twice",
+    emoji: "🦢",
+    symbol: "Ballet line",
+    colors: ["Teal", "White"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Mina_H%26M_Rokh_2.jpg/250px-Mina_H%26M_Rokh_2.jpg",
+    heroImageAlt: "ミナ portrait image",
+    overview:
+      "우아한 퍼포먼스와 차분한 이미지로 알려진 일본인 멤버이며 미성 보컬로도 자주 언급된다.",
+  },
+  {
+    slug: "dahyun",
+    name: "다현",
+    normalizedName: "dahyun",
+    emoji: "🤍",
+    symbol: "White piano key",
+    colors: ["White", "Piano Black"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Dahyun_at_press_conference_for_You_Are_the_Apple_of_My_Eye_02_%28cropped%29.png/250px-Dahyun_at_press_conference_for_You_Are_the_Apple_of_My_Eye_02_%28cropped%29.png",
+    heroImageAlt: "ダヒョン portrait image",
+    overview:
+      "랩과 예능, 무대 리액션에서 존재감이 큰 멤버로, 최근에는 연기 활동도 병행한다.",
+  },
+  {
+    slug: "chaeyoung",
+    name: "채영",
+    normalizedName: "chaeyoung",
+    emoji: "🍓",
+    symbol: "Sketch marker",
+    colors: ["Strawberry Red", "Charcoal"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/241204_Chaeyoung_at_Rokh_H%26M_%281%29.png/250px-241204_Chaeyoung_at_Rokh_H%26M_%281%29.png",
+    heroImageAlt: "チェヨン portrait image",
+    overview:
+      "랩과 작사 참여, 개성적인 비주얼로 자주 언급되는 TWICE의 멤버다.",
+  },
+  {
+    slug: "tzuyu",
+    name: "쯔위",
+    normalizedName: "tzuyu",
+    emoji: "🧊",
+    symbol: "Blue prism",
+    colors: ["Blue", "Silver"],
+    debutDate: "2015-10-20",
+    heroImageSrc:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/0/09/Tzuyu_at_Gucci_Ancora_on_05032024_%283%29.png/506px-Tzuyu_at_Gucci_Ancora_on_05032024_%283%29.png",
+    heroImageAlt: "ツウィ portrait image",
+    overview:
+      "비주얼과 피지컬 비중이 큰 서술과 함께, 솔로 및 개별 활동도 병행하는 TWICE의 막내다.",
+  },
+] as const;
+
+const createTwiceMemberSections = (name: string, overview: string): WikiDetail["sections"] => [
+  {
+    type: "section",
+    sectionIdentifier: `sec-${name}-overview`,
+    title: "Overview",
+    displayOrder: 10,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: `block-${name}-overview-text`,
+        blockType: "text",
+        displayOrder: 10,
+        content: overview,
+      },
+    ],
+    children: [],
+  },
+  {
+    type: "section",
+    sectionIdentifier: `sec-${name}-related`,
+    title: "Related",
+    displayOrder: 20,
+    depth: 1,
+    contents: [
+      {
+        blockIdentifier: `block-${name}-related-profiles`,
+        blockType: "profile_card_list",
+        displayOrder: 10,
+        wikiIdentifiers: ["twice"],
+        title: "Group",
+      },
+    ],
+    children: [],
+  },
+];
+
 export const createMockWikiDetail = (
   slug: string,
   options?: CreateMockWikiDetailOptions,
-): WikiDetail =>
-  wikiDetailSchema.parse({
+): WikiDetail => {
+  const isTwiceGroupSlug = slug === "namu-compat-demo" || slug === "twice";
+  const twiceMember = twiceMemberProfiles.find((member) => member.slug === slug);
+
+  return wikiDetailSchema.parse({
     wikiIdentifier: slug,
     slug,
     language: "ja",
@@ -34,24 +449,64 @@ export const createMockWikiDetail = (
     version: 3,
     themeColor: options?.themeColor ?? null,
     heroImage: {
-      src: heroImageDataUri,
-      alt: "Stage lights washing over a concert crowd in blue and gold",
+      src: twiceMember?.heroImageSrc ?? heroImageDataUri,
+      alt:
+        twiceMember?.heroImageAlt ??
+        (isTwiceGroupSlug
+          ? "Pink and apricot concert lights inspired by a TWICE stage"
+          : "Stage lights washing over a concert crowd in blue and gold"
+        ),
     },
-    basic: {
-      name: "Aurora Echo",
-      normalizedName: "aurora-echo",
-      resourceType: "group",
-      groupType: "Girl Group",
-      status: "Active",
-      generation: "5th",
-      debutDate: "2022-03-14",
-      fandomName: "Daybreak",
-      emoji: "🌅",
-      representativeSymbol: "Solar wave",
-      officialColors: ["Solar Gold", "Midnight Blue", "Pearl Mist"],
-      agencyName: "North Harbor Entertainment",
-    },
-    sections: [
+    basic:
+      isTwiceGroupSlug
+        ? {
+            name: "TWICE",
+            normalizedName: "twice",
+            resourceType: "group",
+            groupType: "Girl Group",
+            status: "Active",
+            generation: "3rd",
+            debutDate: "2015-10-20",
+            fandomName: "ONCE",
+            emoji: "🍭",
+            representativeSymbol: "Candy bong",
+            officialColors: ["Apricot", "Neon Magenta"],
+            agencyName: "JYP Entertainment",
+          }
+        : twiceMember
+          ? {
+              name: twiceMember.name,
+              normalizedName: twiceMember.normalizedName,
+              resourceType: "group",
+              groupType: "Girl Group Member",
+              status: "Active",
+              generation: "3rd",
+              debutDate: twiceMember.debutDate,
+              fandomName: "ONCE",
+              emoji: twiceMember.emoji,
+              representativeSymbol: twiceMember.symbol,
+              officialColors: [...twiceMember.colors],
+              agencyName: "JYP Entertainment",
+            }
+        : {
+            name: "Aurora Echo",
+            normalizedName: "aurora-echo",
+            resourceType: "group",
+            groupType: "Girl Group",
+            status: "Active",
+            generation: "5th",
+            debutDate: "2022-03-14",
+            fandomName: "Daybreak",
+            emoji: "🌅",
+            representativeSymbol: "Solar wave",
+            officialColors: ["Solar Gold", "Midnight Blue", "Pearl Mist"],
+            agencyName: "North Harbor Entertainment",
+          },
+    sections: isTwiceGroupSlug
+      ? createTwiceCompatibilitySections()
+      : twiceMember
+        ? createTwiceMemberSections(twiceMember.normalizedName, twiceMember.overview)
+      : [
       {
         type: "section",
         sectionIdentifier: "sec-discography",
@@ -238,3 +693,4 @@ export const createMockWikiDetail = (
       },
     ],
   });
+};

--- a/packages/wiki/src/types/wiki.ts
+++ b/packages/wiki/src/types/wiki.ts
@@ -24,6 +24,11 @@ export type WikiEmbedProvider = "youtube" | "spotify" | "x" | "tiktok";
 
 export type WikiListType = "bullet" | "numbered";
 
+export type WikiTableCell = {
+  content: string;
+  colspan?: number;
+};
+
 export type WikiTextBlock = {
   blockIdentifier: string;
   blockType: "text";
@@ -84,6 +89,9 @@ export type WikiTableBlock = {
   displayOrder: number;
   headers: string[] | null;
   rows: string[][];
+  headerCells?: WikiTableCell[] | null;
+  rowCells?: WikiTableCell[][];
+  tableWidth?: number | null;
 };
 
 export type WikiProfileCardListBlock = {
@@ -154,6 +162,26 @@ const wikiBlockSchema = z.discriminatedUnion("blockType", [
     blockType: z.literal("table"),
     headers: z.array(z.string()).nullable(),
     rows: z.array(z.array(z.string())),
+    headerCells: z
+      .array(
+        z.object({
+          content: z.string(),
+          colspan: z.number().int().positive().optional(),
+        }),
+      )
+      .nullable()
+      .optional(),
+    rowCells: z
+      .array(
+        z.array(
+          z.object({
+            content: z.string(),
+            colspan: z.number().int().positive().optional(),
+          }),
+        ),
+      )
+      .optional(),
+    tableWidth: z.number().int().positive().nullable().optional(),
   }),
   wikiBlockBaseSchema.extend({
     blockType: z.literal("profile_card_list"),

--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -146,24 +146,29 @@ describe("wikiEditModel", () => {
 
     expect(serializeWikiSectionsToCode(parsed.sections)).toBe(code);
     expect(code).toContain("[[image|id:img-discography-stage|src:");
-    expect(code).toContain("== Highlights ==");
+    expect(code).toContain("=== Highlights ===");
+    expect(parsed.warnings).toEqual([]);
   });
 
-  it("parses namu-like headings, lists, tables, and unknown macros as editable content", () => {
+  it("parses namuwiki-like headings, lists, tables, and fallback syntax as editable content", () => {
     const parsed = parseWikiSectionsFromCode([
-      "= Overview =",
+      "== Overview ==",
       "",
       "Aurora Echo keeps a fast release cycle.",
       "",
       "[[분류:테스트]]",
       "",
+      "[* 주석 예시]",
+      "",
       "* Debut single",
       "* Follow-up single",
       "",
-      "== Highlights ==",
+      "=== Highlights ===",
       "",
       "|| !Release || !Year ||",
       "|| Low Tide, High Lights || 2022 ||",
+      "",
+      "[include(틀:Discography)]",
     ].join("\n"));
 
     expect(parsed.ok).toBe(true);
@@ -189,32 +194,46 @@ describe("wikiEditModel", () => {
             content: "[[분류:테스트]]",
           },
           {
-            block_type: "list",
+            block_type: "text",
             display_order: 30,
+            content: "[* 주석 예시]",
+          },
+          {
+            block_type: "list",
+            display_order: 40,
             list_type: "bullet",
             items: ["Debut single", "Follow-up single"],
           },
           {
             type: "section",
             title: "Highlights",
-            display_order: 40,
+            display_order: 50,
             contents: [
               {
                 block_type: "table",
                 display_order: 10,
                 headers: ["Release", "Year"],
+                header_cells: [{ content: "Release" }, { content: "Year" }],
                 rows: [["Low Tide, High Lights", "2022"]],
+                row_cells: [[{ content: "Low Tide, High Lights" }, { content: "2022" }]],
+                table_width: null,
+              },
+              {
+                block_type: "text",
+                display_order: 20,
+                content: "[include(틀:Discography)]",
               },
             ],
           },
         ],
       },
     ]);
+    expect(parsed.warnings).toEqual([]);
   });
 
   it("returns a parse error when headings skip levels or exceed the supported depth", () => {
     expect(
-      parseWikiSectionsFromCode(["= Overview =", "", "=== Broken ==="].join("\n")),
+      parseWikiSectionsFromCode(["== Overview ==", "", "==== Broken ===="].join("\n")),
     ).toEqual({
       ok: false,
       message: "Heading depth cannot skip levels. Add the missing parent section first.",
@@ -222,11 +241,11 @@ describe("wikiEditModel", () => {
 
     expect(
       parseWikiSectionsFromCode([
-        "= Overview =",
+        "== Overview ==",
         "",
-        "== Style ==",
+        "=== Style ===",
         "",
-        "==== Too Deep ====",
+        "===== Too Deep =====",
       ].join("\n")),
     ).toEqual({
       ok: false,
@@ -237,7 +256,7 @@ describe("wikiEditModel", () => {
   it("returns a parse error for malformed structured macros", () => {
     expect(
       parseWikiSectionsFromCode([
-        "= Overview =",
+        "== Overview ==",
         "",
         "[[image|id:cover|src:https://example.com/image.png",
       ].join("\n")),
@@ -246,5 +265,97 @@ describe("wikiEditModel", () => {
       message:
         "Code mode could not parse a structured block. Fix the macro syntax or clear the draft.",
     });
+  });
+
+  it("warns when extended table syntax is preserved as plain cell text", () => {
+    const parsed = parseWikiSectionsFromCode([
+      "== Overview ==",
+      "",
+      "||<tablebgcolor=#222> !Name || !Year ||",
+      "||<width=200> Aurora Echo || 2024 ||",
+    ].join("\n"));
+
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(parsed.warnings).toEqual([
+      "Extended table syntax was preserved as plain cell text because the GUI table editor cannot model merged cells or attributes yet.",
+    ]);
+    expect(serializeWikiSectionsToCode(parsed.sections)).toContain("|| !Name || !Year ||");
+  });
+
+  it("converts supported media include macros into embed blocks", () => {
+    const parsed = parseWikiSectionsFromCode([
+      "== Overview ==",
+      "",
+      "[include(틀:영상 정렬, url=jNQXAC9IVRw)]",
+    ].join("\n"));
+
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(toWikiSectionContentPayload(parsed.sections)).toEqual([
+      {
+        type: "section",
+        title: "Overview",
+        display_order: 10,
+        contents: [
+          {
+            block_type: "embed",
+            display_order: 10,
+            provider: "youtube",
+            embed_id: "jNQXAC9IVRw",
+            caption: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("parses supported table width and colspan syntax into structured table cells", () => {
+    const parsed = parseWikiSectionsFromCode([
+      "== Highlights ==",
+      "",
+      "|| !<tablewidth=320> !Release || !Year ||",
+      "|| <-2> Aurora Echo ||  ||",
+    ].join("\n"));
+
+    expect(parsed.ok).toBe(true);
+
+    if (!parsed.ok) {
+      return;
+    }
+
+    expect(toWikiSectionContentPayload(parsed.sections)).toEqual([
+      {
+        type: "section",
+        title: "Highlights",
+        display_order: 10,
+        contents: [
+          {
+            block_type: "table",
+            display_order: 10,
+            headers: ["Release", "Year"],
+            header_cells: [{ content: "Release" }, { content: "Year" }],
+            rows: [["Aurora Echo"]],
+            row_cells: [[{ content: "Aurora Echo", colspan: 2 }]],
+            table_width: 320,
+          },
+        ],
+      },
+    ]);
+    expect(parsed.warnings).toEqual([]);
+    expect(serializeWikiSectionsToCode(parsed.sections)).toContain(
+      "|| <tablewidth=320> !Release || !Year ||",
+    );
+    expect(serializeWikiSectionsToCode(parsed.sections)).toContain(
+      "|| <-2> Aurora Echo ||",
+    );
   });
 });

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -2,6 +2,7 @@ import type {
   WikiBlock,
   WikiBlockType,
   WikiDetail,
+  WikiEmbedBlock,
   WikiEmbedProvider,
   WikiSection,
   WikiSectionContent,
@@ -33,6 +34,9 @@ export type WikiSectionContentPayload =
       items?: string[];
       rows?: string[][];
       headers?: string[] | null;
+      row_cells?: Array<Array<{ content: string; colspan?: number }>>;
+      header_cells?: Array<{ content: string; colspan?: number }> | null;
+      table_width?: number | null;
       wiki_identifiers?: string[];
       title?: string | null;
     };
@@ -55,6 +59,7 @@ export type WikiCodeParseResult =
   | {
       ok: true;
       sections: WikiSection[];
+      warnings: string[];
     }
   | {
       ok: false;
@@ -161,8 +166,42 @@ const serializeCodeMacro = (name: string, values: string[]): string =>
 const serializeCodeField = (key: string, value: string | null | undefined): string | null =>
   value == null ? null : `${key}:${escapeCodeValue(value)}`;
 
-const serializeTableRow = (cells: string[], isHeader = false): string =>
-  `|| ${cells.map((cell) => `${isHeader ? "!" : ""}${cell}`).join(" || ")} ||`;
+const serializeTableCell = (
+  cell: { content: string; colspan?: number },
+  options?: { isHeader?: boolean; tableWidth?: number | null },
+): string => {
+  const attributes = [
+    options?.tableWidth ? `<tablewidth=${options.tableWidth}>` : null,
+    cell.colspan && cell.colspan > 1 ? `<-${cell.colspan}>` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join("");
+
+  const content = `${options?.isHeader ? "!" : ""}${cell.content}`.trimEnd();
+
+  return [attributes, content].filter(Boolean).join(attributes && content ? " " : "");
+};
+
+const serializeTableRow = (
+  cells: string[],
+  isHeader = false,
+  options?: { structuredCells?: Array<{ content: string; colspan?: number }>; tableWidth?: number | null },
+): string => {
+  const sourceCells =
+    options?.structuredCells ??
+    cells.map((cell) => ({
+      content: cell,
+    }));
+
+  return `|| ${sourceCells
+    .map((cell, index) =>
+      serializeTableCell(cell, {
+        isHeader,
+        tableWidth: index === 0 ? options?.tableWidth : null,
+      }),
+    )
+    .join(" || ")} ||`;
+};
 
 const serializeWikiBlockToCode = (block: WikiBlock): string => {
   switch (block.blockType) {
@@ -207,8 +246,19 @@ const serializeWikiBlockToCode = (block: WikiBlock): string => {
         .join("\n");
     case "table":
       return [
-        ...(block.headers ? [serializeTableRow(block.headers, true)] : []),
-        ...block.rows.map((row) => serializeTableRow(row)),
+        ...(block.headers
+          ? [
+              serializeTableRow(block.headers, true, {
+                structuredCells: block.headerCells ?? undefined,
+                tableWidth: block.tableWidth,
+              }),
+            ]
+          : []),
+        ...block.rows.map((row, index) =>
+          serializeTableRow(row, false, {
+            structuredCells: block.rowCells?.[index],
+          }),
+        ),
       ].join("\n");
     case "profile_card_list":
       return serializeCodeMacro("profiles", [
@@ -220,7 +270,8 @@ const serializeWikiBlockToCode = (block: WikiBlock): string => {
 
 const serializeWikiSectionToCode = (section: WikiSection): string => {
   const normalizedSection = normalizeWikiSectionContents(section);
-  const heading = `${"=".repeat(normalizedSection.depth)} ${normalizedSection.title} ${"=".repeat(normalizedSection.depth)}`;
+  const headingDepth = normalizedSection.depth + 1;
+  const heading = `${"=".repeat(headingDepth)} ${normalizedSection.title} ${"=".repeat(headingDepth)}`;
   const sortedContents = sortWikiSectionContents(normalizedSection.contents);
   const contents = [
     ...sortedContents
@@ -248,9 +299,95 @@ const parseTableCells = (line: string): string[] =>
     .split("||")
     .map((cell) => cell.trim());
 
+const parseTableCell = (
+  rawCell: string,
+): {
+  cell: { content: string; colspan?: number };
+  isHeader: boolean;
+  tableWidth: number | null;
+  hasUnsupportedAttributes: boolean;
+} => {
+  let value = rawCell.trim();
+  let isHeader = false;
+  let tableWidth: number | null = null;
+  let colspan: number | undefined;
+  let hasUnsupportedAttributes = false;
+
+  if (value.startsWith("!")) {
+    isHeader = true;
+    value = value.slice(1).trimStart();
+  }
+
+  while (value.startsWith("<")) {
+    const endIndex = value.indexOf(">");
+
+    if (endIndex < 0) {
+      break;
+    }
+
+    const attribute = value.slice(1, endIndex).trim();
+
+    if (/^tablewidth=\d+$/i.test(attribute)) {
+      tableWidth = Number(attribute.split("=")[1]);
+    } else if (/^-\d+$/.test(attribute)) {
+      colspan = Number(attribute.slice(1));
+    } else {
+      hasUnsupportedAttributes = true;
+    }
+
+    value = value.slice(endIndex + 1).trimStart();
+  }
+
+  if (value.startsWith("!")) {
+    isHeader = true;
+    value = value.slice(1).trimStart();
+  }
+
+  return {
+    cell: {
+      content: value,
+      ...(colspan && colspan > 1 ? { colspan } : {}),
+    },
+    hasUnsupportedAttributes,
+    isHeader,
+    tableWidth,
+  };
+};
+
+const countRenderedColumns = (cells: Array<{ colspan?: number }>): number =>
+  cells.reduce((sum, cell) => sum + (cell.colspan ?? 1), 0);
+
+const trimOverflowCells = (
+  cells: Array<{ content: string; colspan?: number }>,
+  columnCount: number,
+): Array<{ content: string; colspan?: number }> => {
+  const trimmed = [...cells];
+
+  while (countRenderedColumns(trimmed) > columnCount) {
+    const lastCell = trimmed.at(-1);
+
+    if (!lastCell || lastCell.content.trim() || (lastCell.colspan ?? 1) > 1) {
+      break;
+    }
+
+    trimmed.pop();
+  }
+
+  return trimmed;
+};
+
 const createParseError = (message: string): WikiCodeParseResult => ({
   ok: false,
   message,
+});
+
+const createParseSuccess = (
+  sections: WikiSection[],
+  warnings: string[] = [],
+): WikiCodeParseResult => ({
+  ok: true,
+  sections,
+  warnings,
 });
 
 const parseCodeField = (part: string): [string, string] | null => {
@@ -293,10 +430,52 @@ const parseCodeMacro = (
   return { name: name.trim(), fields };
 };
 
+const parseNamuIncludeMacro = (
+  line: string,
+): { name: string; params: Record<string, string> } | null => {
+  const trimmedLine = line.trim();
+
+  if (!trimmedLine.startsWith("[include(") || !trimmedLine.endsWith(")]")) {
+    return null;
+  }
+
+  const rawContent = trimmedLine.slice(9, -2).trim();
+  const [rawName, ...rawParts] = splitEscaped(rawContent, ",");
+  const name = rawName?.trim();
+
+  if (!name) {
+    return null;
+  }
+
+  const params = rawParts.reduce<Record<string, string>>((result, part) => {
+    const dividerIndex = part.indexOf("=");
+
+    if (dividerIndex < 0) {
+      return result;
+    }
+
+    const key = part.slice(0, dividerIndex).trim();
+
+    if (!key) {
+      return result;
+    }
+
+    result[key] = unescapeCodeValue(part.slice(dividerIndex + 1).trim());
+
+    return result;
+  }, {});
+
+  return {
+    name,
+    params,
+  };
+};
+
 type WikiCodeBlocksParseResult =
   | {
       ok: true;
       blocks: WikiBlock[];
+      warnings: string[];
     }
   | {
       ok: false;
@@ -332,8 +511,98 @@ const isStructuredBlockStart = (line: string): boolean =>
   isListLine(line) ||
   isTableLine(line);
 
+const detectTextFallbackWarnings = (content: string): string[] => {
+  const warnings = new Set<string>();
+
+  if (/\[\[(파일|File):[^[\]]+\]\]/.test(content)) {
+    warnings.add("File link syntax is still preserved as plain text in the GUI editor.");
+  }
+
+  return [...warnings];
+};
+
+const hasExtendedTableSyntax = (cells: string[]): boolean =>
+  cells.some((cell) =>
+    /^<[^>]+>/.test(cell.trim()) &&
+    !/^<(tablewidth=\d+|-\d+)>/i.test(cell.trim()),
+  );
+
+const includeTemplateToEmbedProvider = (
+  name: string,
+): WikiEmbedProvider | null => {
+  const normalizedName = name.trim().toLowerCase();
+
+  if (["틀:영상 정렬", "틀:youtube", "틀:유튜브"].includes(normalizedName)) {
+    return "youtube";
+  }
+
+  if (["틀:x", "틀:twitter", "틀:트위터", "틀:tweet", "틀:트윗"].includes(normalizedName)) {
+    return "x";
+  }
+
+  if (["틀:spotify", "틀:스포티파이"].includes(normalizedName)) {
+    return "spotify";
+  }
+
+  if (["틀:tiktok", "틀:틱톡"].includes(normalizedName)) {
+    return "tiktok";
+  }
+
+  return null;
+};
+
+const getIncludeEmbedId = (
+  provider: WikiEmbedProvider,
+  params: Record<string, string>,
+): string | null => {
+  const candidates = (() => {
+    switch (provider) {
+      case "youtube":
+        return [params.url, params.주소, params.id, params.video];
+      case "x":
+        return [params.url, params.주소, params.id, params.tweetId, params.vid];
+      case "spotify":
+        return [params.url, params.주소, params.id];
+      case "tiktok":
+        return [params.url, params.주소, params.id, params.video];
+    }
+  })();
+
+  return candidates.find((candidate) => candidate?.trim())?.trim() ?? null;
+};
+
+const parseIncludeEmbedBlock = (
+  line: string,
+): Omit<WikiEmbedBlock, "blockIdentifier" | "displayOrder"> | null => {
+  const includeMacro = parseNamuIncludeMacro(line);
+
+  if (!includeMacro) {
+    return null;
+  }
+
+  const provider = includeTemplateToEmbedProvider(includeMacro.name);
+
+  if (!provider) {
+    return null;
+  }
+
+  const embedId = getIncludeEmbedId(provider, includeMacro.params);
+
+  if (!embedId) {
+    return null;
+  }
+
+  return {
+    blockType: "embed",
+    caption: includeMacro.params.caption?.trim() || includeMacro.params.내용?.trim() || null,
+    embedId,
+    provider,
+  };
+};
+
 const parseCodeBlocks = (lines: string[]): WikiCodeBlocksParseResult => {
   const blocks: WikiBlock[] = [];
+  const warnings = new Set<string>();
   let cursor = 0;
 
   const addBlock = (block: Record<string, unknown> & { blockType: WikiBlockType }) => {
@@ -400,21 +669,46 @@ const parseCodeBlocks = (lines: string[]): WikiCodeBlocksParseResult => {
 
     if (isTableLine(line)) {
       const rows: string[][] = [];
+      const rowCells: Array<Array<{ content: string; colspan?: number }>> = [];
+      let headerCells: Array<{ content: string; colspan?: number }> | null = null;
+      let tableWidth: number | null = null;
 
       while (cursor < lines.length && isTableLine(lines[cursor])) {
-        rows.push(parseTableCells(lines[cursor]));
+        const parsedCells = parseTableCells(lines[cursor]).map(parseTableCell);
+        const cells = parsedCells.map(({ cell }) => cell);
+
+        if (
+          hasExtendedTableSyntax(parseTableCells(lines[cursor])) ||
+          parsedCells.some(({ hasUnsupportedAttributes }) => hasUnsupportedAttributes)
+        ) {
+          warnings.add(
+            "Extended table syntax was preserved as plain cell text because the GUI table editor cannot model merged cells or attributes yet.",
+          );
+        }
+
+        tableWidth ??= parsedCells.find(({ tableWidth: width }) => width != null)?.tableWidth ?? null;
+        rowCells.push(cells);
+        rows.push(cells.map((cell) => cell.content));
         cursor += 1;
       }
 
-      const firstRow = rows[0] ?? [];
-      const hasHeaders = firstRow.length > 0 && firstRow.every((cell) => cell.startsWith("!"));
+      const firstStructuredRow = rowCells[0] ?? [];
+      const firstRawRow = parseTableCells(lines[cursor - rowCells.length] ?? "").map(parseTableCell);
+      const hasHeaders = firstRawRow.length > 0 && firstRawRow.every((cell) => cell.isHeader);
+      const columnCount = countRenderedColumns(hasHeaders ? firstStructuredRow : rowCells[0] ?? []);
+      const normalizedBodyRows = (hasHeaders ? rowCells.slice(1) : rowCells).map((row) =>
+        trimOverflowCells(row, columnCount),
+      );
+
+      headerCells = hasHeaders ? trimOverflowCells(firstStructuredRow, columnCount) : null;
 
       addBlock({
         blockType: "table",
-        headers: hasHeaders ? firstRow.map((cell) => cell.slice(1).trim()) : null,
-        rows: (hasHeaders ? rows.slice(1) : rows).map((row) =>
-          row.map((cell) => cell.trim()),
-        ),
+        headerCells,
+        headers: headerCells ? headerCells.map((cell) => cell.content.trim()) : null,
+        rowCells: normalizedBodyRows,
+        rows: normalizedBodyRows.map((row) => row.map((cell) => cell.content.trim())),
+        tableWidth,
       });
       continue;
     }
@@ -511,6 +805,14 @@ const parseCodeBlocks = (lines: string[]): WikiCodeBlocksParseResult => {
       }
     }
 
+    const includeEmbedBlock = parseIncludeEmbedBlock(line);
+
+    if (includeEmbedBlock) {
+      addBlock(includeEmbedBlock);
+      cursor += 1;
+      continue;
+    }
+
     const textLines: string[] = [];
 
     while (cursor < lines.length) {
@@ -528,15 +830,22 @@ const parseCodeBlocks = (lines: string[]): WikiCodeBlocksParseResult => {
       cursor += 1;
     }
 
+    const textContent = textLines.join("\n");
+
+    for (const warning of detectTextFallbackWarnings(textContent)) {
+      warnings.add(warning);
+    }
+
     addBlock({
       blockType: "text",
-      content: textLines.join("\n"),
+      content: textContent,
     });
   }
 
   return {
     ok: true,
     blocks,
+    warnings: [...warnings],
   };
 };
 
@@ -560,16 +869,15 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
   const normalizedCode = code.replaceAll("\r\n", "\n");
 
   if (!normalizedCode.trim()) {
-    return {
-      ok: true,
-      sections: [],
-    };
+    return createParseSuccess([]);
   }
 
   const lines = normalizedCode.split("\n");
   const rootSections: WikiSection[] = [];
   let sectionStack: WikiSection[] = [];
   let pendingLines: string[] = [];
+  let headingBaseDepth: number | null = null;
+  const warnings = new Set<string>();
 
   const replaceSectionInStack = (nextSection: WikiSection) => {
     const depthIndex = nextSection.depth - 1;
@@ -624,6 +932,10 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
       return createParseError(parsedBlocks.message);
     }
 
+    for (const warning of parsedBlocks.warnings) {
+      warnings.add(warning);
+    }
+
     replaceSectionInStack(appendBlocksToSection(currentSection, parsedBlocks.blocks));
     pendingLines = [];
     return null;
@@ -640,13 +952,16 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
         return flushResult;
       }
 
-      if (headingDepth > WIKI_SECTION_MAX_DEPTH) {
+      headingBaseDepth ??= headingDepth >= 2 ? 2 : 1;
+      const normalizedHeadingDepth = headingDepth - headingBaseDepth + 1;
+
+      if (normalizedHeadingDepth < 1 || normalizedHeadingDepth > WIKI_SECTION_MAX_DEPTH) {
         return createParseError(
           `Code mode supports headings up to depth ${WIKI_SECTION_MAX_DEPTH}.`,
         );
       }
 
-      if (headingDepth > sectionStack.length + 1) {
+      if (normalizedHeadingDepth > sectionStack.length + 1) {
         return createParseError(
           "Heading depth cannot skip levels. Add the missing parent section first.",
         );
@@ -658,14 +973,14 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
         return createParseError("Section headings must include a title.");
       }
 
-      sectionStack = sectionStack.slice(0, headingDepth - 1);
+      sectionStack = sectionStack.slice(0, normalizedHeadingDepth - 1);
       const parent = sectionStack.at(-1);
       const nextSection: WikiSection = {
         type: "section",
         sectionIdentifier: createIdentifier("section"),
         title,
         displayOrder: getNextDisplayOrder(parent ? parent.contents : rootSections),
-        depth: headingDepth,
+        depth: normalizedHeadingDepth,
         contents: [],
         children: [],
       };
@@ -703,10 +1018,7 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
     return flushResult;
   }
 
-  return {
-    ok: true,
-    sections: normalizeWikiSectionsForEditing(rootSections),
-  };
+  return createParseSuccess(normalizeWikiSectionsForEditing(rootSections), [...warnings]);
 };
 
 const getNextDisplayOrder = (contents: WikiSectionContent[]): number =>
@@ -845,7 +1157,10 @@ export const createWikiBlock = (
         blockType,
         displayOrder,
         headers: ["Column 1", "Column 2"],
+        headerCells: [{ content: "Column 1" }, { content: "Column 2" }],
         rows: [["Value 1", "Value 2"]],
+        rowCells: [[{ content: "Value 1" }, { content: "Value 2" }]],
+        tableWidth: null,
       };
     case "profile_card_list":
       return {
@@ -1076,6 +1391,9 @@ const toWikiContentPayload = (
         display_order: content.displayOrder,
         rows: content.rows,
         headers: content.headers,
+        row_cells: content.rowCells,
+        header_cells: content.headerCells ?? null,
+        table_width: content.tableWidth ?? null,
       };
     case "profile_card_list":
       return {

--- a/src/app/ThemeInitializer.tsx
+++ b/src/app/ThemeInitializer.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { themeStorageKey, type ThemeMode } from "./themeMode";
+
+function getSystemTheme(): ThemeMode {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function readTheme(): ThemeMode {
+  const storedTheme = window.localStorage.getItem(themeStorageKey);
+  return storedTheme === "dark" || storedTheme === "light" ? storedTheme : getSystemTheme();
+}
+
+function syncThemeLabel(theme: ThemeMode) {
+  document.querySelectorAll("[data-theme-label]").forEach((element) => {
+    element.textContent = theme === "dark" ? "Dark" : "Light";
+  });
+}
+
+function applyTheme(theme: ThemeMode, persist: boolean) {
+  document.documentElement.dataset.theme = theme;
+  syncThemeLabel(theme);
+  if (persist) {
+    window.localStorage.setItem(themeStorageKey, theme);
+  }
+}
+
+export function ThemeInitializer() {
+  useEffect(() => {
+    applyTheme(readTheme(), false);
+
+    const onClick = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const button = target.closest("[data-theme-toggle]");
+      if (!button) {
+        return;
+      }
+
+      const currentTheme =
+        document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+      const nextTheme: ThemeMode = currentTheme === "dark" ? "light" : "dark";
+      applyTheme(nextTheme, true);
+    };
+
+    document.addEventListener("click", onClick);
+    return () => {
+      document.removeEventListener("click", onClick);
+    };
+  }, []);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,8 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 
 import "./globals.css";
 import { Header } from "./Header";
-import { themeStorageKey } from "./themeMode";
+import { ThemeInitializer } from "./ThemeInitializer";
 
 export const metadata: Metadata = {
   title: "K-Pool Theme Preview",
@@ -19,49 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
-        <Script
-          id="theme-init"
-          strategy="beforeInteractive"
-        >{`(() => {
-  const storageKey = "${themeStorageKey}";
-  const getSystemTheme = () =>
-    window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  const readTheme = () => {
-    const storedTheme = window.localStorage.getItem(storageKey);
-    return storedTheme === "dark" || storedTheme === "light" ? storedTheme : getSystemTheme();
-  };
-  const syncThemeLabel = (theme) => {
-    document.querySelectorAll("[data-theme-label]").forEach((element) => {
-      element.textContent = theme === "dark" ? "Dark" : "Light";
-    });
-  };
-  const applyTheme = (theme, persist) => {
-    document.documentElement.dataset.theme = theme;
-    syncThemeLabel(theme);
-    if (persist) {
-      window.localStorage.setItem(storageKey, theme);
-    }
-  };
-
-  applyTheme(readTheme(), false);
-
-  document.addEventListener("click", (event) => {
-    const target = event.target;
-    if (!(target instanceof Element)) {
-      return;
-    }
-
-    const button = target.closest("[data-theme-toggle]");
-    if (!button) {
-      return;
-    }
-
-    const currentTheme =
-      document.documentElement.dataset.theme === "dark" ? "dark" : "light";
-    const nextTheme = currentTheme === "dark" ? "light" : "dark";
-    applyTheme(nextTheme, true);
-  });
-})();`}</Script>
+        <ThemeInitializer />
         <Header />
         {children}
       </body>

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -35,6 +35,7 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
     canPersist,
     code,
     codeParseError,
+    codeWarnings,
     draft,
     editingId,
     saveState,
@@ -181,6 +182,7 @@ function WikiEditContent({ data }: { data: WikiDetail }) {
             <WikiCodeEditor
               code={code}
               errorMessage={codeParseError}
+              warnings={codeWarnings}
               onChange={updateCode}
               onClear={clearChanges}
             />

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -149,11 +149,11 @@ describe("WikiEditPage", () => {
     fireEvent.change(screen.getByLabelText("Wiki code"), {
       target: {
         value: [
-          "= Overview =",
+          "== Overview ==",
           "",
           "Updated overview from code mode.",
           "",
-          "== Style Guide ==",
+          "=== Style Guide ===",
           "",
           "A new nested section.",
         ].join("\n"),
@@ -175,7 +175,7 @@ describe("WikiEditPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "code" }));
     fireEvent.change(screen.getByLabelText("Wiki code"), {
       target: {
-        value: ["= Overview =", "", "[[image|id:cover]"].join("\n"),
+        value: ["== Overview ==", "", "[[image|id:cover]"].join("\n"),
       },
     });
 
@@ -187,10 +187,82 @@ describe("WikiEditPage", () => {
     expect(confirmSpy).toHaveBeenCalledWith("Discard unsaved wiki changes?");
     expect(screen.queryByTestId("wiki-code-error")).not.toBeInTheDocument();
     expect((screen.getByLabelText("Wiki code") as HTMLTextAreaElement).value).toContain(
-      "= Overview =",
+      "== Overview ==",
     );
 
     confirmSpy.mockRestore();
+  });
+
+  it("shows compatibility warnings for namuwiki syntax that falls back to text blocks", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+    fireEvent.change(screen.getByLabelText("Wiki code"), {
+      target: {
+        value: [
+          "== Overview ==",
+          "",
+          "[[문서|대표 문서]]",
+          "",
+          "[[분류:테스트]]",
+          "",
+          "[* 주석 예시]",
+          "",
+          "[include(틀:Discography)]",
+        ].join("\n"),
+      },
+    });
+
+    expect(screen.queryByTestId("wiki-code-warnings")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("wiki-code-error")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "gui" }));
+
+    expect(document.querySelector('a[href="/wiki/%EB%AC%B8%EC%84%9C"]')).not.toBeNull();
+    expect(screen.getByLabelText("Footnote: 주석 예시")).toBeInTheDocument();
+    expect(screen.getByText("Included from 틀:Discography")).toBeInTheDocument();
+  });
+
+  it("shows compatibility warnings immediately for the dedicated namuwiki demo mock", () => {
+    mockedUseWikiDetail.mockReturnValue({
+      status: "success",
+      data: createMockWikiDetail("twice"),
+    });
+
+    render(React.createElement(WikiEditPage, { slug: "twice" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+
+    expect(screen.queryByTestId("wiki-code-warnings")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "gui" }));
+    expect(document.querySelector('a[href="/wiki/nayeon-twice"]')).not.toBeNull();
+    expect(screen.getByText("TWICE Members")).toBeInTheDocument();
+  });
+
+  it("maps supported media include macros into embed blocks in gui mode", () => {
+    mockedUseWikiDetail.mockReturnValue(successState);
+
+    render(React.createElement(WikiEditPage, { slug: "aurora-echo" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+    fireEvent.change(screen.getByLabelText("Wiki code"), {
+      target: {
+        value: [
+          "== Overview ==",
+          "",
+          "[include(틀:영상 정렬, url=jNQXAC9IVRw)]",
+        ].join("\n"),
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "gui" }));
+
+    expect(screen.getByTitle("YouTube embed")).toHaveAttribute(
+      "src",
+      "https://www.youtube-nocookie.com/embed/jNQXAC9IVRw",
+    );
   });
 
   it("renders loading, error, and empty states", () => {

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -60,14 +60,22 @@ const createInitialDraft = (wiki: WikiDetail): WikiDetail => ({
 const getCodeFromSections = (sections: WikiDetail["sections"]): string =>
   serializeWikiSectionsToCode(sections);
 
+const getWarningsFromCode = (code: string): string[] => {
+  const parsed = parseWikiSectionsFromCode(code);
+
+  return parsed.ok ? parsed.warnings : [];
+};
+
 export const useWikiEditDraft = (
   wiki: WikiDetail,
   options?: WikiEditDraftOptions,
 ) => {
   const initialDraft = useMemo(() => createInitialDraft(wiki), [wiki]);
+  const initialCode = useMemo(() => getCodeFromSections(initialDraft.sections), [initialDraft]);
   const [draft, setDraft] = useState<WikiDetail>(initialDraft);
-  const [code, setCode] = useState(() => getCodeFromSections(initialDraft.sections));
+  const [code, setCode] = useState(initialCode);
   const [codeParseError, setCodeParseError] = useState<string | null>(null);
+  const [codeWarnings, setCodeWarnings] = useState(() => getWarningsFromCode(initialCode));
   const [editingId, setEditingId] = useState<WikiContentEditorId | "basic" | "hero" | null>(
     null,
   );
@@ -80,11 +88,13 @@ export const useWikiEditDraft = (
   const submitAdapter = options?.submitAdapter ?? optimisticActionAdapter;
 
   const commitDraft = (nextDraft: WikiDetail, nextCode = getCodeFromSections(nextDraft.sections)) => {
+    const parsedCode = parseWikiSectionsFromCode(nextCode);
     const payload = toWikiEditPayload(nextDraft);
 
     setDraft(nextDraft);
     setCode(nextCode);
     setCodeParseError(null);
+    setCodeWarnings(parsedCode.ok ? parsedCode.warnings : []);
     setSaveState({
       status: "dirty",
       message: "Unsaved changes",
@@ -116,6 +126,7 @@ export const useWikiEditDraft = (
     setDraft(initialDraft);
     setCode(getCodeFromSections(initialDraft.sections));
     setCodeParseError(null);
+    setCodeWarnings([]);
     setEditingId(null);
     setSaveState({
       status: "saved",
@@ -148,6 +159,7 @@ export const useWikiEditDraft = (
     canPersist: !codeParseError,
     code,
     codeParseError,
+    codeWarnings,
     draft,
     editingId,
     saveState,
@@ -161,6 +173,7 @@ export const useWikiEditDraft = (
 
       if (!parsed.ok) {
         setCodeParseError(parsed.message);
+        setCodeWarnings([]);
         setSaveState({
           status: "dirty",
           message: "Unsaved changes",

--- a/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
@@ -23,14 +23,17 @@ describe("WikiBlockDisplay", () => {
   });
 
   it("renders table blocks", () => {
-    render(
+    const { container } = render(
       <WikiBlockDisplay
         block={{
           blockIdentifier: "table-1",
           blockType: "table",
           displayOrder: 20,
           headers: ["Role", "Member"],
+          headerCells: [{ content: "Role" }, { content: "Member" }],
           rows: [["Leader", "Mina"]],
+          rowCells: [[{ content: "Leader" }, { content: "Mina" }]],
+          tableWidth: 320,
         }}
       />,
     );
@@ -38,6 +41,26 @@ describe("WikiBlockDisplay", () => {
     expect(screen.getByText("Role")).toBeInTheDocument();
     expect(screen.getByText("Leader")).toBeInTheDocument();
     expect(screen.getByText("Mina")).toBeInTheDocument();
+    expect(container.querySelector("table")).toHaveStyle({ width: "320px" });
+  });
+
+  it("renders table cell colspan when present", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "table-2",
+          blockType: "table",
+          displayOrder: 20,
+          headers: ["Release", "Year"],
+          headerCells: [{ content: "Release" }, { content: "Year" }],
+          rows: [["Aurora Echo"]],
+          rowCells: [[{ content: "Aurora Echo", colspan: 2 }]],
+          tableWidth: 320,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Aurora Echo", { selector: "td" })).toHaveAttribute("colspan", "2");
   });
 
   it("renders image captions when present", () => {

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment } from "react";
 import Image from "next/image";
-import { type WikiBlock } from "@kpool/wiki";
+import { type WikiBlock, type WikiTableCell } from "@kpool/wiki";
 
 import { WikiEmbedFrame } from "../../../app/wiki/[slug]/WikiEmbedFrame";
 import { WikiRelatedProfiles } from "../../../app/wiki/[slug]/WikiRelatedProfiles";
@@ -20,6 +20,47 @@ export function WikiBlockDisplay({
   showEditableImageOverlay = false,
   textClassName = "text-sm leading-7 text-text-strong",
 }: WikiBlockDisplayProps) {
+  const renderPlainTextWithNamuLinks = (text: string, keyPrefix: string) => {
+    const pattern = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+    const nodes: React.ReactNode[] = [];
+    let lastIndex = 0;
+    let match: RegExpExecArray | null = pattern.exec(text);
+
+    while (match) {
+      const [raw, targetValue, displayValue] = match;
+      const target = targetValue?.trim() ?? "";
+
+      if (match.index > lastIndex) {
+        nodes.push(text.slice(lastIndex, match.index));
+      }
+
+      if (target.startsWith("분류:") || target.startsWith("파일:")) {
+        nodes.push(raw);
+      } else {
+        nodes.push(
+          <a
+            className="text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800"
+            href={`/wiki/${encodeURIComponent(target)}`}
+            key={`${keyPrefix}-namu-link-${match.index}`}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {displayValue?.trim() || target}
+          </a>,
+        );
+      }
+
+      lastIndex = match.index + raw.length;
+      match = pattern.exec(text);
+    }
+
+    if (lastIndex < text.length) {
+      nodes.push(text.slice(lastIndex));
+    }
+
+    return nodes;
+  };
+
   const renderInlineTokens = (content: string | ReturnType<typeof parseInlineMarkdown>) => {
     const tokens = typeof content === "string" ? parseInlineMarkdown(content) : content;
 
@@ -43,13 +84,33 @@ export function WikiBlockDisplay({
               {renderInlineTokens(token.children)}
             </a>
           );
+        case "footnote":
+          return (
+            <sup
+              aria-label={`Footnote: ${token.content}`}
+              className="ml-1 text-xs font-semibold text-text-muted"
+              key={`footnote-${index}`}
+              title={token.content}
+            >
+              [*]
+            </sup>
+          );
+        case "include":
+          return (
+            <span
+              className="inline-flex rounded-full border border-stroke-subtle px-2 py-0.5 text-xs font-semibold text-text-muted"
+              key={`include-${index}`}
+            >
+              Included from {token.target}
+            </span>
+          );
         case "text":
           return (
             <Fragment key={`text-${index}`}>
               {token.text.split("\n").map((line, lineIndex) => (
                 <Fragment key={`text-${index}-line-${lineIndex}`}>
                   {lineIndex > 0 ? <br /> : null}
-                  {line}
+                  {renderPlainTextWithNamuLinks(line, `text-${index}-line-${lineIndex}`)}
                 </Fragment>
               ))}
             </Fragment>
@@ -111,17 +172,45 @@ export function WikiBlockDisplay({
         </ul>
       );
     case "table":
+      const headerCells: WikiTableCell[] | null =
+        block.headerCells ?? block.headers?.map((header) => ({ content: header })) ?? null;
+      const rowCells: WikiTableCell[][] =
+        block.rowCells ?? block.rows.map((row) => row.map((cell) => ({ content: cell })));
+
       return (
         <div className="overflow-x-auto">
-          <table className="min-w-full text-left text-sm">
-            {block.headers ? (
+          <table
+            className="min-w-full text-left text-sm"
+            style={block.tableWidth ? { width: `${block.tableWidth}px` } : undefined}
+          >
+            {headerCells ? (
               <thead>
-                <tr>{block.headers.map((header) => <th className="border-b border-stroke-subtle px-3 py-2" key={header}>{header}</th>)}</tr>
+                <tr>
+                  {headerCells.map((header, index) => (
+                    <th
+                      className="border-b border-stroke-subtle px-3 py-2"
+                      colSpan={header.colspan ?? 1}
+                      key={`${header.content}-${index}`}
+                    >
+                      {header.content}
+                    </th>
+                  ))}
+                </tr>
               </thead>
             ) : null}
             <tbody>
-              {block.rows.map((row) => (
-                <tr key={row.join("|")}>{row.map((cell) => <td className="border-b border-stroke-subtle px-3 py-2 text-text-strong" key={cell}>{cell}</td>)}</tr>
+              {rowCells.map((row, rowIndex) => (
+                <tr key={`row-${rowIndex}`}>
+                  {row.map((cell, cellIndex) => (
+                    <td
+                      className="border-b border-stroke-subtle px-3 py-2 text-text-strong"
+                      colSpan={cell.colspan ?? 1}
+                      key={`${cell.content}-${cellIndex}`}
+                    >
+                      {cell.content}
+                    </td>
+                  ))}
+                </tr>
               ))}
             </tbody>
           </table>

--- a/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
+++ b/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
@@ -21,19 +21,117 @@ describe("WikiBlockForm", () => {
     });
   });
 
-  it("submits parsed table rows", () => {
+  it("submits structured table cell edits", () => {
     const onSave = vi.fn();
 
     render(<WikiBlockForm block={wikiStoryTableBlock} onCancel={() => {}} onSave={onSave} />);
 
-    fireEvent.change(screen.getByLabelText("Rows"), {
-      target: { value: "Album, 2024" },
+    fireEvent.change(screen.getByLabelText("Row 1 cell 1"), {
+      target: { value: "Album" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 cell 2"), {
+      target: { value: "2024" },
     });
     fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
 
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
+        rowCells: [[{ content: "Album" }, { content: "2024" }]],
         rows: [["Album", "2024"]],
+      }),
+    );
+  });
+
+  it("submits table width changes", () => {
+    const onSave = vi.fn();
+
+    render(<WikiBlockForm block={wikiStoryTableBlock} onCancel={() => {}} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText("Table width"), {
+      target: { value: "320" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tableWidth: 320,
+      }),
+    );
+  });
+
+  it("adds a column and preserves structured cells", () => {
+    const onSave = vi.fn();
+
+    render(<WikiBlockForm block={wikiStoryTableBlock} onCancel={() => {}} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Column" }));
+    fireEvent.change(screen.getByLabelText("Row 1 cell 1"), {
+      target: { value: "Aurora Echo" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 cell 2"), {
+      target: { value: "2024" },
+    });
+    fireEvent.change(screen.getByLabelText("Header cell 3"), {
+      target: { value: "Notes" },
+    });
+    fireEvent.change(screen.getByLabelText("Row 1 cell 3"), {
+      target: { value: "Lead single" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headerCells: [{ content: "Release" }, { content: "Year" }, { content: "Notes" }],
+        rowCells: [[{ content: "Aurora Echo" }, { content: "2024" }, { content: "Lead single" }]],
+      }),
+    );
+  });
+
+  it("connects horizontally selected cells", () => {
+    const onSave = vi.fn();
+    const block = {
+      ...wikiStoryTableBlock,
+      headers: ["Release", "Year"],
+      headerCells: [{ content: "Release" }, { content: "Year" }],
+      rows: [["Aurora Echo", "2024"]],
+      rowCells: [[{ content: "Aurora Echo" }, { content: "2024" }]],
+    };
+
+    render(<WikiBlockForm block={block} onCancel={() => {}} onSave={onSave} />);
+
+    fireEvent.click(screen.getByLabelText("Row 1 cell 1"));
+    fireEvent.click(screen.getByLabelText("Row 1 cell 2"), { shiftKey: true });
+    fireEvent.click(screen.getByRole("button", { name: "+ Connect" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowCells: [[{ content: "Aurora Echo", colspan: 2 }]],
+        rows: [["Aurora Echo"]],
+      }),
+    );
+  });
+
+  it("cancels a connected cell from the toolbar", () => {
+    const onSave = vi.fn();
+    const block = {
+      ...wikiStoryTableBlock,
+      headers: ["Release", "Year"],
+      headerCells: [{ content: "Release" }, { content: "Year" }],
+      rows: [["Aurora Echo"]],
+      rowCells: [[{ content: "Aurora Echo", colspan: 2 }]],
+    };
+
+    render(<WikiBlockForm block={block} onCancel={() => {}} onSave={onSave} />);
+
+    fireEvent.click(screen.getByLabelText("Row 1 cell 1"));
+    fireEvent.click(screen.getByRole("button", { name: "+ Cancel connect" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rowCells: [[{ content: "Aurora Echo" }, { content: "" }]],
+        rows: [["Aurora Echo", ""]],
       }),
     );
   });

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -9,6 +9,8 @@ import {
   type WikiBlock,
   type WikiEmbedProvider,
   type WikiListType,
+  type WikiTableBlock,
+  type WikiTableCell,
   type WikiTextBlock,
 } from "@kpool/wiki";
 
@@ -32,6 +34,562 @@ type TextBlockFormProps = {
   onCancel: () => void;
   onSave: (changes: Partial<WikiBlock>) => void;
 };
+
+type TableBlockFormProps = {
+  block: WikiTableBlock;
+  onCancel: () => void;
+  onSave: (changes: Partial<WikiBlock>) => void;
+};
+
+type TableEditorState = {
+  hasHeaderRow: boolean;
+  headerCells: WikiTableCell[];
+  rowCells: WikiTableCell[][];
+  tableWidth: string;
+};
+
+type TableCellSelection =
+  | {
+      kind: "header";
+      cellIndexes: number[];
+    }
+  | {
+      kind: "body";
+      rowIndex: number;
+      cellIndexes: number[];
+    };
+
+const getRenderedColumnCount = (cells: WikiTableCell[]): number =>
+  cells.reduce((count, cell) => count + Math.max(1, cell.colspan ?? 1), 0);
+
+const createEmptyTableCell = (): WikiTableCell => ({ content: "" });
+
+const createEmptyTableRow = (columnCount: number): WikiTableCell[] =>
+  Array.from({ length: Math.max(1, columnCount) }, () => createEmptyTableCell());
+
+const getTableColumnCount = (headerCells: WikiTableCell[], rowCells: WikiTableCell[][]): number =>
+  Math.max(
+    1,
+    getRenderedColumnCount(headerCells),
+    ...rowCells.map((row) => getRenderedColumnCount(row)),
+  );
+
+const clampCellColspan = (
+  row: WikiTableCell[],
+  cellIndex: number,
+  requestedColspan: number,
+  columnCount: number,
+): number => {
+  const renderedBefore = row
+    .slice(0, cellIndex)
+    .reduce((count, cell) => count + Math.max(1, cell.colspan ?? 1), 0);
+  const trailingCellCount = row.length - cellIndex - 1;
+  const maxColspan = Math.max(1, columnCount - renderedBefore - trailingCellCount);
+
+  return Math.max(1, Math.min(requestedColspan, maxColspan));
+};
+
+const normalizeTableRow = (row: WikiTableCell[], columnCount: number): WikiTableCell[] => {
+  const safeRow = row.length > 0 ? row : [createEmptyTableCell()];
+  const normalized = safeRow.map((cell, cellIndex) => ({
+    content: cell.content,
+    ...(clampCellColspan(
+      safeRow,
+      cellIndex,
+      Math.max(1, cell.colspan ?? 1),
+      columnCount,
+    ) > 1
+      ? {
+          colspan: clampCellColspan(
+            safeRow,
+            cellIndex,
+            Math.max(1, cell.colspan ?? 1),
+            columnCount,
+          ),
+        }
+      : {}),
+  }));
+  const renderedColumns = getRenderedColumnCount(normalized);
+
+  if (renderedColumns >= columnCount) {
+    return normalized;
+  }
+
+  return [
+    ...normalized,
+    ...Array.from({ length: columnCount - renderedColumns }, () => createEmptyTableCell()),
+  ];
+};
+
+const normalizeTableEditorState = (state: TableEditorState): TableEditorState => {
+  const baseColumnCount = getTableColumnCount(
+    state.hasHeaderRow ? state.headerCells : [],
+    state.rowCells,
+  );
+  const rowCells =
+    state.rowCells.length > 0
+      ? state.rowCells.map((row) => normalizeTableRow(row, baseColumnCount))
+      : [createEmptyTableRow(baseColumnCount)];
+  const columnCount = getTableColumnCount(state.hasHeaderRow ? state.headerCells : [], rowCells);
+
+  return {
+    ...state,
+    headerCells: state.hasHeaderRow
+      ? normalizeTableRow(state.headerCells, columnCount)
+      : [],
+    rowCells: rowCells.map((row) => normalizeTableRow(row, columnCount)),
+  };
+};
+
+const createTableEditorState = (block: WikiTableBlock): TableEditorState =>
+  normalizeTableEditorState({
+    hasHeaderRow: Boolean((block.headerCells ?? block.headers)?.length),
+    headerCells:
+      block.headerCells ??
+      block.headers?.map((header) => ({
+        content: header,
+      })) ??
+      [],
+    rowCells:
+      block.rowCells ??
+      block.rows.map((row) =>
+        row.map((cell) => ({
+          content: cell,
+        })),
+      ),
+    tableWidth: block.tableWidth?.toString() ?? "",
+  });
+
+const toLegacyTableArrays = (cells: WikiTableCell[][]): string[][] =>
+  cells.map((row) => row.map((cell) => cell.content.trim()));
+
+const getSortedUniqueIndexes = (cellIndexes: number[]): number[] =>
+  [...new Set(cellIndexes)].sort((left, right) => left - right);
+
+const createSelectionRange = (startIndex: number, endIndex: number): number[] =>
+  Array.from(
+    { length: Math.abs(endIndex - startIndex) + 1 },
+    (_, offset) => Math.min(startIndex, endIndex) + offset,
+  );
+
+const connectCells = (row: WikiTableCell[], selectedIndexes: number[]): WikiTableCell[] => {
+  const indexes = getSortedUniqueIndexes(selectedIndexes);
+
+  if (indexes.length < 2) {
+    return row;
+  }
+
+  const [firstIndex] = indexes;
+
+  if (firstIndex == null) {
+    return row;
+  }
+
+  const firstCell = row[firstIndex];
+
+  if (!firstCell) {
+    return row;
+  }
+
+  const mergedColspan = indexes.length;
+
+  return row.flatMap((cell, cellIndex) => {
+    if (!indexes.includes(cellIndex)) {
+      return [cell];
+    }
+
+    if (cellIndex !== firstIndex) {
+      return [];
+    }
+
+    return [
+      {
+        ...firstCell,
+        ...(mergedColspan > 1 ? { colspan: mergedColspan } : {}),
+      },
+    ];
+  });
+};
+
+const cancelConnectedCell = (row: WikiTableCell[], cellIndex: number): WikiTableCell[] => {
+  const cell = row[cellIndex];
+  const colspan = cell?.colspan ?? 1;
+
+  if (!cell || colspan <= 1) {
+    return row;
+  }
+
+  return row.flatMap((currentCell, currentIndex) => {
+    if (currentIndex !== cellIndex) {
+      return [currentCell];
+    }
+
+    return [
+      {
+        content: currentCell.content,
+      },
+      ...Array.from({ length: colspan - 1 }, () => createEmptyTableCell()),
+    ];
+  });
+};
+
+function WikiTableBlockForm({ block, onCancel, onSave }: TableBlockFormProps) {
+  const [tableState, setTableState] = useState<TableEditorState>(() => createTableEditorState(block));
+  const [selection, setSelection] = useState<TableCellSelection | null>(null);
+  const columnCount = getTableColumnCount(
+    tableState.hasHeaderRow ? tableState.headerCells : [],
+    tableState.rowCells,
+  );
+
+  const updateState = (updater: (current: TableEditorState) => TableEditorState) => {
+    setTableState((current) => normalizeTableEditorState(updater(current)));
+  };
+
+  const isSelectedCell = (nextSelection: TableCellSelection | null): boolean => {
+    if (!selection || !nextSelection || selection.kind !== nextSelection.kind) {
+      return false;
+    }
+
+    if (selection.kind === "body" && nextSelection.kind === "body" && selection.rowIndex !== nextSelection.rowIndex) {
+      return false;
+    }
+
+    return nextSelection.cellIndexes.some((cellIndex) => selection.cellIndexes.includes(cellIndex));
+  };
+
+  const selectCell = (
+    nextSelection:
+      | {
+          kind: "header";
+          cellIndex: number;
+        }
+      | {
+          kind: "body";
+          rowIndex: number;
+          cellIndex: number;
+        },
+    useRangeSelection: boolean,
+  ) => {
+    setSelection((current) => {
+      if (!useRangeSelection || !current || current.kind !== nextSelection.kind) {
+        return nextSelection.kind === "header"
+          ? { kind: "header", cellIndexes: [nextSelection.cellIndex] }
+          : { kind: "body", rowIndex: nextSelection.rowIndex, cellIndexes: [nextSelection.cellIndex] };
+      }
+
+      if (current.kind === "body" && nextSelection.kind === "body" && current.rowIndex !== nextSelection.rowIndex) {
+        return { kind: "body", rowIndex: nextSelection.rowIndex, cellIndexes: [nextSelection.cellIndex] };
+      }
+
+      const anchorIndex = current.cellIndexes[0] ?? nextSelection.cellIndex;
+      const cellIndexes = createSelectionRange(anchorIndex, nextSelection.cellIndex);
+
+      return nextSelection.kind === "header"
+        ? { kind: "header", cellIndexes }
+        : { kind: "body", rowIndex: nextSelection.rowIndex, cellIndexes };
+    });
+  };
+
+  const updateHeaderCell = (cellIndex: number, content: string) => {
+    updateState((current) => ({
+      ...current,
+      headerCells: current.headerCells.map((cell, index) =>
+        index === cellIndex ? { ...cell, content } : cell,
+      ),
+    }));
+  };
+
+  const updateBodyCell = (rowIndex: number, cellIndex: number, content: string) => {
+    updateState((current) => ({
+      ...current,
+      rowCells: current.rowCells.map((row, currentRowIndex) =>
+        currentRowIndex === rowIndex
+          ? row.map((cell, currentCellIndex) =>
+              currentCellIndex === cellIndex ? { ...cell, content } : cell,
+            )
+          : row,
+      ),
+    }));
+  };
+
+  const addColumn = () => {
+    updateState((current) => ({
+      ...current,
+      headerCells: current.hasHeaderRow
+        ? [...current.headerCells, createEmptyTableCell()]
+        : current.headerCells,
+      rowCells: current.rowCells.map((row) => [...row, createEmptyTableCell()]),
+    }));
+    setSelection(null);
+  };
+
+  const addRow = () => {
+    updateState((current) => ({
+      ...current,
+      rowCells: [...current.rowCells, createEmptyTableRow(columnCount)],
+    }));
+    setSelection(null);
+  };
+
+  const toggleHeaderRow = () => {
+    updateState((current) => ({
+      ...current,
+      hasHeaderRow: !current.hasHeaderRow,
+      headerCells: current.hasHeaderRow
+        ? []
+        : createEmptyTableRow(getTableColumnCount([], current.rowCells)),
+    }));
+    setSelection(null);
+  };
+
+  const selectedRow =
+    selection == null
+      ? null
+      : selection.kind === "header"
+        ? tableState.headerCells
+        : tableState.rowCells[selection.rowIndex] ?? null;
+  const selectedIndexes = selection ? getSortedUniqueIndexes(selection.cellIndexes) : [];
+  const hasConnectAction =
+    selectedRow != null &&
+    selectedIndexes.length > 1 &&
+    selectedIndexes.every((cellIndex, index) => {
+      const cell = selectedRow[cellIndex];
+      const previousIndex = selectedIndexes[index - 1];
+
+      return (
+        cell != null &&
+        (cell.colspan ?? 1) === 1 &&
+        (previousIndex == null || cellIndex === previousIndex + 1)
+      );
+    });
+  const hasCancelConnectAction =
+    selectedRow != null &&
+    selectedIndexes.length === 1 &&
+    ((selectedRow[selectedIndexes[0] ?? -1]?.colspan ?? 1) > 1);
+
+  const connectSelection = () => {
+    if (!selection || !hasConnectAction) {
+      return;
+    }
+
+    if (selection.kind === "header") {
+      updateState((current) => ({
+        ...current,
+        headerCells: connectCells(current.headerCells, selection.cellIndexes),
+      }));
+      setSelection({
+        kind: "header",
+        cellIndexes: [Math.min(...selection.cellIndexes)],
+      });
+      return;
+    }
+
+    updateState((current) => ({
+      ...current,
+      rowCells: current.rowCells.map((row, rowIndex) =>
+        rowIndex === selection.rowIndex ? connectCells(row, selection.cellIndexes) : row,
+      ),
+    }));
+    setSelection({
+      kind: "body",
+      rowIndex: selection.rowIndex,
+      cellIndexes: [Math.min(...selection.cellIndexes)],
+    });
+  };
+
+  const cancelConnectedSelection = () => {
+    if (!selection || !hasCancelConnectAction) {
+      return;
+    }
+
+    const selectedIndex = selection.cellIndexes[0];
+
+    if (selectedIndex == null) {
+      return;
+    }
+
+    if (selection.kind === "header") {
+      updateState((current) => ({
+        ...current,
+        headerCells: cancelConnectedCell(current.headerCells, selectedIndex),
+      }));
+      setSelection({
+        kind: "header",
+        cellIndexes: createSelectionRange(
+          selectedIndex,
+          selectedIndex + ((tableState.headerCells[selectedIndex]?.colspan ?? 1) - 1),
+        ),
+      });
+      return;
+    }
+
+    const selectedRowCell = tableState.rowCells[selection.rowIndex]?.[selectedIndex];
+    const colspan = selectedRowCell?.colspan ?? 1;
+
+    updateState((current) => ({
+      ...current,
+      rowCells: current.rowCells.map((row, rowIndex) =>
+        rowIndex === selection.rowIndex ? cancelConnectedCell(row, selectedIndex) : row,
+      ),
+    }));
+    setSelection({
+      kind: "body",
+      rowIndex: selection.rowIndex,
+      cellIndexes: createSelectionRange(selectedIndex, selectedIndex + (colspan - 1)),
+    });
+  };
+
+  const submitTable = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const normalizedState = normalizeTableEditorState(tableState);
+    const headerCells = normalizedState.hasHeaderRow ? normalizedState.headerCells : null;
+    const rowCells = normalizedState.rowCells;
+
+    onSave({
+      headerCells,
+      headers: headerCells ? headerCells.map((cell) => cell.content.trim()) : null,
+      rowCells,
+      rows: toLegacyTableArrays(rowCells),
+      tableWidth: normalizedState.tableWidth ? Number(normalizedState.tableWidth) : null,
+    });
+  };
+
+  return (
+    <form className="grid gap-4" onSubmit={submitTable}>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="grid gap-2 text-sm font-semibold text-text-strong">
+          Table width
+          <input
+            className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
+            min="1"
+            onChange={(event) =>
+              setTableState((current) => ({
+                ...current,
+                tableWidth: event.target.value,
+              }))
+            }
+            type="number"
+            value={tableState.tableWidth}
+          />
+        </label>
+        <button
+          className="rounded-xl border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong"
+          onClick={toggleHeaderRow}
+          type="button"
+        >
+          {tableState.hasHeaderRow ? "Remove header row" : "Add header row"}
+        </button>
+        <button
+          className="rounded-xl border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong"
+          onClick={addRow}
+          type="button"
+        >
+          + Row
+        </button>
+        <button
+          className="rounded-xl border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong"
+          onClick={addColumn}
+          type="button"
+        >
+          + Column
+        </button>
+        {hasConnectAction ? (
+          <button
+            className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-semibold text-text-strong"
+            onClick={connectSelection}
+            type="button"
+          >
+            + Connect
+          </button>
+        ) : null}
+        {hasCancelConnectAction ? (
+          <button
+            className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-semibold text-text-strong"
+            onClick={cancelConnectedSelection}
+            type="button"
+          >
+            + Cancel connect
+          </button>
+        ) : null}
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
+        <table
+          className="min-w-full border-collapse text-left text-sm"
+          style={tableState.tableWidth ? { width: `${tableState.tableWidth}px` } : undefined}
+        >
+          {tableState.hasHeaderRow ? (
+            <thead>
+              <tr>
+                {tableState.headerCells.map((cell, cellIndex) => (
+                  <th
+                    className={`min-w-40 border-b border-stroke-subtle bg-surface-muted/60 align-top ${
+                      isSelectedCell({ kind: "header", cellIndexes: [cellIndex] })
+                        ? "ring-2 ring-text-strong/20 ring-inset"
+                        : ""
+                    }`}
+                    colSpan={cell.colspan ?? 1}
+                    key={`header-${cellIndex}`}
+                  >
+                    <div className="grid gap-2 p-3">
+                      <label className="grid gap-1 text-xs font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Header {cellIndex + 1}
+                        <input
+                          aria-label={`Header cell ${cellIndex + 1}`}
+                          className="rounded-lg border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-normal text-text-strong"
+                          onClick={(event) =>
+                            selectCell({ kind: "header", cellIndex }, event.shiftKey)
+                          }
+                          onChange={(event) => updateHeaderCell(cellIndex, event.target.value)}
+                          value={cell.content}
+                        />
+                      </label>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+          ) : null}
+          <tbody>
+            {tableState.rowCells.map((row, rowIndex) => (
+              <tr key={`row-${rowIndex}`}>
+                {row.map((cell, cellIndex) => (
+                  <td
+                    className={`min-w-40 border-b border-stroke-subtle align-top ${
+                      isSelectedCell({ kind: "body", rowIndex, cellIndexes: [cellIndex] })
+                        ? "bg-surface-muted/40 ring-2 ring-text-strong/15 ring-inset"
+                        : ""
+                    }`}
+                    colSpan={cell.colspan ?? 1}
+                    key={`row-${rowIndex}-cell-${cellIndex}`}
+                  >
+                    <div className="p-3">
+                      <input
+                        aria-label={`Row ${rowIndex + 1} cell ${cellIndex + 1}`}
+                        className="w-full rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm font-normal text-text-strong outline-none transition focus:border-stroke-subtle focus:bg-surface-base"
+                        onClick={(event) =>
+                          selectCell({ kind: "body", rowIndex, cellIndex }, event.shiftKey)
+                        }
+                        onChange={(event) =>
+                          updateBodyCell(rowIndex, cellIndex, event.target.value)
+                        }
+                        placeholder="Value"
+                        value={cell.content}
+                      />
+                    </div>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <WikiFormActions onCancel={onCancel} />
+    </form>
+  );
+}
 
 function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
   const editorLabelId = `wiki-text-label-${block.blockIdentifier}`;
@@ -300,13 +858,7 @@ export function WikiBlockForm({
         </form>
       );
     case "table":
-      return (
-        <form onSubmit={(event) => submit(event, (data) => ({ headers: getLines(data, "headers"), rows: getLines(data, "rows").map((row) => row.split(",").map((cell) => cell.trim())) }))}>
-          <label className="grid gap-2 text-sm font-semibold text-text-strong">Headers<textarea className="min-h-20 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={(block.headers ?? []).join("\n")} name="headers" /></label>
-          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Rows<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.rows.map((row) => row.join(", ")).join("\n")} name="rows" /></label>
-          <WikiFormActions onCancel={onCancel} />
-        </form>
-      );
+      return <WikiTableBlockForm block={block} onCancel={onCancel} onSave={onSave} />;
     case "profile_card_list":
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ title: getString(data, "title") || null, wikiIdentifiers: getLines(data, "wikiIdentifiers") }))}>

--- a/src/components/Wiki/WikiCodeEditor/index.tsx
+++ b/src/components/Wiki/WikiCodeEditor/index.tsx
@@ -5,6 +5,7 @@ import { cardSurfaceMutedStyle, cardSurfaceStyle } from "../styles";
 type WikiCodeEditorProps = {
   code: string;
   errorMessage: string | null;
+  warnings: string[];
   onChange: (value: string) => void;
   onClear: () => void;
 };
@@ -12,6 +13,7 @@ type WikiCodeEditorProps = {
 export function WikiCodeEditor({
   code,
   errorMessage,
+  warnings,
   onChange,
   onClear,
 }: WikiCodeEditorProps) {
@@ -29,11 +31,11 @@ export function WikiCodeEditor({
           <p className="max-w-3xl text-sm text-text-muted">
             Edit the whole section tree with headings like
             {" "}
-            <code>= Overview =</code>
+            <code>== Overview ==</code>
             {" "}
             and
             {" "}
-            <code>== Style ==</code>
+            <code>=== Style ===</code>
             .
           </p>
         </div>
@@ -58,13 +60,30 @@ export function WikiCodeEditor({
           {errorMessage}
         </div>
       ) : (
-        <div
-          className="mt-4 rounded-2xl border border-stroke-subtle px-4 py-3 text-sm text-text-muted"
-          style={cardSurfaceMutedStyle}
-        >
-          Supported blocks: plain text, quotes with <code>&gt;</code>, lists, tables,
-          and structured macros for image, gallery, embed, and profiles.
-        </div>
+        <>
+          <div
+            className="mt-4 rounded-2xl border border-stroke-subtle px-4 py-3 text-sm text-text-muted"
+            style={cardSurfaceMutedStyle}
+          >
+            Supported blocks: plain text, quotes with <code>&gt;</code>, lists, tables,
+            and structured macros for image, gallery, embed, and profiles.
+          </div>
+          {warnings.length > 0 ? (
+            <div
+              className="mt-4 rounded-2xl border border-status-warning/30 px-4 py-3 text-sm text-text-strong"
+              data-testid="wiki-code-warnings"
+              role="status"
+              style={cardSurfaceMutedStyle}
+            >
+              <p className="font-semibold text-status-warning">Compatibility notes</p>
+              <ul className="mt-2 list-disc pl-5">
+                {warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </>
       )}
 
       <label className="mt-4 grid gap-2 text-sm font-semibold text-text-strong">

--- a/src/components/Wiki/editing.test.ts
+++ b/src/components/Wiki/editing.test.ts
@@ -102,9 +102,36 @@ describe("parseInlineMarkdown", () => {
     ]);
   });
 
+  it("parses supported namuwiki inline syntax", () => {
+    expect(
+      parseInlineMarkdown(
+        "[[문서|대표 문서]] [* 주석 예시] [include(틀:Discography)] [br]next",
+      ),
+    ).toEqual([
+      {
+        children: [{ kind: "text", text: "대표 문서" }],
+        href: "/wiki/%EB%AC%B8%EC%84%9C",
+        kind: "link",
+      },
+      { kind: "text", text: " " },
+      { content: "주석 예시", kind: "footnote" },
+      { kind: "text", text: " " },
+      { kind: "include", target: "틀:Discography" },
+      { kind: "text", text: " " },
+      { kind: "text", text: "\n" },
+      { kind: "text", text: "next" },
+    ]);
+  });
+
   it("keeps invalid markdown as plain text", () => {
     expect(parseInlineMarkdown("Broken [link](not a url")).toEqual([
       { kind: "text", text: "Broken [link](not a url" },
+    ]);
+  });
+
+  it("keeps category syntax as plain text for now", () => {
+    expect(parseInlineMarkdown("[[분류:테스트]]")).toEqual([
+      { kind: "text", text: "[[분류:테스트]]" },
     ]);
   });
 });

--- a/src/components/Wiki/editing.ts
+++ b/src/components/Wiki/editing.ts
@@ -58,7 +58,9 @@ export type InlineMarkdownToken =
   | { kind: "strong"; children: InlineMarkdownToken[] }
   | { kind: "emphasis"; children: InlineMarkdownToken[] }
   | { kind: "strikethrough"; children: InlineMarkdownToken[] }
-  | { kind: "link"; children: InlineMarkdownToken[]; href: string };
+  | { kind: "link"; children: InlineMarkdownToken[]; href: string }
+  | { kind: "footnote"; content: string }
+  | { kind: "include"; target: string };
 
 const markdownWrapMap: Record<Exclude<InlineMarkdownFormat, "link">, string> = {
   bold: "**",
@@ -164,6 +166,100 @@ const parseLinkToken = (content: string, startIndex: number): { node: InlineMark
   };
 };
 
+const parseNamuLinkToken = (
+  content: string,
+  startIndex: number,
+): { node: InlineMarkdownToken; nextIndex: number } | null => {
+  if (!content.startsWith("[[", startIndex)) {
+    return null;
+  }
+
+  const endIndex = content.indexOf("]]", startIndex + 2);
+
+  if (endIndex < 0) {
+    return null;
+  }
+
+  const rawValue = content.slice(startIndex + 2, endIndex).trim();
+
+  if (!rawValue || rawValue.startsWith("분류:") || rawValue.startsWith("파일:")) {
+    return null;
+  }
+
+  const [target, display = target] = rawValue.split("|");
+
+  if (!target?.trim()) {
+    return null;
+  }
+
+  return {
+    nextIndex: endIndex + 2,
+    node: {
+      children: parseInlineMarkdown(display.trim()),
+      href: `/wiki/${encodeURIComponent(target.trim())}`,
+      kind: "link",
+    },
+  };
+};
+
+const parseFootnoteToken = (
+  content: string,
+  startIndex: number,
+): { node: InlineMarkdownToken; nextIndex: number } | null => {
+  if (!content.startsWith("[*", startIndex)) {
+    return null;
+  }
+
+  const endIndex = content.indexOf("]", startIndex + 2);
+
+  if (endIndex < 0) {
+    return null;
+  }
+
+  const rawValue = content.slice(startIndex + 2, endIndex).trim();
+
+  if (!rawValue) {
+    return null;
+  }
+
+  return {
+    nextIndex: endIndex + 1,
+    node: {
+      content: rawValue,
+      kind: "footnote",
+    },
+  };
+};
+
+const parseIncludeToken = (
+  content: string,
+  startIndex: number,
+): { node: InlineMarkdownToken; nextIndex: number } | null => {
+  if (!content.startsWith("[include(", startIndex)) {
+    return null;
+  }
+
+  const endIndex = content.indexOf(")]", startIndex + 9);
+
+  if (endIndex < 0) {
+    return null;
+  }
+
+  const rawValue = content.slice(startIndex + 9, endIndex).trim();
+
+  if (!rawValue) {
+    return null;
+  }
+
+  return {
+    nextIndex: endIndex + 2,
+    node: {
+      kind: "include",
+      target: rawValue,
+    },
+  };
+};
+
 const parseWrappedToken = (
   content: string,
   startIndex: number,
@@ -203,6 +299,16 @@ export const parseInlineMarkdown = (content: string): InlineMarkdownToken[] => {
   while (cursor < content.length) {
     const slice = content.slice(cursor);
     const token =
+      (slice.startsWith("[[") && parseNamuLinkToken(content, cursor)) ||
+      (slice.startsWith("[*") && parseFootnoteToken(content, cursor)) ||
+      (slice.startsWith("[include(") && parseIncludeToken(content, cursor)) ||
+      (slice.startsWith("[br]") && {
+        nextIndex: cursor + 4,
+        node: {
+          kind: "text" as const,
+          text: "\n",
+        },
+      }) ||
       (slice.startsWith("**") && parseWrappedToken(content, cursor, "**", "strong")) ||
       (slice.startsWith("~~") && parseWrappedToken(content, cursor, "~~", "strikethrough")) ||
       (slice.startsWith("_") && parseWrappedToken(content, cursor, "_", "emphasis")) ||
@@ -258,6 +364,10 @@ const inlineTokensToHtml = (tokens: InlineMarkdownToken[]): string =>
           return `<del>${inlineTokensToHtml(token.children)}</del>`;
         case "link":
           return `<a href="${escapeHtml(token.href)}">${inlineTokensToHtml(token.children)}</a>`;
+        case "footnote":
+          return `<sup title="${escapeHtml(token.content)}">[*]</sup>`;
+        case "include":
+          return `<span>[include(${escapeHtml(token.target)})]</span>`;
       }
     })
     .join("");

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -88,15 +88,15 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(page.getByTestId("wiki-code-editor")).toBeVisible();
   await page.getByLabel("Wiki code").fill(
     [
-      "= Overview =",
+      "== Overview ==",
       "",
       "Updated overview from code mode.",
       "",
-      "== Style Guide ==",
+      "=== Style Guide ===",
       "",
       "A new nested section.",
       "",
-      "= Members =",
+      "== Members ==",
       "",
       "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
     ].join("\n"),
@@ -106,14 +106,36 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(page.getByText("Updated overview from code mode.")).toBeVisible();
 
   await page.getByRole("button", { name: "code" }).click();
-  await page.getByLabel("Wiki code").fill("= Overview =\n\n[[image|id:cover]");
+  await page.getByLabel("Wiki code").fill("== Overview ==\n\n[[image|id:cover]");
   await expect(page.getByTestId("wiki-code-error")).toBeVisible();
   await expect(page.getByRole("button", { name: "Save wiki changes" })).toBeDisabled();
   page.once("dialog", (dialog) => dialog.accept());
   await page.getByRole("button", { name: "Clear wiki changes" }).click();
   await expect(page.getByTestId("wiki-code-error")).toHaveCount(0);
-  await expect(page.getByLabel("Wiki code")).toHaveValue(/= Overview =/);
+  await expect(page.getByLabel("Wiki code")).toHaveValue(/== Overview ==/);
+
+  await page.getByLabel("Wiki code").fill(
+    [
+      "== Overview ==",
+      "",
+      "[[문서|대표 문서]]",
+      "",
+      "[[분류:테스트]]",
+      "",
+      "[* 주석 예시]",
+      "",
+      "[include(틀:Discography)]",
+    ].join("\n"),
+  );
   await page.getByRole("button", { name: "gui" }).click();
+  await expect(page.locator("a", { hasText: "대표 문서" })).toHaveAttribute(
+    "href",
+    "/wiki/%EB%AC%B8%EC%84%9C",
+  );
+  await expect(page.getByLabel("Footnote: 주석 예시")).toBeVisible();
+  await expect(page.getByText("Included from 틀:Discography")).toBeVisible();
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Clear wiki changes" }).click();
   await page.getByRole("button", { name: "Collapse editor sidebar" }).click();
 
   const overviewAddControls = page.getByTestId("wiki-edit-add-section-sec-overview");
@@ -170,4 +192,63 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(
     page.getByTestId("wiki-edit-add-section-sec-discography-highlights-chart"),
   ).toContainText("Max depth reached");
+});
+
+test("wiki edit page exposes the TWICE namuwiki compatibility demo mock", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/wiki/twice/edit");
+
+  await expect(page.getByRole("heading", { name: "TWICE", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "code" }).click();
+  await expect(page.getByTestId("wiki-code-warnings")).toHaveCount(0);
+  await expect(page.getByLabel("Wiki code")).toHaveValue(/== Overview ==/);
+  await expect(page.getByLabel("Wiki code")).toHaveValue(/\[\[나연\(TWICE\)\|나연\]\]/);
+  await page.getByRole("button", { name: "gui" }).click();
+  await expect(page.locator('a[href="/wiki/%EB%82%98%EC%97%B0(TWICE)"]')).toHaveCount(1);
+  await expect(page.locator('a[href="/wiki/nayeon-twice"]')).toHaveAttribute(
+    "href",
+    "/wiki/nayeon-twice",
+  );
+  await expect(page.getByLabel("Footnote: 오디션 프로그램 SIXTEEN을 통해 결성되었다.")).toBeVisible();
+  await expect(page.getByText("Included from 틀:TWICE/음반")).toBeVisible();
+  await expect(page.getByTitle("YouTube embed: TWICE \"CHEER UP\" M/V")).toHaveAttribute(
+    "src",
+    "https://www.youtube-nocookie.com/embed/c7rCyll5AeY",
+  );
+  await expect(page.locator('a[href="/wiki/momo-twice"]')).toHaveAttribute("href", "/wiki/momo-twice");
+});
+
+test("twice member profile cards open the member wiki pages", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/wiki/twice/edit");
+
+  await page.locator('a[href="/wiki/nayeon-twice"]').click();
+  await expect(page).toHaveURL(/\/wiki\/nayeon-twice$/);
+  await expect(page.getByRole("heading", { name: "나연" })).toBeVisible();
+  await page.getByTestId("section-toggle-sec-nayeon-twice-overview").click({ force: true });
+  await expect(page.getByText(/TWICE의 맏언니이자 리드보컬 포지션/)).toBeVisible();
+});
+
+test("wiki edit page converts supported media includes into embeds", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/wiki/aurora-echo/edit");
+
+  await page.getByRole("button", { name: "code" }).click();
+  await page.getByLabel("Wiki code").fill(
+    [
+      "== Overview ==",
+      "",
+      "[include(틀:영상 정렬, url=jNQXAC9IVRw)]",
+    ].join("\n"),
+  );
+  await page.getByRole("button", { name: "gui" }).click();
+
+  await expect(page.getByTitle("YouTube embed")).toHaveAttribute(
+    "src",
+    "https://www.youtube-nocookie.com/embed/jNQXAC9IVRw",
+  );
 });


### PR DESCRIPTION
## 📝 変更内容

- Wiki コードモードでナムウィキ互換の見出し深度、インライン 링크、脚注、include 記法を扱えるようにした
- テーブルを `headerCells` / `rowCells` / `tableWidth` を持つ構造化データとして編集・表示・シリアライズできるようにした
- GUI エディタで表現しきれない構文に対して互換警告を表示し、モックデータと単体/E2E テストを拡充した

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

- 既存のコードモードはナムウィキ系の記法を十分に扱えず、見出し深度やリンク、include、テーブル装飾のあるデータを GUI と相互変換すると情報が落ちやすかった
- Wiki 編集体験を維持したまま、外部由来のナムウィキ記法を読み書きしやすくする必要があった

## 🧪 テスト

### テストの実行確認

- [ ] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [ ] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

### 動作確認

- コードモードで `==` / `===` 見出しがセクション深度に正しくマッピングされること
- `[[...]]` リンク、`[* ...]` 脚注、`[include(...)]` が表示系・コード系で崩れないこと
- テーブルの列追加、行追加、ヘッダー切り替え、セル結合/解除がフォーム上で行えること

## 🔍 レビューのポイント

- `packages/wiki/src/wikiEditModel.ts` のコードモード変換で、ナムウィキ互換構文の parse / serialize が意図通り往復できるか
- `src/components/Wiki/WikiBlockForm/index.tsx` のテーブル編集 UI が merged cell と旧 `rows` / `headers` 互換を保てているか
- `src/components/Wiki/WikiBlockDisplay/index.tsx` と `src/components/Wiki/WikiCodeEditor/index.tsx` の互換表示・警告表示が UX 的に妥当か

## 📖 関連情報

### 関連Issue・タスク

Closes #42

## ⚠️ 注意事項

- `task check` と `pnpm build` の実行結果は未確認
- `.codex/tmp/` と `public/kpool.ico` の未追跡ファイルは今回の PR に含めていない

---

## チェックリスト

- [ ] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [ ] 破壊的変更がある場合は適切に文書化した
