### PR TITLE
Wikiドラフト保存APIを接続する

### DIFF
--- a/packages/types/src/wiki-private-api.ts
+++ b/packages/types/src/wiki-private-api.ts
@@ -374,7 +374,16 @@ const TalentDraftWikiDetail = z
   })
   .passthrough();
 const WikiWorkflowRequestBody = WikiAssociationTargets;
-const UpdateWikiDraftRequestBody = WikiAssociationTargets;
+const UpdateWikiDraftRequestBody = WikiAssociationTargets.and(
+  z
+    .object({
+      resourceType: z.string(),
+      basic: z.record(z.unknown()),
+      sections: z.array(z.unknown()).optional(),
+      themeColor: z.string().nullable().optional(),
+    })
+    .passthrough(),
+);
 const PublishWikiRequestBody = WikiAssociationTargets;
 const PublishedWikiSummary = z
   .object({

--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -8,6 +8,7 @@ import {
   getWikiContentEditorId,
   parseWikiSectionsFromCode,
   serializeWikiSectionsToCode,
+  toWikiEditRequestPayload,
   toWikiSectionContentPayload,
   updateWikiBlock,
   updateWikiSection,
@@ -123,6 +124,24 @@ describe("wikiEditModel", () => {
         }),
       ]),
     );
+  });
+
+  it("creates the EditWiki request body without legacy top-level snake_case fields", () => {
+    const wiki = createMockWikiDetail("gr-aurora-echo", {
+      themeColor: "#4c5cff",
+    });
+
+    const payload = toWikiEditRequestPayload(wiki);
+
+    expect(payload).toEqual({
+      resourceType: "group",
+      basic: wiki.basic,
+      sections: toWikiSectionContentPayload(wiki.sections),
+      themeColor: "#4c5cff",
+    });
+    expect(payload).not.toHaveProperty("wiki_identifier");
+    expect(payload).not.toHaveProperty("theme_color");
+    expect(payload).not.toHaveProperty("contents");
   });
 
   it("creates stable editor ids for sections and blocks", () => {

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -55,6 +55,13 @@ export type WikiEditPayload = {
   contents: WikiSectionContentPayload[];
 };
 
+export type WikiEditRequestPayload = {
+  resourceType: WikiDetail["resourceType"];
+  basic: WikiDetail["basic"];
+  sections: WikiSectionContentPayload[];
+  themeColor: string | null;
+};
+
 export type WikiCodeParseResult =
   | {
       ok: true;
@@ -1327,6 +1334,13 @@ export const toWikiEditPayload = (wiki: WikiDetail): WikiEditPayload => ({
   hero_image: wiki.heroImage,
   basic: wiki.basic,
   contents: toWikiSectionContentPayload(wiki.sections),
+});
+
+export const toWikiEditRequestPayload = (wiki: WikiDetail): WikiEditRequestPayload => ({
+  resourceType: wiki.resourceType,
+  basic: wiki.basic,
+  sections: toWikiSectionContentPayload(wiki.sections),
+  themeColor: wiki.themeColor ?? null,
 });
 
 const toWikiContentPayload = (

--- a/src/app/api/wiki/drafts/[wikiId]/route.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  createDraftWikiApiClient,
+  getDraftWikiErrorMessage,
+  saveDraftWiki,
+} from "../../../../wiki/draftWiki";
+
+type WikiDraftSaveRouteContext = {
+  params: Promise<{
+    wikiId: string;
+  }>;
+};
+
+export async function POST(request: NextRequest, context: WikiDraftSaveRouteContext) {
+  const client = createDraftWikiApiClient();
+
+  if (!client) {
+    return NextResponse.json(
+      { message: "Wiki draft API is not configured." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const { wikiId } = await context.params;
+    const body = await request.json();
+    const result = await saveDraftWiki(client, wikiId, body);
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { message: getDraftWikiErrorMessage(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -19,6 +19,7 @@ import {
 import { getWikiResourceLabel, type WikiResourceType } from "../../wikiRouting";
 import { buildWikiThemeCssVariables } from "../wikiThemePalette";
 import { type loadDraftWikiState } from "../../draftWiki";
+import { saveWikiDraft, type WikiSaveResult } from "./saveWikiDraft";
 import { useWikiEditDraft } from "./useWikiEditDraft";
 
 type WikiEditPageProps = {
@@ -26,9 +27,18 @@ type WikiEditPageProps = {
   slug: string;
   themeColor?: string;
   wikiState: Awaited<ReturnType<typeof loadDraftWikiState>>;
+  saveAdapter?: (draft: WikiDetail) => Promise<WikiSaveResult>;
 };
 
-function WikiEditContent({ data, language }: { data: WikiDetail; language: string }) {
+function WikiEditContent({
+  data,
+  language,
+  saveAdapter,
+}: {
+  data: WikiDetail;
+  language: string;
+  saveAdapter: (draft: WikiDetail) => Promise<WikiSaveResult>;
+}) {
   const flipCardId = useId();
   const [isBasicFlipped, setIsBasicFlipped] = useState(false);
   const [editorMode, setEditorMode] = useState<WikiEditorMode>("gui");
@@ -55,7 +65,7 @@ function WikiEditContent({ data, language }: { data: WikiDetail; language: strin
     addSection,
     addBlock,
     deleteContent,
-  } = useWikiEditDraft(data);
+  } = useWikiEditDraft(data, { saveAdapter });
   const resourceLabel = getWikiResourceLabel(draft.resourceType as WikiResourceType);
   const themeStyles = buildWikiThemeCssVariables(draft.themeColor);
   const themeLabel = draft.themeColor?.toUpperCase();
@@ -94,6 +104,14 @@ function WikiEditContent({ data, language }: { data: WikiDetail; language: strin
             <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
               {draft.basic.name}
             </h1>
+            {saveState.showMessage ? (
+              <p
+                className="mt-3 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"
+                data-testid="wiki-edit-save-state"
+              >
+                {saveState.message}
+              </p>
+            ) : null}
           </div>
         </header>
 
@@ -217,7 +235,12 @@ function WikiEditContent({ data, language }: { data: WikiDetail; language: strin
   );
 }
 
-export function WikiEditPage({ language, themeColor, wikiState }: WikiEditPageProps) {
+export function WikiEditPage({
+  language,
+  themeColor,
+  wikiState,
+  saveAdapter = saveWikiDraft,
+}: WikiEditPageProps) {
   if (wikiState.status === "error") {
     return <WikiStatePanel message={wikiState.message} title="Unable to load wiki" tone="danger" />;
   }
@@ -238,6 +261,7 @@ export function WikiEditPage({ language, themeColor, wikiState }: WikiEditPagePr
         themeColor: themeColor ?? wikiState.data.themeColor,
       }}
       language={language}
+      saveAdapter={saveAdapter}
     />
   );
 }

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createMockWikiDetail } from "@kpool/wiki";
@@ -18,10 +18,12 @@ const renderPage = (
   } | {
     status: "empty";
   } = successState,
+  saveAdapter = vi.fn().mockResolvedValue({ ok: true }),
 ) =>
   render(
     React.createElement(WikiEditPage, {
       language: "ja",
+      saveAdapter,
       slug: "gr-aurora-echo",
       wikiState,
     }),
@@ -187,6 +189,48 @@ describe("WikiEditPage", () => {
     );
 
     confirmSpy.mockRestore();
+  });
+
+  it("saves the loaded draft through the injected save adapter", async () => {
+    const saveAdapter = vi.fn().mockResolvedValue({ ok: true });
+
+    renderPage(successState, saveAdapter);
+
+    fireEvent.change(screen.getByLabelText("Slug"), {
+      target: { value: "custom-title" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
+
+    expect(screen.getByText("Saving changes")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Saved")).toBeInTheDocument());
+    expect(saveAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: "gr-custom-title",
+        wikiIdentifier: "gr-aurora-echo",
+      }),
+    );
+  });
+
+  it("shows save failure and allows retrying", async () => {
+    const saveAdapter = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+
+    renderPage(successState, saveAdapter);
+
+    fireEvent.change(screen.getByLabelText("Slug"), {
+      target: { value: "retry-title" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
+
+    await waitFor(() => expect(screen.getByText("Save failed")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
+
+    await waitFor(() => expect(screen.getByText("Saved")).toBeInTheDocument());
+    expect(saveAdapter).toHaveBeenCalledTimes(2);
   });
 
   it("shows compatibility warnings for namuwiki syntax that falls back to text blocks", () => {

--- a/src/app/wiki/[slug]/edit/saveWikiDraft.ts
+++ b/src/app/wiki/[slug]/edit/saveWikiDraft.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import {
+  toWikiEditRequestPayload,
+  type WikiDetail,
+  type WikiEditRequestPayload,
+} from "@kpool/wiki";
+
+export type WikiSaveResult = { ok: true } | { ok: false };
+
+export const saveWikiDraft = async (draft: WikiDetail): Promise<WikiSaveResult> => {
+  const response = await fetch(
+    `/api/wiki/drafts/${encodeURIComponent(draft.wikiIdentifier)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(toWikiEditRequestPayload(draft)),
+    },
+  );
+
+  return response.ok ? { ok: true } : { ok: false };
+};
+
+export const createSaveWikiDraftBody = (
+  draft: WikiDetail,
+): WikiEditRequestPayload => toWikiEditRequestPayload(draft);

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -28,33 +28,39 @@ type WikiSaveState =
       status: "dirty";
       message: string;
       payload: WikiEditPayload;
+      showMessage: boolean;
     }
   | {
       status: "saved";
       message: string;
       payload: WikiEditPayload;
+      showMessage: boolean;
     }
   | {
       status: "saving";
       message: string;
       payload: WikiEditPayload;
+      showMessage: boolean;
     }
   | {
       status: "submitting";
       message: string;
       payload: WikiEditPayload;
+      showMessage: boolean;
     }
   | {
       status: "failed";
       message: string;
       payload: WikiEditPayload;
+      showMessage: boolean;
     };
 
 type WikiEditDraftOptions = {
-  saveAdapter?: (payload: WikiEditPayload) => { ok: true } | { ok: false };
+  saveAdapter?: (draft: WikiDetail) => Promise<{ ok: true } | { ok: false }>;
   submitAdapter?: (payload: WikiEditPayload) => { ok: true } | { ok: false };
 };
 
+const optimisticSaveAdapter = async () => ({ ok: true }) as const;
 const optimisticActionAdapter = () => ({ ok: true }) as const;
 
 const createInitialDraft = (wiki: WikiDetail): WikiDetail => ({
@@ -88,8 +94,9 @@ export const useWikiEditDraft = (
     status: "saved",
     message: "Saved",
     payload: toWikiEditPayload(initialDraft),
+    showMessage: false,
   });
-  const saveAdapter = options?.saveAdapter ?? optimisticActionAdapter;
+  const saveAdapter = options?.saveAdapter ?? optimisticSaveAdapter;
   const submitAdapter = options?.submitAdapter ?? optimisticActionAdapter;
 
   const commitDraft = (nextDraft: WikiDetail, nextCode = getCodeFromSections(nextDraft.sections)) => {
@@ -104,27 +111,37 @@ export const useWikiEditDraft = (
       status: "dirty",
       message: "Unsaved changes",
       payload,
+      showMessage: true,
     });
   };
 
-  const saveDraft = () => {
+  const saveDraft = async () => {
     const payload = toWikiEditPayload(draft);
 
     setSaveState({
       status: "saving",
       message: "Saving changes",
       payload,
+      showMessage: true,
     });
 
-    queueMicrotask(() => {
-      const result = saveAdapter(payload);
+    try {
+      const result = await saveAdapter(draft);
 
       setSaveState({
         status: result.ok ? "saved" : "failed",
         message: result.ok ? "Saved" : "Save failed",
         payload,
+        showMessage: true,
       });
-    });
+    } catch {
+      setSaveState({
+        status: "failed",
+        message: "Save failed",
+        payload,
+        showMessage: true,
+      });
+    }
   };
 
   const clearDraft = () => {
@@ -137,6 +154,7 @@ export const useWikiEditDraft = (
       status: "saved",
       message: "Saved",
       payload: toWikiEditPayload(initialDraft),
+      showMessage: false,
     });
   };
 
@@ -147,6 +165,7 @@ export const useWikiEditDraft = (
       status: "submitting",
       message: "Submitting for review",
       payload,
+      showMessage: true,
     });
 
     queueMicrotask(() => {
@@ -156,6 +175,7 @@ export const useWikiEditDraft = (
         status: result.ok ? "saved" : "failed",
         message: result.ok ? "Submitted for review" : "Submit failed",
         payload,
+        showMessage: true,
       });
     });
   };
@@ -183,6 +203,7 @@ export const useWikiEditDraft = (
           status: "dirty",
           message: "Unsaved changes",
           payload: toWikiEditPayload(draft),
+          showMessage: true,
         });
         return;
       }

--- a/src/app/wiki/draftWiki.test.ts
+++ b/src/app/wiki/draftWiki.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   adaptDraftWikiResponse,
@@ -6,6 +6,7 @@ import {
   getDraftWikiAlias,
   getDraftWikiErrorMessage,
   loadDraftWikiState,
+  saveDraftWiki,
 } from "./draftWiki";
 
 describe("draftWiki", () => {
@@ -147,5 +148,34 @@ describe("draftWiki", () => {
         },
       }),
     ).toBe("backend exploded");
+  });
+
+  it("saves a draft wiki with the wiki identifier as the edit path param", async () => {
+    const client = {
+      WikiOperations_editWiki: vi.fn().mockResolvedValue({
+        language: "ja",
+        name: "Aurora Echo",
+        resourceType: "group",
+        status: "draft",
+      }),
+    };
+    const body = {
+      resourceType: "group",
+      basic: { name: "Aurora Echo" },
+      sections: [],
+      themeColor: "#4c5cff",
+    };
+
+    await expect(saveDraftWiki(client as never, "wiki-1", body)).resolves.toEqual({
+      language: "ja",
+      name: "Aurora Echo",
+      resourceType: "group",
+      status: "draft",
+    });
+    expect(client.WikiOperations_editWiki).toHaveBeenCalledWith(body, {
+      params: {
+        wikiId: "wiki-1",
+      },
+    });
   });
 });

--- a/src/app/wiki/draftWiki.ts
+++ b/src/app/wiki/draftWiki.ts
@@ -19,6 +19,8 @@ const draftWikiApiResponseSchema = z.union([
 
 type DraftWikiApiClient = ReturnType<typeof createApiClient>;
 type DraftWikiApiResponse = z.infer<typeof draftWikiApiResponseSchema>;
+type EditWikiRequestBody = z.infer<typeof schemas.UpdateWikiDraftRequestBody>;
+type DraftWikiSummary = z.infer<typeof schemas.DraftWikiSummary>;
 
 type DraftWikiState =
   | { status: "success"; data: WikiDetail }
@@ -226,6 +228,19 @@ export const fetchDraftWiki = async (
 
   return adaptDraftWikiResponse(draftWikiApiResponseSchema.parse(response));
 };
+
+export const saveDraftWiki = async (
+  client: DraftWikiApiClient,
+  wikiId: string,
+  body: EditWikiRequestBody,
+): Promise<DraftWikiSummary> =>
+  schemas.DraftWikiSummary.parse(
+    await client.WikiOperations_editWiki(body, {
+      params: {
+        wikiId,
+      },
+    }),
+  );
 
 export const createDraftWikiApiClient = (
   baseUrl: string = defaultApiBaseUrl ?? "",

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -45,6 +45,22 @@ test("wiki detail page shows the empty state", async ({ page }) => {
 test("wiki edit page supports inline edits and nested content controls", async ({
   page,
 }) => {
+  const saveRequests: unknown[] = [];
+
+  await page.route("**/api/wiki/drafts/*", async (route) => {
+    saveRequests.push(route.request().postDataJSON());
+    await route.fulfill({
+      contentType: "application/json",
+      status: 201,
+      body: JSON.stringify({
+        language: "ja",
+        name: "Aurora Echo",
+        resourceType: "group",
+        status: "draft",
+      }),
+    });
+  });
+
   await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto("/wiki/ja/gr-aurora-echo/edit?themeColor=%234c5cff");
 
@@ -192,6 +208,25 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await expect(
     page.getByTestId("wiki-edit-add-section-sec-discography-highlights-chart"),
   ).toContainText("Max depth reached");
+
+  await page.getByRole("button", { name: "Expand editor sidebar" }).click();
+  await page.getByRole("button", { name: "Save wiki changes" }).click();
+  await expect(page.getByTestId("wiki-edit-save-state")).toHaveText("Saved");
+  expect(saveRequests).toContainEqual(
+    expect.objectContaining({
+      resourceType: "group",
+      themeColor: "#4c5cff",
+      basic: expect.objectContaining({
+        name: "Aurora Echo",
+      }),
+      sections: expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          title: "Overview",
+        }),
+      ]),
+    }),
+  );
 });
 
 test("wiki edit page exposes the TWICE namuwiki compatibility demo mock", async ({


### PR DESCRIPTION
## 📝 変更内容

Wiki編集画面の保存処理をドラフト保存APIに接続しました。

- `/api/wiki/drafts/[wikiId]` の POST ルートを追加
- 編集画面の Save 操作でドラフト保存APIへリクエストする処理を追加
- 保存中 / 保存成功 / 保存失敗の状態表示を追加
- Wiki編集用リクエスト payload を `resourceType`, `basic`, `sections`, `themeColor` 形式に整理
- ドラフト保存処理の unit test と E2E の保存確認を追加
- `UpdateWikiDraftRequestBody` の schema を保存APIの body に合わせて更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki編集画面で編集内容を実際のドラフト保存APIへ送信できるようにするため。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

E2E で Wiki 編集画面の Save 操作が `/api/wiki/drafts/*` に保存 payload を送信し、保存成功状態を表示することを確認。

## 🔍 レビューのポイント

- API route が `wikiIdentifier` を path param として backend の `WikiOperations_editWiki` に渡していること
- 保存 payload から legacy な top-level snake_case field を除外し、backend schema に合わせた形式になっていること
- 保存失敗時に再試行できる UI 状態になっていること

## 📖 関連情報

### 関連Issue・タスク

Closes #45

## ⚠️ 注意事項

環境変数の追加なし。破壊的変更なし。

## 📸 スクリーンショット・デモ

UI 変更は保存状態テキストの表示追加のみ。E2E で保存成功表示を確認済み。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した