### PR TITLE
サインアップ導線と登録フローを追加

### DIFF
--- a/src/app/accountApi.test.ts
+++ b/src/app/accountApi.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getAccountApiBaseUrl,
+  parseCreateAccountResult,
+  withAccountApiPrefix,
+} from "./accountApi";
+
+describe("account API helpers", () => {
+  it("adds the backend account prefix when the base URL omits it", () => {
+    expect(withAccountApiPrefix("http://127.0.0.1:8080")).toBe(
+      "http://127.0.0.1:8080/api/account",
+    );
+    expect(withAccountApiPrefix("http://127.0.0.1:8080/api/account")).toBe(
+      "http://127.0.0.1:8080/api/account",
+    );
+  });
+
+  it("uses the server-only env var for the Account API base URL", () => {
+    expect(getAccountApiBaseUrl({ KPOOL_ACCOUNT_API_BASE_URL: "http://api.test" })).toBe(
+      "http://api.test/api/account",
+    );
+  });
+
+  it("accepts the backend empty array response for an already handled account", () => {
+    expect(parseCreateAccountResult([])).toEqual({});
+  });
+});

--- a/src/app/accountApi.ts
+++ b/src/app/accountApi.ts
@@ -1,0 +1,35 @@
+import { schemas } from "@kpool/types/account-api";
+import { z } from "zod";
+
+export type CreateAccountRequest = z.infer<typeof schemas.CreateAccountRequestBody>;
+export type CreateAccountResult = z.infer<typeof schemas.CreateAccountResult>;
+
+type AccountApiEnv = Record<string, string | undefined>;
+
+const trimTrailingSlashes = (value: string): string => {
+  let trimmedValue = value;
+
+  while (trimmedValue.endsWith("/")) {
+    trimmedValue = trimmedValue.slice(0, -1);
+  }
+
+  return trimmedValue;
+};
+
+export const withAccountApiPrefix = (baseUrl: string): string =>
+  baseUrl.endsWith("/api/account")
+    ? baseUrl
+    : `${trimTrailingSlashes(baseUrl)}/api/account`;
+
+export const getAccountApiBaseUrl = (
+  env: AccountApiEnv = process.env,
+): string | null =>
+  env.KPOOL_ACCOUNT_API_BASE_URL
+    ? withAccountApiPrefix(env.KPOOL_ACCOUNT_API_BASE_URL)
+    : null;
+
+export const parseCreateAccountRequest = (body: unknown): CreateAccountRequest =>
+  schemas.CreateAccountRequestBody.parse(body);
+
+export const parseCreateAccountResult = (body: unknown): CreateAccountResult =>
+  schemas.CreateAccountResult.parse(Array.isArray(body) && body.length === 0 ? {} : body);

