### PR TITLE
公開Wiki詳細をバックエンドAPI取得に切り替える

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Open [http://localhost:3000](http://localhost:3000) in your browser.
 
 ## Environment Variables
 
-Wiki edit pages fetch backend draft data via `KPOOL_WIKI_PRIVATE_API_BASE_URL`.
+Wiki pages fetch backend data via `KPOOL_WIKI_PRIVATE_API_BASE_URL`.
 For local development, create `.env.local` from the example and point it at the backend:
 
 ```bash

--- a/src/app/wiki/[language]/[slug]/page.tsx
+++ b/src/app/wiki/[language]/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { WikiDetailPage } from "../../[slug]/WikiDetailPage";
+import { loadPublicWikiState } from "../../publicWiki";
 
 type WikiDetailRouteProps = {
   params: Promise<{
@@ -16,12 +17,14 @@ const getThemeColor = (value: string | string[] | undefined): string | undefined
 export default async function Page({ params, searchParams }: WikiDetailRouteProps) {
   const { language, slug } = await params;
   const { themeColor } = await searchParams;
+  const wikiState = await loadPublicWikiState(language, slug);
 
   return (
     <WikiDetailPage
       language={language}
       slug={slug}
       themeColor={getThemeColor(themeColor)}
+      wikiState={wikiState}
     />
   );
 }

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  type WikiDetailState,
   normalizeWikiSectionContents,
   sortWikiSections,
 } from "@kpool/wiki";
@@ -16,21 +17,24 @@ import {
 import { useI18n } from "../../i18n/I18nProvider";
 import { getWikiResourceLabel } from "../wikiRouting";
 import { buildWikiThemeCssVariables } from "./wikiThemePalette";
-import { useWikiDetail } from "./useWikiDetail";
 
 type WikiDetailPageProps = {
   language: string;
   slug: string;
   themeColor?: string;
+  wikiState: WikiDetailState;
 };
 
-export function WikiDetailPage({ language, slug, themeColor }: WikiDetailPageProps) {
+export function WikiDetailPage({
+  language,
+  themeColor,
+  wikiState,
+}: WikiDetailPageProps) {
   const { dictionary } = useI18n();
   const t = dictionary.wiki;
-  const wikiDetail = useWikiDetail(slug, { language, themeColor });
   const flipCardId = useId();
 
-  if (wikiDetail.status === "loading") {
+  if (wikiState.status === "loading") {
     return (
       <WikiStatePanel
         message={t.loadingMessage}
@@ -39,17 +43,17 @@ export function WikiDetailPage({ language, slug, themeColor }: WikiDetailPagePro
     );
   }
 
-  if (wikiDetail.status === "error") {
+  if (wikiState.status === "error") {
     return (
       <WikiStatePanel
-        message={wikiDetail.message}
+        message={wikiState.message}
         title={t.loadErrorTitle}
         tone="danger"
       />
     );
   }
 
-  if (wikiDetail.status === "empty") {
+  if (wikiState.status === "empty") {
     return (
       <WikiStatePanel
         message={t.emptyPublicMessage}
@@ -58,10 +62,11 @@ export function WikiDetailPage({ language, slug, themeColor }: WikiDetailPagePro
     );
   }
 
-  const { data } = wikiDetail;
+  const { data } = wikiState;
   const sections = sortWikiSections(data.sections.map(normalizeWikiSectionContents));
-  const themeStyles = buildWikiThemeCssVariables(data.themeColor);
-  const themeLabel = data.themeColor?.toUpperCase();
+  const effectiveThemeColor = themeColor ?? data.themeColor ?? undefined;
+  const themeStyles = buildWikiThemeCssVariables(effectiveThemeColor);
+  const themeLabel = effectiveThemeColor?.toUpperCase();
 
   return (
     <main

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -11,7 +11,6 @@ import {
   WikiPublicHeroBasicSection,
   WikiSectionAccordion,
   WikiStatePanel,
-  accentBadgeStyle,
   mainBackgroundStyle,
 } from "../../../components/Wiki";
 import { useI18n } from "../../i18n/I18nProvider";
@@ -66,7 +65,6 @@ export function WikiDetailPage({
   const sections = sortWikiSections(data.sections.map(normalizeWikiSectionContents));
   const effectiveThemeColor = themeColor ?? data.themeColor ?? undefined;
   const themeStyles = buildWikiThemeCssVariables(effectiveThemeColor);
-  const themeLabel = effectiveThemeColor?.toUpperCase();
 
   return (
     <main
@@ -83,15 +81,6 @@ export function WikiDetailPage({
             <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
               {data.basic.name}
             </h1>
-            {themeLabel ? (
-              <span
-                className="rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]"
-                data-testid="wiki-theme-badge"
-                style={accentBadgeStyle}
-              >
-                {t.theme} {themeLabel}
-              </span>
-            ) : null}
           </div>
         </header>
 

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -71,7 +71,6 @@ function WikiEditContent({
   } = useWikiEditDraft(data, { saveAdapter });
   const resourceLabel = getWikiResourceLabel(draft.resourceType as WikiResourceType);
   const themeStyles = buildWikiThemeCssVariables(draft.themeColor);
-  const themeLabel = draft.themeColor?.toUpperCase();
   const closeEditor = () => setEditingId(null);
   const editHeroImage = () => {
     setIsBasicFlipped(false);
@@ -119,14 +118,6 @@ function WikiEditContent({
         </header>
 
         <div className="flex min-w-0 flex-col gap-8">
-          {themeLabel ? (
-            <div>
-              <span className="rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]" data-testid="wiki-edit-theme-badge" style={cardSurfaceStyle}>
-                {t.theme} {themeLabel}
-              </span>
-            </div>
-          ) : null}
-
           <section>
             <WikiHeroBasicFlipCard
               basic={draft.basic}

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -1,15 +1,9 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { WikiDetailPage } from "./WikiDetailPage";
-import { useWikiDetail, type WikiDetailState } from "./useWikiDetail";
-
-vi.mock("./useWikiDetail", () => ({
-  useWikiDetail: vi.fn(),
-}));
-
-const mockedUseWikiDetail = vi.mocked(useWikiDetail);
+import type { WikiDetailState } from "@kpool/wiki";
 
 const successState: WikiDetailState = {
   status: "success",
@@ -91,14 +85,14 @@ const successState: WikiDetailState = {
 };
 
 describe("WikiDetailPage", () => {
-  beforeEach(() => {
-    mockedUseWikiDetail.mockReset();
-  });
-
   it("renders the public wiki detail view", () => {
-    mockedUseWikiDetail.mockReturnValue(successState);
-
-    render(React.createElement(WikiDetailPage, { language: "ja", slug: "gr-aurora-echo" }));
+    render(
+      React.createElement(WikiDetailPage, {
+        language: "ja",
+        slug: "gr-aurora-echo",
+        wikiState: successState,
+      }),
+    );
 
     expect(screen.getAllByRole("heading", { name: "Aurora Echo" })[0]).toBeInTheDocument();
     expect(screen.getAllByText("Aurora Echo")[0]).toBeInTheDocument();
@@ -118,18 +112,17 @@ describe("WikiDetailPage", () => {
   });
 
   it("injects theme css variables and badges when themeColor is provided", () => {
-    mockedUseWikiDetail.mockReturnValue({
-      ...successState,
-      data: {
-        ...successState.data,
-        themeColor: "#d94f70",
-      },
-    });
-
     const { container } = render(
       React.createElement(WikiDetailPage, {
         language: "ja",
         slug: "gr-aurora-echo",
+        wikiState: {
+          ...successState,
+          data: {
+            ...successState.data,
+            themeColor: "#d94f70",
+          },
+        },
       }),
     );
 
@@ -145,9 +138,13 @@ describe("WikiDetailPage", () => {
   });
 
   it("renders the empty state", () => {
-    mockedUseWikiDetail.mockReturnValue({ status: "empty" });
-
-    render(React.createElement(WikiDetailPage, { language: "ja", slug: "empty" }));
+    render(
+      React.createElement(WikiDetailPage, {
+        language: "ja",
+        slug: "empty",
+        wikiState: { status: "empty" },
+      }),
+    );
 
     expect(screen.getByText("No public wiki yet")).toBeInTheDocument();
     expect(

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -111,7 +111,7 @@ describe("WikiDetailPage", () => {
     expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
   });
 
-  it("injects theme css variables and badges when themeColor is provided", () => {
+  it("injects theme css variables without rendering the color code when themeColor is provided", () => {
     const { container } = render(
       React.createElement(WikiDetailPage, {
         language: "ja",
@@ -126,9 +126,7 @@ describe("WikiDetailPage", () => {
       }),
     );
 
-    expect(screen.getByTestId("wiki-theme-badge")).toHaveTextContent(
-      "Theme #D94F70",
-    );
+    expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
     const rootStyle = container
       .querySelector('[data-testid="wiki-theme-root"]')
       ?.getAttribute("style");

--- a/src/app/wiki/draftWiki.ts
+++ b/src/app/wiki/draftWiki.ts
@@ -1,4 +1,4 @@
-import { type WikiBasic, type WikiDetail, wikiDetailSchema } from "@kpool/wiki";
+import { type WikiDetail } from "@kpool/wiki";
 import {
   createApiClient,
   schemas,
@@ -9,6 +9,11 @@ import {
   getWikiResourceTypeFromSlug,
   type WikiResourceType,
 } from "./wikiRouting";
+import {
+  adaptWikiApiResponse,
+  getWikiApiErrorMessage,
+  withWikiApiPrefix,
+} from "./wikiApiModel";
 
 const draftWikiApiResponseSchema = z.union([
   schemas.AgencyDraftWikiDetail,
@@ -34,171 +39,10 @@ const draftWikiAliasByResourceType = {
   talent: "WikiOperations_getTalentDraftWiki",
 } as const;
 
-const trimTrailingSlashes = (value: string): string => {
-  let trimmedValue = value;
-
-  while (trimmedValue.endsWith("/")) {
-    trimmedValue = trimmedValue.slice(0, -1);
-  }
-
-  return trimmedValue;
-};
-
-const withWikiApiPrefix = (baseUrl: string): string =>
-  baseUrl.endsWith("/api/wiki")
-    ? baseUrl
-    : `${trimTrailingSlashes(baseUrl)}/api/wiki`;
-
 const defaultApiBaseUrl = process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
 
-const createPlaceholderHeroImage = (
-  name: string,
-  resourceType: WikiResourceType,
-  imageIdentifier?: string | null,
-): WikiDetail["heroImage"] => ({
-  alt: `${name} hero image`,
-  src:
-    "data:image/svg+xml;utf8," +
-    encodeURIComponent(`
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900">
-        <defs>
-          <linearGradient id="wiki-gradient" x1="0%" x2="100%" y1="0%" y2="100%">
-            <stop offset="0%" stop-color="#16253f" />
-            <stop offset="100%" stop-color="#3560a3" />
-          </linearGradient>
-        </defs>
-        <rect width="1200" height="900" fill="url(#wiki-gradient)" />
-        <text x="64" y="120" fill="#ffffff" font-family="Arial, sans-serif" font-size="42">
-          ${resourceType.toUpperCase()}
-        </text>
-        <text x="64" y="184" fill="#ffffff" font-family="Arial, sans-serif" font-size="60">
-          ${name}
-        </text>
-        <text x="64" y="248" fill="#cfd8e6" font-family="Arial, sans-serif" font-size="28">
-          ${imageIdentifier ?? "draft-hero-image"}
-        </text>
-      </svg>
-    `),
-});
-
-const toStringArray = (value: unknown): string[] | undefined =>
-  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : undefined;
-
-const toOptionalString = (value: unknown): string | undefined =>
-  typeof value === "string" && value.length > 0 ? value : undefined;
-
-const toNullableString = (value: unknown): string | null | undefined =>
-  typeof value === "string" ? value : value === null ? null : undefined;
-
-const inferResourceType = (response: DraftWikiApiResponse): WikiResourceType => {
-  const fromSlug = getWikiResourceTypeFromSlug(response.slug);
-
-  if (fromSlug) {
-    return fromSlug;
-  }
-
-  if (
-    response.resourceType === "agency" ||
-    response.resourceType === "group" ||
-    response.resourceType === "song" ||
-    response.resourceType === "talent"
-  ) {
-    return response.resourceType;
-  }
-
-  return "group";
-};
-
-const adaptDraftWikiBasic = (response: DraftWikiApiResponse): WikiBasic => {
-  const basic = response.basic as Record<string, unknown>;
-  const resourceType = inferResourceType(response);
-
-  return {
-    name: String(basic.name ?? response.slug),
-    normalizedName: String(basic.normalizedName ?? basic.name ?? response.slug),
-    resourceType,
-    agencyName: toNullableString(basic.agencyName),
-    albumName: toOptionalString(basic.albumName),
-    arranger: toOptionalString(basic.arranger),
-    birthday: toOptionalString(basic.birthday),
-    bloodType: toOptionalString(basic.bloodType),
-    ceo: toOptionalString(basic.ceo),
-    composer: toOptionalString(basic.composer),
-    debutDate: toOptionalString(basic.debutDate),
-    emoji: toOptionalString(basic.emoji),
-    englishLevel: toOptionalString(basic.englishLevel),
-    fandomName: toOptionalString(basic.fandomName),
-    generation: toOptionalString(basic.generation),
-    genres: toStringArray(basic.genres),
-    groupType: toOptionalString(basic.groupType),
-    height: typeof basic.height === "number" ? basic.height : undefined,
-    lyricist: toOptionalString(basic.lyricist),
-    mbti: toOptionalString(basic.mbti),
-    officialColors: toStringArray(basic.officialColors),
-    officialWebsite: toOptionalString(basic.officialWebsite),
-    position: toOptionalString(basic.position),
-    realName: toOptionalString(basic.realName),
-    releaseDate: toOptionalString(basic.releaseDate),
-    representativeSymbol: toOptionalString(basic.representativeSymbol),
-    socialLinks: toStringArray(basic.socialLinks),
-    songType: toOptionalString(basic.songType),
-    status: toOptionalString(basic.status),
-    zodiacSign: toOptionalString(basic.zodiacSign),
-  };
-};
-
-const toSectionIdentifier = (value: unknown, index: number): string =>
-  typeof value === "string" && value.length > 0 ? value : `section-${index + 1}`;
-
-const toSectionTitle = (value: unknown, fallback: string): string =>
-  typeof value === "string" && value.length > 0 ? value : fallback;
-
-const adaptDraftWikiSections = (sections: unknown[]): WikiDetail["sections"] =>
-  sections.map((section, index) => {
-    const sectionRecord =
-      typeof section === "object" && section !== null
-        ? (section as Record<string, unknown>)
-        : {};
-    const sectionIdentifier = toSectionIdentifier(sectionRecord.id, index);
-    const content =
-      typeof sectionRecord.content === "string" ? sectionRecord.content : "";
-
-    return {
-      type: "section",
-      sectionIdentifier,
-      title: toSectionTitle(sectionRecord.title, sectionIdentifier),
-      displayOrder: index + 1,
-      depth: 1,
-      contents: content
-        ? [
-            {
-              blockIdentifier: `${sectionIdentifier}-text-1`,
-              blockType: "text",
-              displayOrder: 1,
-              content,
-            },
-          ]
-        : [],
-      children: [],
-    };
-  });
-
 export const adaptDraftWikiResponse = (response: DraftWikiApiResponse): WikiDetail =>
-  wikiDetailSchema.parse({
-    basic: adaptDraftWikiBasic(response),
-    heroImage: createPlaceholderHeroImage(
-      String((response.basic as Record<string, unknown>).name ?? response.slug),
-      inferResourceType(response),
-      response.heroImage.imageIdentifier,
-    ),
-    language: response.language,
-    resourceType: inferResourceType(response),
-    sections: adaptDraftWikiSections(response.sections),
-    slug: response.slug,
-    themeColor: response.themeColor ?? null,
-    version: response.version,
-    wikiIdentifier: response.wikiIdentifier,
-  });
+  adaptWikiApiResponse(response);
 
 export const getDraftWikiAlias = (
   slug: string,
@@ -247,48 +91,13 @@ export const createDraftWikiApiClient = (
 ): DraftWikiApiClient | null =>
   baseUrl ? createApiClient(withWikiApiPrefix(baseUrl)) : null;
 
-const hasMessage = (value: unknown): value is { message: string } =>
-  typeof value === "object" &&
-  value !== null &&
-  "message" in value &&
-  typeof (value as { message: unknown }).message === "string";
-
-export const getDraftWikiErrorMessage = (error: unknown): string => {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "response" in error &&
-    typeof (error as { response?: unknown }).response === "object" &&
-    (error as { response?: unknown }).response !== null
-  ) {
-    const response = (error as {
-      response: {
-        status?: number;
-        data?: unknown;
-      };
-    }).response;
-    const detail =
-      hasMessage(response.data) ? response.data.message : null;
-
-    if (response.status === 404) {
-      return detail ?? "Draft wiki was not found.";
-    }
-
-    if (response.status) {
-      return detail ?? `Draft wiki request failed with status ${response.status}.`;
-    }
-  }
-
-  if (error instanceof z.ZodError) {
-    return `Draft wiki response did not match the expected schema: ${error.issues[0]?.message ?? "invalid response"}`;
-  }
-
-  if (hasMessage(error)) {
-    return error.message;
-  }
-
-  return "Wiki drafts are temporarily unavailable. Please try again later.";
-};
+export const getDraftWikiErrorMessage = (error: unknown): string =>
+  getWikiApiErrorMessage(error, {
+    notFound: "Draft wiki was not found.",
+    requestFailedPrefix: "Draft wiki request failed with status",
+    responseSchemaPrefix: "Draft wiki response did not match the expected schema",
+    unavailable: "Wiki drafts are temporarily unavailable. Please try again later.",
+  });
 
 export const loadDraftWikiState = async (
   language: string,

--- a/src/app/wiki/publicWiki.test.ts
+++ b/src/app/wiki/publicWiki.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  adaptPublicWikiResponse,
+  createPublicWikiApiClient,
+  fetchPublicWiki,
+  getPublicWikiEndpointPath,
+  getPublicWikiErrorMessage,
+  loadPublicWikiState,
+} from "./publicWiki";
+
+const publicWikiResponse = {
+  basic: {
+    agencyName: "North Harbor Entertainment",
+    debutDate: "2022-03-14",
+    fandomName: "Daybreak",
+    generation: "5th",
+    groupType: "Girl Group",
+    name: "Aurora Echo",
+    normalizedName: "aurora-echo",
+    officialColors: ["Solar Gold", "Midnight Blue"],
+    representativeSymbol: "Solar wave",
+    status: "Active",
+  },
+  heroImage: {
+    alt: "Aurora Echo public image",
+    src: "https://cdn.example.com/aurora-echo.webp",
+  },
+  language: "ja",
+  resourceType: "group",
+  sections: [
+    {
+      id: "overview",
+      title: "Overview",
+      content: "Published overview from the backend.",
+    },
+  ],
+  slug: "gr-aurora-echo",
+  themeColor: "#4c5cff",
+  version: 4,
+  wikiIdentifier: "wiki-1",
+};
+
+describe("publicWiki", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes a public wiki response into the shared detail shape", () => {
+    const wiki = adaptPublicWikiResponse(publicWikiResponse);
+
+    expect(wiki).toMatchObject({
+      basic: {
+        agencyName: "North Harbor Entertainment",
+        name: "Aurora Echo",
+        resourceType: "group",
+      },
+      heroImage: {
+        alt: "Aurora Echo public image",
+        src: "https://cdn.example.com/aurora-echo.webp",
+      },
+      language: "ja",
+      resourceType: "group",
+      slug: "gr-aurora-echo",
+      themeColor: "#4c5cff",
+      version: 4,
+    });
+    expect(wiki.sections).toEqual([
+      {
+        type: "section",
+        sectionIdentifier: "overview",
+        title: "Overview",
+        displayOrder: 1,
+        depth: 1,
+        contents: [
+          {
+            blockIdentifier: "overview-text-1",
+            blockType: "text",
+            displayOrder: 1,
+            content: "Published overview from the backend.",
+          },
+        ],
+        children: [],
+      },
+    ]);
+  });
+
+  it("builds the public wiki endpoint from language, resource type, and slug", () => {
+    expect(getPublicWikiEndpointPath("ja", "group", "gr-aurora echo")).toBe(
+      "/wiki/ja/group/gr-aurora%20echo",
+    );
+  });
+
+  it("fetches the public wiki by inferred slug resource type", async () => {
+    const client = {
+      fetchWiki: vi.fn().mockResolvedValue(publicWikiResponse),
+    };
+
+    await expect(fetchPublicWiki(client, "ja", "gr-aurora-echo")).resolves.toMatchObject({
+      basic: {
+        name: "Aurora Echo",
+      },
+      slug: "gr-aurora-echo",
+    });
+    expect(client.fetchWiki).toHaveBeenCalledWith("ja", "group", "gr-aurora-echo");
+  });
+
+  it("returns empty for unsupported public wiki slug prefixes", async () => {
+    const client = {
+      fetchWiki: vi.fn(),
+    };
+
+    await expect(fetchPublicWiki(client, "ja", "aurora-echo")).resolves.toBeNull();
+    expect(client.fetchWiki).not.toHaveBeenCalled();
+  });
+
+  it("creates a fetch client with the wiki api prefix", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue(publicWikiResponse),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = createPublicWikiApiClient("http://127.0.0.1:8080");
+
+    await expect(client?.fetchWiki("ja", "group", "gr-aurora-echo")).resolves.toEqual(
+      publicWikiResponse,
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8080/api/wiki/wiki/ja/group/gr-aurora-echo",
+      expect.objectContaining({
+        headers: {
+          accept: "application/json",
+        },
+      }),
+    );
+  });
+
+  it("returns an error when the wiki api base url is not configured", async () => {
+    expect(createPublicWikiApiClient("")).toBeNull();
+    await expect(loadPublicWikiState("ja", "gr-twice")).resolves.toEqual({
+      status: "error",
+      message: "Wiki API is not configured.",
+    });
+  });
+
+  it("turns api errors into a specific message", () => {
+    expect(
+      getPublicWikiErrorMessage({
+        response: {
+          status: 404,
+        },
+      }),
+    ).toBe("Public wiki was not found.");
+
+    expect(
+      getPublicWikiErrorMessage({
+        response: {
+          data: {
+            message: "published wiki failed",
+          },
+          status: 500,
+        },
+      }),
+    ).toBe("published wiki failed");
+  });
+});

--- a/src/app/wiki/publicWiki.ts
+++ b/src/app/wiki/publicWiki.ts
@@ -1,0 +1,143 @@
+import { type WikiDetail, type WikiDetailState } from "@kpool/wiki";
+import { z } from "zod";
+
+import {
+  getWikiResourceTypeFromSlug,
+  type WikiResourceType,
+} from "./wikiRouting";
+import {
+  adaptWikiApiResponse,
+  getWikiApiErrorMessage,
+  withWikiApiPrefix,
+} from "./wikiApiModel";
+
+const publicWikiHeroImageSchema = z
+  .object({
+    imageIdentifier: z.string().nullable().optional(),
+    src: z.string().optional(),
+    alt: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const publicWikiApiResponseSchema = z
+  .object({
+    wikiIdentifier: z.string(),
+    slug: z.string(),
+    language: z.string(),
+    resourceType: z.string(),
+    version: z.number().int(),
+    themeColor: z.string().nullable().optional(),
+    heroImage: publicWikiHeroImageSchema.nullable().optional(),
+    basic: z.unknown(),
+    sections: z.array(z.unknown()),
+  })
+  .passthrough();
+
+type PublicWikiApiResponse = z.infer<typeof publicWikiApiResponseSchema>;
+
+export type PublicWikiApiClient = {
+  fetchWiki: (
+    language: string,
+    resourceType: WikiResourceType,
+    slug: string,
+  ) => Promise<unknown>;
+};
+
+const defaultApiBaseUrl = process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
+
+export const getPublicWikiEndpointPath = (
+  language: string,
+  resourceType: WikiResourceType,
+  slug: string,
+): string =>
+  `/wiki/${encodeURIComponent(language)}/${resourceType}/${encodeURIComponent(slug)}`;
+
+export const createPublicWikiApiClient = (
+  baseUrl: string = defaultApiBaseUrl ?? "",
+): PublicWikiApiClient | null => {
+  if (!baseUrl) {
+    return null;
+  }
+
+  const apiBaseUrl = withWikiApiPrefix(baseUrl);
+
+  return {
+    fetchWiki: async (language, resourceType, slug) => {
+      const response = await fetch(
+        `${apiBaseUrl}${getPublicWikiEndpointPath(language, resourceType, slug)}`,
+        {
+          headers: {
+            accept: "application/json",
+          },
+          next: {
+            revalidate: 60,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw {
+          response: {
+            status: response.status,
+            data: await response.json().catch(() => null),
+          },
+        };
+      }
+
+      return response.json();
+    },
+  };
+};
+
+export const adaptPublicWikiResponse = (
+  response: PublicWikiApiResponse,
+): WikiDetail => adaptWikiApiResponse(response);
+
+export const fetchPublicWiki = async (
+  client: PublicWikiApiClient,
+  language: string,
+  slug: string,
+): Promise<WikiDetail | null> => {
+  const resourceType = getWikiResourceTypeFromSlug(slug);
+
+  if (!resourceType) {
+    return null;
+  }
+
+  const response = await client.fetchWiki(language, resourceType, slug);
+
+  return adaptPublicWikiResponse(publicWikiApiResponseSchema.parse(response));
+};
+
+export const getPublicWikiErrorMessage = (error: unknown): string =>
+  getWikiApiErrorMessage(error, {
+    notFound: "Public wiki was not found.",
+    requestFailedPrefix: "Public wiki request failed with status",
+    responseSchemaPrefix: "Public wiki response did not match the expected schema",
+    unavailable: "Public wikis are temporarily unavailable. Please try again later.",
+  });
+
+export const loadPublicWikiState = async (
+  language: string,
+  slug: string,
+): Promise<WikiDetailState> => {
+  const client = createPublicWikiApiClient();
+
+  if (!client) {
+    return {
+      status: "error",
+      message: "Wiki API is not configured.",
+    };
+  }
+
+  try {
+    const wiki = await fetchPublicWiki(client, language, slug);
+
+    return wiki ? { status: "success", data: wiki } : { status: "empty" };
+  } catch (error) {
+    return {
+      status: "error",
+      message: getPublicWikiErrorMessage(error),
+    };
+  }
+};

--- a/src/app/wiki/wikiApiModel.ts
+++ b/src/app/wiki/wikiApiModel.ts
@@ -1,0 +1,264 @@
+import { type WikiBasic, type WikiDetail, wikiDetailSchema } from "@kpool/wiki";
+import { z } from "zod";
+
+import {
+  getWikiResourceTypeFromSlug,
+  type WikiResourceType,
+} from "./wikiRouting";
+
+export const trimTrailingSlashes = (value: string): string => {
+  let trimmedValue = value;
+
+  while (trimmedValue.endsWith("/")) {
+    trimmedValue = trimmedValue.slice(0, -1);
+  }
+
+  return trimmedValue;
+};
+
+export const withWikiApiPrefix = (baseUrl: string): string =>
+  baseUrl.endsWith("/api/wiki")
+    ? baseUrl
+    : `${trimTrailingSlashes(baseUrl)}/api/wiki`;
+
+export const toStringArray = (value: unknown): string[] | undefined =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : undefined;
+
+export const toOptionalString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+export const toNullableString = (value: unknown): string | null | undefined =>
+  typeof value === "string" ? value : value === null ? null : undefined;
+
+type WikiApiResponse = {
+  basic?: unknown;
+  heroImage?: {
+    imageIdentifier?: string | null;
+    src?: string;
+    alt?: string | null;
+  } | null;
+  language: string;
+  resourceType?: unknown;
+  sections: unknown[];
+  slug: string;
+  themeColor?: string | null;
+  version: number;
+  wikiIdentifier: string;
+};
+
+export const inferResourceType = (response: WikiApiResponse): WikiResourceType => {
+  const fromSlug = getWikiResourceTypeFromSlug(response.slug);
+
+  if (fromSlug) {
+    return fromSlug;
+  }
+
+  if (
+    response.resourceType === "agency" ||
+    response.resourceType === "group" ||
+    response.resourceType === "song" ||
+    response.resourceType === "talent"
+  ) {
+    return response.resourceType;
+  }
+
+  return "group";
+};
+
+export const createPlaceholderHeroImage = (
+  name: string,
+  resourceType: WikiResourceType,
+  imageIdentifier?: string | null,
+): WikiDetail["heroImage"] => ({
+  alt: `${name} hero image`,
+  src:
+    "data:image/svg+xml;utf8," +
+    encodeURIComponent(`
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900">
+        <defs>
+          <linearGradient id="wiki-gradient" x1="0%" x2="100%" y1="0%" y2="100%">
+            <stop offset="0%" stop-color="#16253f" />
+            <stop offset="100%" stop-color="#3560a3" />
+          </linearGradient>
+        </defs>
+        <rect width="1200" height="900" fill="url(#wiki-gradient)" />
+        <text x="64" y="120" fill="#ffffff" font-family="Arial, sans-serif" font-size="42">
+          ${resourceType.toUpperCase()}
+        </text>
+        <text x="64" y="184" fill="#ffffff" font-family="Arial, sans-serif" font-size="60">
+          ${name}
+        </text>
+        <text x="64" y="248" fill="#cfd8e6" font-family="Arial, sans-serif" font-size="28">
+          ${imageIdentifier ?? "wiki-hero-image"}
+        </text>
+      </svg>
+    `),
+});
+
+const adaptWikiBasic = (response: WikiApiResponse): WikiBasic => {
+  const basic =
+    typeof response.basic === "object" && response.basic !== null
+      ? (response.basic as Record<string, unknown>)
+      : {};
+  const resourceType = inferResourceType(response);
+
+  return {
+    name: String(basic.name ?? response.slug),
+    normalizedName: String(basic.normalizedName ?? basic.name ?? response.slug),
+    resourceType,
+    agencyName: toNullableString(basic.agencyName),
+    albumName: toOptionalString(basic.albumName),
+    arranger: toOptionalString(basic.arranger),
+    birthday: toOptionalString(basic.birthday),
+    bloodType: toOptionalString(basic.bloodType),
+    ceo: toOptionalString(basic.ceo),
+    composer: toOptionalString(basic.composer),
+    debutDate: toOptionalString(basic.debutDate),
+    emoji: toOptionalString(basic.emoji),
+    englishLevel: toOptionalString(basic.englishLevel),
+    fandomName: toOptionalString(basic.fandomName),
+    generation: toOptionalString(basic.generation),
+    genres: toStringArray(basic.genres),
+    groupType: toOptionalString(basic.groupType),
+    height: typeof basic.height === "number" ? basic.height : undefined,
+    lyricist: toOptionalString(basic.lyricist),
+    mbti: toOptionalString(basic.mbti),
+    officialColors: toStringArray(basic.officialColors),
+    officialWebsite: toOptionalString(basic.officialWebsite),
+    position: toOptionalString(basic.position),
+    realName: toOptionalString(basic.realName),
+    releaseDate: toOptionalString(basic.releaseDate),
+    representativeSymbol: toOptionalString(basic.representativeSymbol),
+    socialLinks: toStringArray(basic.socialLinks),
+    songType: toOptionalString(basic.songType),
+    status: toOptionalString(basic.status),
+    zodiacSign: toOptionalString(basic.zodiacSign),
+  };
+};
+
+const toSectionIdentifier = (value: unknown, index: number): string =>
+  typeof value === "string" && value.length > 0 ? value : `section-${index + 1}`;
+
+const toSectionTitle = (value: unknown, fallback: string): string =>
+  typeof value === "string" && value.length > 0 ? value : fallback;
+
+const adaptWikiSections = (sections: unknown[]): WikiDetail["sections"] =>
+  sections.map((section, index) => {
+    const sectionRecord =
+      typeof section === "object" && section !== null
+        ? (section as Record<string, unknown>)
+        : {};
+    const sectionIdentifier = toSectionIdentifier(sectionRecord.id, index);
+    const content =
+      typeof sectionRecord.content === "string" ? sectionRecord.content : "";
+
+    return {
+      type: "section",
+      sectionIdentifier,
+      title: toSectionTitle(sectionRecord.title, sectionIdentifier),
+      displayOrder: index + 1,
+      depth: 1,
+      contents: content
+        ? [
+            {
+              blockIdentifier: `${sectionIdentifier}-text-1`,
+              blockType: "text",
+              displayOrder: 1,
+              content,
+            },
+          ]
+        : [],
+      children: [],
+    };
+  });
+
+const getHeroImage = (response: WikiApiResponse): WikiDetail["heroImage"] => {
+  const basic =
+    typeof response.basic === "object" && response.basic !== null
+      ? (response.basic as Record<string, unknown>)
+      : {};
+  const name = String(basic.name ?? response.slug);
+
+  if (response.heroImage?.src) {
+    return {
+      alt: response.heroImage.alt ?? `${name} hero image`,
+      src: response.heroImage.src,
+    };
+  }
+
+  return createPlaceholderHeroImage(
+    name,
+    inferResourceType(response),
+    response.heroImage?.imageIdentifier,
+  );
+};
+
+export const adaptWikiApiResponse = (response: WikiApiResponse): WikiDetail =>
+  wikiDetailSchema.parse({
+    basic: adaptWikiBasic(response),
+    heroImage: getHeroImage(response),
+    language: response.language,
+    resourceType: inferResourceType(response),
+    sections: adaptWikiSections(response.sections),
+    slug: response.slug,
+    themeColor: response.themeColor ?? null,
+    version: response.version,
+    wikiIdentifier: response.wikiIdentifier,
+  });
+
+export const getWikiApiErrorMessage = (
+  error: unknown,
+  messages: {
+    notFound: string;
+    responseSchemaPrefix: string;
+    unavailable: string;
+    requestFailedPrefix: string;
+  },
+): string => {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof (error as { response?: unknown }).response === "object" &&
+    (error as { response?: unknown }).response !== null
+  ) {
+    const response = (error as {
+      response: {
+        status?: number;
+        data?: unknown;
+      };
+    }).response;
+    const detail =
+      typeof response.data === "object" &&
+      response.data !== null &&
+      "message" in response.data &&
+      typeof (response.data as { message: unknown }).message === "string"
+        ? (response.data as { message: string }).message
+        : null;
+
+    if (response.status === 404) {
+      return detail ?? messages.notFound;
+    }
+
+    if (response.status) {
+      return detail ?? `${messages.requestFailedPrefix} ${response.status}.`;
+    }
+  }
+
+  if (error instanceof z.ZodError) {
+    return `${messages.responseSchemaPrefix}: ${error.issues[0]?.message ?? "invalid response"}`;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+
+  return messages.unavailable;
+};

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -49,7 +49,7 @@ test("home page demo links open the wiki detail page with a theme color override
   await page.getByTestId("wiki-theme-demo-rose-stage").click();
 
   await expect(page).toHaveURL(/themeColor=%23d94f70/);
-  await expect(page.getByTestId("wiki-theme-badge")).toHaveText("Theme #D94F70");
+  await expect(page.getByTestId("wiki-theme-badge")).toHaveCount(0);
   await expect(page.getByTestId("wiki-theme-root")).toHaveAttribute(
     "style",
     /--wiki-page-background-light:/,

--- a/tests/e2e/wiki-detail.spec.ts
+++ b/tests/e2e/wiki-detail.spec.ts
@@ -9,7 +9,7 @@ test("wiki detail page shows the public layout and flip interaction", async ({
   await expect(
     page.getByRole("heading", { name: /Aurora Echo/i }),
   ).toBeVisible();
-  await expect(page.getByTestId("wiki-theme-badge")).toHaveText("Theme #4C5CFF");
+  await expect(page.getByTestId("wiki-theme-badge")).toHaveCount(0);
   await expect(page.getByTestId("wiki-theme-root")).toHaveAttribute(
     "style",
     /--wiki-header-background-light:/,
@@ -65,9 +65,7 @@ test("wiki edit page supports inline edits and nested content controls", async (
   await page.goto("/wiki/ja/gr-aurora-echo/edit?themeColor=%234c5cff");
 
   await expect(page.getByRole("heading", { name: "Aurora Echo" })).toBeVisible();
-  await expect(page.getByTestId("wiki-edit-theme-badge")).toHaveText(
-    "Theme #4C5CFF",
-  );
+  await expect(page.getByTestId("wiki-edit-theme-badge")).toHaveCount(0);
   await expect(page.getByText("Saved")).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Save wiki changes" })).toHaveCount(1);
   await expect(page.getByRole("button", { name: "Submit wiki for review" })).toHaveCount(1);


### PR DESCRIPTION
## 📝 変更内容

公開 Wiki 詳細ページの表示データを、フロントエンド内の詳細取得フックからバックエンドの公開 Wiki API 経由で読み込む構成に変更しました。

- 公開 Wiki API クライアントとレスポンス変換処理を追加
- ドラフト Wiki と公開 Wiki で共通利用する API レスポンス変換処理を `wikiApiModel.ts` に分離
- 言語付き Wiki 詳細ページで `loadPublicWikiState` を呼び出し、`WikiDetailPage` に状態を渡すよう変更
- Wiki 詳細 / 編集画面のテーマカラーコード表示バッジを削除
- 公開 Wiki API の単体テストと既存テストを更新
- README の環境変数説明を公開 Wiki 取得にも合う内容へ更新

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🔧 リファクタリング (Refactoring)
- [x] 🧪 テスト (Tests)
- [x] 💄 UI/UX (Style)

## 🎯 変更理由・背景

公開 Wiki 詳細ページをバックエンドの公開 API と接続し、実際の公開データをサーバー側で取得して表示できるようにするためです。

また、ドラフト Wiki と公開 Wiki で共通するレスポンス正規化・エラーメッセージ生成処理を分離し、今後の API 接続範囲拡張時に重複を増やさない構成にしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- 公開 Wiki 詳細ページでテーマカラー CSS 変数が適用されることをテストで確認
- テーマカラーコードのバッジが表示されないことをユニットテスト / E2E テストで確認
- 公開 Wiki API の endpoint 生成、fetch、エラー処理、レスポンス変換を単体テストで確認

## 🔍 レビューのポイント

- 公開 Wiki API のパス形式がバックエンド想定と一致しているか
- `wikiApiModel.ts` に分離したレスポンス変換処理がドラフト Wiki / 公開 Wiki の両方に適しているか
- API 未設定、404、レスポンススキーマ不一致時の状態表示が妥当か
- テーマカラーコード表示バッジ削除後もテーマ CSS 変数が正しく適用されているか

## 📖 関連情報

### 関連Issue・タスク

Closes #60

## ⚠️ 注意事項

- `KPOOL_WIKI_PRIVATE_API_BASE_URL` が未設定の場合、公開 Wiki 詳細ページは API 未設定エラーを表示します
- 型生成ファイルの更新はありません

## 📸 スクリーンショット・デモ

UI 表示は既存レイアウトを維持しつつ、テーマカラーコードのバッジ表示のみ削除しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