--- a/src/app/api/account/accounts/route.ts
+++ b/src/app/api/account/accounts/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import {
+  getAccountApiBaseUrl,
+  parseCreateAccountRequest,
+  parseCreateAccountResult,
+} from "../../../accountApi";
+import { getIdentityRouteErrorMessage } from "../../../identityApi";
+
+const readResponseBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+};
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getAccountApiBaseUrl();
+
+  if (!baseUrl) {
+    return NextResponse.json(
+      { message: "Account API is not configured." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const account = parseCreateAccountRequest(await request.json());
+    const apiResponse = await fetch(`${baseUrl}/accounts`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        ...(request.headers.get("accept-language")
+          ? { "Accept-Language": request.headers.get("accept-language") ?? "" }
+          : {}),
+        "Content-Type": "application/json",
+        ...(request.headers.get("cookie")
+          ? { Cookie: request.headers.get("cookie") ?? "" }
+          : {}),
+      },
+      body: JSON.stringify(account),
+      cache: "no-store",
+    });
+    const body = await readResponseBody(apiResponse);
+
+    if (!apiResponse.ok) {
+      return NextResponse.json(
+        { message: getIdentityRouteErrorMessage({ status: apiResponse.status, data: body }) },
+        { status: apiResponse.status },
+      );
+    }
+
+    return NextResponse.json(parseCreateAccountResult(body), { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Account API response did not match the expected schema." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: getIdentityRouteErrorMessage({ data: error }) },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/identity/auth/register/route.ts
+++ b/src/app/api/identity/auth/register/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import {
+  getIdentityApiBaseUrl,
+  getIdentityRouteErrorMessage,
+  parseCreateIdentityRequest,
+  parseIdentitySummary,
+} from "../../../../identityApi";
+
+const readResponseBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+};
+
+const getSetCookieHeaders = (headers: Headers): string[] => {
+  const headersWithSetCookie = headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  const setCookies = headersWithSetCookie.getSetCookie?.();
+
+  if (setCookies && setCookies.length > 0) {
+    return setCookies;
+  }
+
+  const setCookie = headers.get("set-cookie");
+
+  return setCookie ? [setCookie] : [];
+};
+
+const withSetCookie = (response: NextResponse, apiResponse: Response): NextResponse => {
+  getSetCookieHeaders(apiResponse.headers).forEach((setCookie) => {
+    response.headers.append("set-cookie", setCookie);
+  });
+
+  return response;
+};
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getIdentityApiBaseUrl();
+
+  if (!baseUrl) {
+    return NextResponse.json(
+      { message: "Identity API is not configured." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const identity = parseCreateIdentityRequest(await request.json());
+    const apiResponse = await fetch(`${baseUrl}/auth/register`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        ...(request.headers.get("accept-language")
+          ? { "Accept-Language": request.headers.get("accept-language") ?? "" }
+          : {}),
+        "Content-Type": "application/json",
+        ...(request.headers.get("cookie")
+          ? { Cookie: request.headers.get("cookie") ?? "" }
+          : {}),
+      },
+      body: JSON.stringify(identity),
+      cache: "no-store",
+    });
+    const body = await readResponseBody(apiResponse);
+
+    if (!apiResponse.ok) {
+      return withSetCookie(
+        NextResponse.json(
+          { message: getIdentityRouteErrorMessage({ status: apiResponse.status, data: body }) },
+          { status: apiResponse.status },
+        ),
+        apiResponse,
+      );
+    }
+
+    return withSetCookie(
+      NextResponse.json(parseIdentitySummary(body), { status: 201 }),
+      apiResponse,
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Identity API response did not match the expected schema." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: getIdentityRouteErrorMessage({ data: error }) },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/identity/auth/verify-email/route.ts
+++ b/src/app/api/identity/auth/verify-email/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { z } from "zod";
+
+import {
+  getIdentityApiBaseUrl,
+  getIdentityRouteErrorMessage,
+  parseVerifyEmailRequest,
+  parseVerifyEmailResult,
+} from "../../../../identityApi";
+
+const readResponseBody = async (response: Response): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+};
+
+export async function POST(request: NextRequest) {
+  const baseUrl = getIdentityApiBaseUrl();
+
+  if (!baseUrl) {
+    return NextResponse.json(
+      { message: "Identity API is not configured." },
+      { status: 500 },
+    );
+  }
+
+  try {
+    const verification = parseVerifyEmailRequest(await request.json());
+    const apiResponse = await fetch(`${baseUrl}/auth/verify-email`, {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        ...(request.headers.get("accept-language")
+          ? { "Accept-Language": request.headers.get("accept-language") ?? "" }
+          : {}),
+        "Content-Type": "application/json",
+        ...(request.headers.get("cookie")
+          ? { Cookie: request.headers.get("cookie") ?? "" }
+          : {}),
+      },
+      body: JSON.stringify(verification),
+      cache: "no-store",
+    });
+    const body = await readResponseBody(apiResponse);
+
+    if (!apiResponse.ok) {
+      return NextResponse.json(
+        { message: getIdentityRouteErrorMessage({ status: apiResponse.status, data: body }) },
+        { status: apiResponse.status },
+      );
+    }
+
+    return NextResponse.json(parseVerifyEmailResult(body), { status: 200 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { message: "Identity API response did not match the expected schema." },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(
+      { message: getIdentityRouteErrorMessage({ data: error }) },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/identityApi.ts
+++ b/src/app/identityApi.ts
@@ -4,6 +4,9 @@ import { z } from "zod";
 export type IdentityLoginRequest = z.infer<typeof schemas.LoginRequestBody>;
 export type IdentitySummary = z.infer<typeof schemas.IdentitySummary>;
 export type RedirectUrlResult = z.infer<typeof schemas.RedirectUrlResult>;
+export type CreateIdentityRequest = z.infer<typeof schemas.CreateIdentityRequestBody>;
+export type VerifyEmailRequest = z.infer<typeof schemas.VerifyEmailRequestBody>;
+export type VerifyEmailResult = z.infer<typeof schemas.VerifyEmailResult>;
 
 type IdentityApiEnv = Record<string, string | undefined>;
 
@@ -75,3 +78,12 @@ export const parseIdentitySummary = (body: unknown): IdentitySummary =>
 
 export const parseRedirectUrlResult = (body: unknown): RedirectUrlResult =>
   schemas.RedirectUrlResult.parse(body);
+
+export const parseCreateIdentityRequest = (body: unknown): CreateIdentityRequest =>
+  schemas.CreateIdentityRequestBody.parse(body);
+
+export const parseVerifyEmailRequest = (body: unknown): VerifyEmailRequest =>
+  schemas.VerifyEmailRequestBody.parse(body);
+
+export const parseVerifyEmailResult = (body: unknown): VerifyEmailResult =>
+  schemas.VerifyEmailResult.parse(body);

--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState, type FormEvent } from "react";
 
@@ -204,6 +205,16 @@ export function LoginPage({
                 ? "ログインしています"
                 : "メールアドレスでログイン"}
             </button>
+
+            <p className="text-center text-sm text-text-muted">
+              アカウントをお持ちでない方は{" "}
+              <Link
+                href="/signup"
+                className="font-semibold text-brand-primary underline-offset-4 hover:underline"
+              >
+                アカウント登録へ
+              </Link>
+            </p>
           </form>
         </section>
       </div>

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -19,6 +19,11 @@ describe("LoginPage", () => {
     expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
     expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "メールアドレスでログイン" })).toBeInTheDocument();
+    expect(screen.getByText("アカウントをお持ちでない方は")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "アカウント登録へ" })).toHaveAttribute(
+      "href",
+      "/signup",
+    );
   });
 
   it("requests an SSO redirect URL and navigates to it", async () => {

--- a/src/app/signup/SignupPage.tsx
+++ b/src/app/signup/SignupPage.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+
+import {
+  buildCreateAccountRequest,
+  buildCreateIdentityRequest,
+  getSignupStepItems,
+  signupWithApi,
+  type SignupAccountFormValues,
+  type SignupAdapter,
+  type SignupPhase,
+  type SignupStepId,
+  type SignupStepState,
+} from "./signupFlow";
+
+type SignupPageProps = {
+  signupAdapter?: SignupAdapter;
+  navigate?: (url: string) => void;
+  refresh?: () => void;
+};
+
+const initialValues: SignupAccountFormValues = {
+  email: "",
+  accountName: "",
+  accountType: "individual",
+  language: "ja",
+  username: "",
+  password: "",
+  confirmedPassword: "",
+  base64EncodedImage: "",
+  invitationToken: "",
+};
+
+const accountTypeOptions = [
+  { value: "individual", label: "個人", panelId: "individual-account-panel" },
+  { value: "corporation", label: "法人", panelId: "corporation-account-panel" },
+];
+
+const languageOptions = [
+  { value: "ja", label: "日本語" },
+  { value: "en", label: "English" },
+  { value: "ko", label: "한국어" },
+];
+
+const stepStateLabel: Record<SignupStepState, string> = {
+  pending: "待機中",
+  active: "入力中",
+  processing: "処理中",
+  complete: "完了",
+  error: "エラー",
+};
+
+const stepStateClassName: Record<SignupStepState, string> = {
+  pending: "bg-stroke-subtle",
+  active: "bg-brand-primary",
+  processing: "bg-brand-primary",
+  complete: "bg-emerald-500",
+  error: "bg-red-500",
+};
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error
+    ? error.message
+    : "登録処理に失敗しました。時間をおいて再度お試しください。";
+
+export function SignupPage({
+  signupAdapter = signupWithApi,
+  navigate,
+  refresh,
+}: SignupPageProps) {
+  const router = useRouter();
+  const [values, setValues] = useState<SignupAccountFormValues>(initialValues);
+  const [authCode, setAuthCode] = useState("");
+  const [phase, setPhase] = useState<SignupPhase>("account");
+  const [pending, setPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorStep, setErrorStep] = useState<SignupStepId | null>(null);
+
+  const setField = (field: keyof SignupAccountFormValues, value: string): void => {
+    setValues((current) => ({ ...current, [field]: value }));
+  };
+
+  const setAccountName = (accountName: string): void => {
+    setValues((current) => ({
+      ...current,
+      accountName,
+      username: accountName,
+    }));
+  };
+
+  const handleAccountSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPending(true);
+    setErrorMessage(null);
+    setErrorStep(null);
+
+    try {
+      await signupAdapter.createAccount(buildCreateAccountRequest(values), {
+        language: values.language,
+      });
+      setPhase("verification");
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setErrorStep("account");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleVerificationSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPending(true);
+    setErrorMessage(null);
+    setErrorStep(null);
+
+    try {
+      await signupAdapter.verifyEmail(
+        { email: values.email, authCode },
+        { language: values.language },
+      );
+      setPhase("identity");
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setErrorStep("verification");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const handleIdentitySubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPending(true);
+    setErrorMessage(null);
+    setErrorStep(null);
+
+    try {
+      await signupAdapter.createIdentity(buildCreateIdentityRequest(values), {
+        language: values.language,
+      });
+      setPhase("complete");
+
+      if (navigate) {
+        navigate("/mypage");
+      } else {
+        router.replace("/mypage");
+        router.refresh();
+      }
+      refresh?.();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setErrorStep("identity");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const steps = getSignupStepItems({ phase, pending, errorStep });
+  const isAccountPhase = phase === "account";
+  const isVerificationPhase = phase === "verification";
+  const isIdentityPhase = phase === "identity";
+  const selectedAccountType = accountTypeOptions.find(
+    (option) => option.value === values.accountType,
+  ) ?? accountTypeOptions[0];
+
+  return (
+    <main className="min-h-[calc(100vh-73px)] bg-surface-base px-6 py-10 text-text-strong sm:px-10 lg:px-16">
+      <div className="mx-auto max-w-3xl space-y-7">
+        <div className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.08em] text-brand-primary">
+            K-Pool Account
+          </p>
+          <h1 className="text-3xl font-bold sm:text-4xl">アカウント登録</h1>
+          <p className="max-w-2xl text-sm leading-6 text-text-muted">
+            メールアドレスでアカウントを作成し、届いた認証コードで登録を完了します。
+          </p>
+        </div>
+
+        <section className="rounded-lg border border-stroke-subtle bg-surface-raised p-6 shadow-[0_12px_36px_rgba(29,47,73,0.08)]">
+          {isAccountPhase ? (
+            <form className="space-y-5" onSubmit={(event) => void handleAccountSubmit(event)}>
+              <div
+                role="tablist"
+                aria-label="アカウント種別"
+                className="-mx-6 -mt-6 mb-5 flex border-b border-stroke-subtle px-6"
+              >
+                {accountTypeOptions.map((option) => {
+                  const selected = values.accountType === option.value;
+
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      role="tab"
+                      id={`${option.value}-account-tab`}
+                      aria-selected={selected}
+                      aria-controls={option.panelId}
+                      className={[
+                        "relative min-h-12 px-4 text-sm font-semibold transition",
+                        selected
+                          ? "text-brand-primary after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-full after:bg-brand-primary"
+                          : "text-text-muted hover:text-text-strong",
+                      ].join(" ")}
+                      onClick={() => setField("accountType", option.value)}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div
+                role="tabpanel"
+                id={selectedAccountType.panelId}
+                aria-labelledby={`${selectedAccountType.value}-account-tab`}
+                className="grid gap-4 sm:grid-cols-2"
+              >
+                <label className="block space-y-2 text-sm font-semibold sm:col-span-2">
+                  <span>登録用メールアドレス</span>
+                  <input
+                    type="email"
+                    autoComplete="email"
+                    required
+                    value={values.email}
+                    onChange={(event) => setField("email", event.target.value)}
+                    className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                  />
+                </label>
+
+                <label className="block space-y-2 text-sm font-semibold">
+                  <span>アカウント名</span>
+                  <input
+                    type="text"
+                    autoComplete="organization"
+                    required
+                    value={values.accountName}
+                    onChange={(event) => setAccountName(event.target.value)}
+                    className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                  />
+                </label>
+
+                <label className="block space-y-2 text-sm font-semibold sm:col-span-2">
+                  <span>言語</span>
+                  <select
+                    required
+                    value={values.language}
+                    onChange={(event) => setField("language", event.target.value)}
+                    className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                  >
+                    {languageOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              {errorMessage ? (
+                <p
+                  className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700"
+                  role="alert"
+                >
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <button
+                type="submit"
+                className="flex min-h-12 w-full items-center justify-center rounded-lg border border-brand-primary bg-surface-base px-5 py-3 text-sm font-semibold text-brand-primary transition hover:bg-brand-highlight/30 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={pending}
+              >
+                {pending ? "認証コードを送信しています" : "認証コードを送信"}
+              </button>
+            </form>
+          ) : null}
+
+          {isVerificationPhase ? (
+            <form
+              className="space-y-5"
+              onSubmit={(event) => void handleVerificationSubmit(event)}
+            >
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold">認証コード入力</h2>
+                <p className="text-sm leading-6 text-text-muted">
+                  {values.email} に届いた認証コードを入力してください。
+                </p>
+              </div>
+
+              <label className="block space-y-2 text-sm font-semibold">
+                <span>認証コード</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  required
+                  value={authCode}
+                  onChange={(event) => setAuthCode(event.target.value)}
+                  className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                />
+              </label>
+
+              {errorMessage ? (
+                <p
+                  className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700"
+                  role="alert"
+                >
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <button
+                type="submit"
+                className="flex min-h-12 w-full items-center justify-center rounded-lg border border-brand-primary bg-surface-base px-5 py-3 text-sm font-semibold text-brand-primary transition hover:bg-brand-highlight/30 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={pending}
+              >
+                {pending ? "認証コードを確認しています" : "認証コードを確認"}
+              </button>
+            </form>
+          ) : null}
+
+          {isIdentityPhase ? (
+            <form className="space-y-5" onSubmit={(event) => void handleIdentitySubmit(event)}>
+              <div className="space-y-2">
+                <h2 className="text-lg font-semibold">登録情報設定</h2>
+                <p className="text-sm leading-6 text-text-muted">
+                  ログインに使うパスワードを設定してください。
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <label className="block space-y-2 text-sm font-semibold">
+                  <span>パスワード</span>
+                  <input
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    value={values.password}
+                    onChange={(event) => setField("password", event.target.value)}
+                    className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                  />
+                </label>
+
+                <label className="block space-y-2 text-sm font-semibold">
+                  <span>確認用パスワード</span>
+                  <input
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    value={values.confirmedPassword}
+                    onChange={(event) => setField("confirmedPassword", event.target.value)}
+                    className="w-full rounded-lg border border-stroke-subtle bg-surface-base px-4 py-3 text-base text-text-strong outline-none transition focus:border-brand-primary focus:ring-2 focus:ring-brand-highlight"
+                  />
+                </label>
+              </div>
+
+              {errorMessage ? (
+                <p
+                  className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-semibold text-red-700"
+                  role="alert"
+                >
+                  {errorMessage}
+                </p>
+              ) : null}
+
+              <button
+                type="submit"
+                className="flex min-h-12 w-full items-center justify-center rounded-lg border border-brand-primary bg-surface-base px-5 py-3 text-sm font-semibold text-brand-primary transition hover:bg-brand-highlight/30 disabled:cursor-not-allowed disabled:opacity-70"
+                disabled={pending}
+              >
+                {pending ? "登録を完了しています" : "登録を完了"}
+              </button>
+            </form>
+          ) : null}
+        </section>
+
+        <ol className="grid grid-cols-3 gap-2" aria-label="登録ステップ">
+          {steps.map((step) => (
+            <li
+              key={step.id}
+              className={`h-1.5 rounded-full transition-colors ${stepStateClassName[step.state]}`}
+              aria-label={`${step.label}: ${stepStateLabel[step.state]}`}
+            />
+          ))}
+        </ol>
+      </div>
+    </main>
+  );
+}

--- a/src/app/signup/page.test.tsx
+++ b/src/app/signup/page.test.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SignupPage } from "./SignupPage";
+import type { SignupAdapter } from "./signupFlow";
+
+const createAdapter = (overrides: Partial<SignupAdapter> = {}): SignupAdapter => ({
+  createAccount: vi.fn().mockResolvedValue({
+    accountIdentifier: "22222222-2222-2222-2222-222222222222",
+    email: "member@example.com",
+    type: "individual",
+    name: "Member Account",
+    status: "active",
+    accountCategory: "standard",
+  }),
+  verifyEmail: vi.fn().mockResolvedValue({
+    email: "member@example.com",
+    verifiedAt: "2026-05-05T00:00:00+00:00",
+  }),
+  createIdentity: vi.fn().mockResolvedValue({
+    identityIdentifier: "11111111-1111-1111-1111-111111111111",
+    username: "member",
+    email: "member@example.com",
+    language: "ja",
+  }),
+  ...overrides,
+});
+
+const fillAccountForm = () => {
+  fireEvent.change(screen.getByLabelText("登録用メールアドレス"), {
+    target: { value: "member@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText("アカウント名"), {
+    target: { value: "Member Account" },
+  });
+};
+
+describe("SignupPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("creates an account, verifies email, creates identity, and opens mypage", async () => {
+    const adapter = createAdapter();
+    const navigate = vi.fn();
+
+    render(<SignupPage signupAdapter={adapter} navigate={navigate} />);
+    fillAccountForm();
+    fireEvent.click(screen.getByRole("button", { name: "認証コードを送信" }));
+
+    await waitFor(() =>
+      expect(adapter.createAccount).toHaveBeenCalledWith(
+        {
+          email: "member@example.com",
+          accountName: "Member Account",
+          accountType: "individual",
+          identityIdentifier: null,
+        },
+        { language: "ja" },
+      ),
+    );
+    expect(await screen.findByRole("heading", { name: "認証コード入力" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("認証コード"), {
+      target: { value: "123456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "認証コードを確認" }));
+
+    await waitFor(() =>
+      expect(adapter.verifyEmail).toHaveBeenCalledWith(
+        {
+          email: "member@example.com",
+          authCode: "123456",
+        },
+        { language: "ja" },
+      ),
+    );
+    expect(await screen.findByRole("heading", { name: "登録情報設定" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("パスワード"), {
+      target: { value: "secret-password" },
+    });
+    fireEvent.change(screen.getByLabelText("確認用パスワード"), {
+      target: { value: "secret-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "登録を完了" }));
+
+    await waitFor(() =>
+      expect(adapter.createIdentity).toHaveBeenCalledWith(
+        {
+          username: "Member Account",
+          email: "member@example.com",
+          password: "secret-password",
+          confirmedPassword: "secret-password",
+          base64EncodedImage: null,
+          invitationToken: null,
+          requestLanguage: "ja",
+        },
+        { language: "ja" },
+      ),
+    );
+    expect(navigate).toHaveBeenCalledWith("/mypage");
+  });
+
+  it("keeps typed account values and shows an error when account creation fails", async () => {
+    const adapter = createAdapter({
+      createAccount: vi.fn().mockRejectedValue(new Error("このメールアドレスは登録済みです。")),
+    });
+
+    render(<SignupPage signupAdapter={adapter} />);
+    fillAccountForm();
+    fireEvent.click(screen.getByRole("button", { name: "認証コードを送信" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "このメールアドレスは登録済みです。",
+    );
+    expect(screen.getByLabelText("登録用メールアドレス")).toHaveValue("member@example.com");
+    expect(screen.getByLabelText("アカウント名")).toHaveValue("Member Account");
+  });
+
+  it("uses the selected corporation account type when the corporation tab is selected", async () => {
+    const adapter = createAdapter();
+
+    render(<SignupPage signupAdapter={adapter} />);
+    fillAccountForm();
+    fireEvent.click(screen.getByRole("tab", { name: "法人" }));
+    fireEvent.click(screen.getByRole("button", { name: "認証コードを送信" }));
+
+    await waitFor(() =>
+      expect(adapter.createAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountType: "corporation",
+        }),
+        { language: "ja" },
+      ),
+    );
+  });
+});

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,5 @@
+import { SignupPage } from "./SignupPage";
+
+export default function Page() {
+  return <SignupPage />;
+}

--- a/src/app/signup/signupFlow.test.ts
+++ b/src/app/signup/signupFlow.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCreateAccountRequest,
+  buildCreateIdentityRequest,
+  getSignupStepItems,
+  type SignupAccountFormValues,
+} from "./signupFlow";
+
+const values: SignupAccountFormValues = {
+  email: "member@example.com",
+  accountName: "Member Account",
+  accountType: "individual",
+  language: "ja",
+  username: "member",
+  password: "secret-password",
+  confirmedPassword: "secret-password",
+  base64EncodedImage: "",
+  invitationToken: "",
+};
+
+describe("signup flow helpers", () => {
+  it("builds account and identity requests from form values", () => {
+    expect(buildCreateAccountRequest(values)).toEqual({
+      email: "member@example.com",
+      accountName: "Member Account",
+      accountType: "individual",
+      identityIdentifier: null,
+    });
+    expect(buildCreateIdentityRequest(values)).toEqual({
+      username: "member",
+      email: "member@example.com",
+      password: "secret-password",
+      confirmedPassword: "secret-password",
+      base64EncodedImage: null,
+      invitationToken: null,
+      requestLanguage: "ja",
+    });
+  });
+
+  it("marks the current step and completed steps for the visible progress", () => {
+    expect(
+      getSignupStepItems({
+        phase: "verification",
+        pending: false,
+        errorStep: null,
+      }),
+    ).toEqual([
+      { id: "account", label: "アカウント情報入力", state: "complete" },
+      { id: "verification", label: "認証コード入力", state: "active" },
+      { id: "identity", label: "登録情報設定", state: "pending" },
+    ]);
+  });
+
+  it("marks the step that failed", () => {
+    expect(
+      getSignupStepItems({
+        phase: "verification",
+        pending: false,
+        errorStep: "verification",
+      })[1],
+    ).toEqual({
+      id: "verification",
+      label: "認証コード入力",
+      state: "error",
+    });
+  });
+});

--- a/src/app/signup/signupFlow.ts
+++ b/src/app/signup/signupFlow.ts
@@ -1,0 +1,222 @@
+import type { CreateAccountRequest, CreateAccountResult } from "../accountApi";
+import type {
+  CreateIdentityRequest,
+  IdentitySummary,
+  VerifyEmailRequest,
+  VerifyEmailResult,
+} from "../identityApi";
+
+export type SignupStepId = "account" | "verification" | "identity";
+export type SignupPhase = "account" | "verification" | "identity" | "complete";
+
+export type SignupStepState = "pending" | "active" | "processing" | "complete" | "error";
+
+export type SignupStepItem = {
+  id: SignupStepId;
+  label: string;
+  state: SignupStepState;
+};
+
+export type SignupAccountFormValues = {
+  email: string;
+  accountName: string;
+  accountType: string;
+  language: string;
+  username: string;
+  password: string;
+  confirmedPassword: string;
+  base64EncodedImage: string;
+  invitationToken: string;
+};
+
+export type SignupAdapter = {
+  createAccount: (
+    request: CreateAccountRequest,
+    options?: { language: string },
+  ) => Promise<CreateAccountResult>;
+  verifyEmail: (
+    request: VerifyEmailRequest,
+    options?: { language: string },
+  ) => Promise<VerifyEmailResult>;
+  createIdentity: (
+    request: CreateIdentityRequest,
+    options?: { language: string },
+  ) => Promise<IdentitySummary>;
+};
+
+export type SignupResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; message: string };
+
+const signupStepLabels: Record<SignupStepId, string> = {
+  account: "アカウント情報入力",
+  verification: "認証コード入力",
+  identity: "登録情報設定",
+};
+
+const signupStepOrder: SignupStepId[] = ["account", "verification", "identity"];
+
+const phaseStepIndex: Record<SignupPhase, number> = {
+  account: 0,
+  verification: 1,
+  identity: 2,
+  complete: 3,
+};
+
+const getActiveStep = (phase: SignupPhase): SignupStepId | null => {
+  if (phase === "complete") {
+    return null;
+  }
+
+  return phase;
+};
+
+export const getSignupStepItems = ({
+  phase,
+  pending,
+  errorStep,
+}: {
+  phase: SignupPhase;
+  pending: boolean;
+  errorStep: SignupStepId | null;
+}): SignupStepItem[] => {
+  const activeStep = getActiveStep(phase);
+  const currentIndex = phaseStepIndex[phase];
+
+  return signupStepOrder.map((stepId, index) => {
+    const state =
+      errorStep === stepId
+        ? "error"
+        : index < currentIndex
+          ? "complete"
+          : activeStep === stepId && pending
+            ? "processing"
+            : activeStep === stepId
+              ? "active"
+              : "pending";
+
+    return {
+      id: stepId,
+      label: signupStepLabels[stepId],
+      state,
+    };
+  });
+};
+
+export const buildCreateAccountRequest = (
+  values: SignupAccountFormValues,
+): CreateAccountRequest => ({
+  email: values.email,
+  accountName: values.accountName,
+  accountType: values.accountType,
+  identityIdentifier: null,
+});
+
+export const buildCreateIdentityRequest = (
+  values: SignupAccountFormValues,
+): CreateIdentityRequest & { requestLanguage: string } => ({
+  username: values.username,
+  email: values.email,
+  password: values.password,
+  confirmedPassword: values.confirmedPassword,
+  base64EncodedImage: values.base64EncodedImage || null,
+  invitationToken: values.invitationToken || null,
+  requestLanguage: values.language,
+});
+
+export const getSignupErrorMessage = async (response: Response): Promise<string> => {
+  try {
+    const body = (await response.json()) as unknown;
+
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "message" in body &&
+      typeof (body as { message: unknown }).message === "string"
+    ) {
+      return (body as { message: string }).message;
+    }
+  } catch {
+    return "登録処理に失敗しました。時間をおいて再度お試しください。";
+  }
+
+  if (response.status === 409) {
+    return "このメールアドレスはすでに登録されています。";
+  }
+
+  if (response.status === 422) {
+    return "入力内容を確認してください。";
+  }
+
+  return "登録処理に失敗しました。時間をおいて再度お試しください。";
+};
+
+const postJson = async <T>(
+  url: string,
+  body: unknown,
+  options?: { language: string },
+): Promise<SignupResult<T>> => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...(options?.language ? { "Accept-Language": options.language } : {}),
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      message: await getSignupErrorMessage(response),
+    };
+  }
+
+  return {
+    ok: true,
+    data: (await response.json()) as T,
+  };
+};
+
+export const signupWithApi: SignupAdapter = {
+  createAccount: async (request, options) => {
+    const result = await postJson<CreateAccountResult>(
+      "/api/account/accounts",
+      request,
+      options,
+    );
+
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+
+    return result.data;
+  },
+  verifyEmail: async (request, options) => {
+    const result = await postJson<VerifyEmailResult>(
+      "/api/identity/auth/verify-email",
+      request,
+      options,
+    );
+
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+
+    return result.data;
+  },
+  createIdentity: async (request, options) => {
+    const result = await postJson<IdentitySummary>(
+      "/api/identity/auth/register",
+      request,
+      options,
+    );
+
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+
+    return result.data;
+  },
+};

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -128,8 +128,109 @@ test("login page submits email credentials through the Identity API proxy", asyn
   await page.goto("/login");
 
   await page.getByLabel("メールアドレス").fill("member@example.com");
-  await page.getByLabel("パスワード").fill("secret-password");
+  await page.getByLabel("パスワード", { exact: true }).fill("secret-password");
   await page.getByRole("button", { name: "メールアドレスでログイン" }).click();
+
+  await expect(page).toHaveURL(/\/mypage$/);
+});
+
+test("login page links to signup and completes the signup flow through API proxies", async ({
+  page,
+}) => {
+  await page.route("**/api/account/accounts", async (route) => {
+    const requestBody = route.request().postDataJSON();
+
+    expect(requestBody).toEqual({
+      email: "new-member@example.com",
+      accountName: "New Member Account",
+      accountType: "individual",
+      identityIdentifier: null,
+    });
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        accountIdentifier: "22222222-2222-2222-2222-222222222222",
+        email: "new-member@example.com",
+        type: "individual",
+        name: "New Member Account",
+        status: "active",
+        accountCategory: "standard",
+      }),
+    });
+  });
+  await page.route("**/api/identity/auth/verify-email", async (route) => {
+    const requestBody = route.request().postDataJSON();
+
+    expect(requestBody).toEqual({
+      email: "new-member@example.com",
+      authCode: "123456",
+    });
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        email: "new-member@example.com",
+        verifiedAt: "2026-05-05T00:00:00+00:00",
+      }),
+    });
+  });
+  await page.route("**/api/identity/auth/register", async (route) => {
+    const requestBody = route.request().postDataJSON();
+
+    expect(requestBody).toEqual({
+      username: "New Member Account",
+      email: "new-member@example.com",
+      password: "secret-password",
+      confirmedPassword: "secret-password",
+      base64EncodedImage: null,
+      invitationToken: null,
+      requestLanguage: "ja",
+    });
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        identityIdentifier: "11111111-1111-1111-1111-111111111111",
+        username: "New Member Account",
+        email: "new-member@example.com",
+        language: "ja",
+      }),
+    });
+  });
+
+  await page.goto("/login");
+  await page.getByRole("link", { name: "アカウント登録へ" }).click();
+
+  await expect(page).toHaveURL(/\/signup$/);
+  await expect(page.getByRole("heading", { name: "アカウント登録" })).toBeVisible();
+
+  await page.getByLabel("登録用メールアドレス").fill("new-member@example.com");
+  await page.getByLabel("アカウント名").fill("New Member Account");
+  await page.getByLabel("言語").selectOption("ja");
+  await page.getByRole("button", { name: "認証コードを送信" }).click();
+
+  await expect(page.getByRole("heading", { name: "認証コード入力" })).toBeVisible();
+  await expect(
+    page.getByRole("listitem", { name: "アカウント情報入力: 完了" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("listitem", { name: "認証コード入力: 入力中" }),
+  ).toBeVisible();
+
+  await page.getByLabel("認証コード", { exact: true }).fill("123456");
+  await page.getByRole("button", { name: "認証コードを確認" }).click();
+
+  await expect(page.getByRole("heading", { name: "登録情報設定" })).toBeVisible();
+  await expect(
+    page.getByRole("listitem", { name: "認証コード入力: 完了" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("listitem", { name: "登録情報設定: 入力中" }),
+  ).toBeVisible();
+
+  await page.getByLabel("パスワード", { exact: true }).fill("secret-password");
+  await page.getByLabel("確認用パスワード").fill("secret-password");
+  await page.getByRole("button", { name: "登録を完了" }).click();
 
   await expect(page).toHaveURL(/\/mypage$/);
 });


### PR DESCRIPTION
## 📝 変更内容

- `/login` のメールアドレスログインフォーム下に `/signup` への導線を追加
- `/signup` に Account 作成、メール認証コード確認、Identity 作成を順に進める登録フローを追加
- Account API / Identity API 向けの Next.js Route Handler と helper を追加
- サインアップ画面、signup helper、Account API helper、ログイン導線のユニットテストを追加
- `/login` から `/signup` へ遷移し、API mock 経由で登録完了まで進む E2E を追加

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

未登録ユーザーが `/login` からアカウント作成へ進める導線がなかったため、ログイン画面にサインアップリンクを追加し、登録手続きを `/signup` 画面内で完結できるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [ ] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`: pass（34 files / 132 tests）
- `pnpm build`: pass
  - sandbox 内では Turbopack の port bind 制限で失敗
  - 権限昇格後の通常実行では成功
- `task test:e2e`: 13 件中 9 件 pass
  - 追加した signup flow E2E は pass
  - 既存の `wiki-detail.spec.ts` の wiki edit 系 4 件が失敗

## 🔍 レビューのポイント

- Account 作成、認証コード検証、Identity 作成の順序が backend 契約と合っているか
- API Route Handler の cookie / `Accept-Language` / エラー整形の扱いが既存 Identity API proxy と揃っているか
- `/signup` のステップ状態、pending、エラー表示が期待どおりか
- サインアップ完了後の `/mypage` 遷移と `router.refresh()` の扱い

## 📖 関連情報

### 関連Issue・タスク

Closes #52

## ⚠️ 注意事項

- Account API 用に `KPOOL_ACCOUNT_API_BASE_URL` を参照します
- 未追跡の `.codex/tmp/` は PR 差分に含めません

## 📸 スクリーンショット・デモ

未添付。追加 E2E で `/login` から `/signup` への遷移と登録フローを確認しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [ ] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
