### PR TITLE
Zodスキーマの更新

### DIFF
--- a/packages/types/src/wiki-private-api.ts
+++ b/packages/types/src/wiki-private-api.ts
@@ -69,6 +69,30 @@ const ImageHideRequestSummary = z
     status: z.string(),
   })
   .passthrough();
+const UploadedImageListItem = z
+  .object({
+    imageIdentifier: KPool_Common_Uuid,
+    url: z.string(),
+    resourceType: z.string(),
+    wikiIdentifier: KPool_Common_Uuid,
+    imageUsage: z.string(),
+    displayOrder: z.number().int(),
+    sourceUrl: z.string(),
+    sourceName: z.string(),
+    altText: z.string(),
+    isHidden: z.boolean(),
+    uploadedAt: z.string().nullable(),
+  })
+  .passthrough();
+const ListUploadedImagesResponseBody = z
+  .object({
+    images: z.array(UploadedImageListItem),
+    current_page: z.number().int(),
+    last_page: z.number().int(),
+    total: z.number().int(),
+    per_page: z.number().int(),
+  })
+  .passthrough();
 const RequestCertificationRequestBody = z
   .object({
     resourceType: z.string(),
@@ -442,6 +466,8 @@ export const schemas = {
   ImageSummary,
   RequestImageHideRequestBody,
   ImageHideRequestSummary,
+  UploadedImageListItem,
+  ListUploadedImagesResponseBody,
   RequestCertificationRequestBody,
   OfficialCertificationSummary,
   PolicyConditionClause,
@@ -800,6 +826,43 @@ const endpoints = makeApi([
       {
         status: 403,
         description: `Access is forbidden.`,
+        schema: KPool_Common_ProblemDetails,
+      },
+      {
+        status: 422,
+        description: `Client error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+      {
+        status: 500,
+        description: `Server error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+    ],
+  },
+  {
+    method: "get",
+    path: "/images",
+    alias: "ImageListOperations_listUploadedImages",
+    description: `List uploaded images.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "wikiIdentifier",
+        type: "Query",
+        schema: z.string().uuid(),
+      },
+      {
+        name: "perPage",
+        type: "Query",
+        schema: z.number().int().optional(),
+      },
+    ],
+    response: ListUploadedImagesResponseBody,
+    errors: [
+      {
+        status: 401,
+        description: `Access is unauthorized.`,
         schema: KPool_Common_ProblemDetails,
       },
       {

--- a/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
+++ b/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { wikiStorySection } from "../storybook/fixtures";
 import { WikiSectionAccordion } from "./index";
 
 describe("WikiSectionAccordion", () => {
+  afterEach(() => cleanup());
+
   it("renders the section summary closed by default", () => {
     render(<WikiSectionAccordion language="ja" section={wikiStorySection} />);
 


### PR DESCRIPTION
## 📝 変更内容

バックエンドの最新 OpenAPI 定義から生成した Zod スキーマを更新し、フロントエンドで利用する依存関係を同期しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

バックエンドの API 仕様とフロントエンドの Zod スキーマを手動実行 workflow で同期できるようにするためです。

## 🧪 テスト

### テストの実行確認

- [ ] `make check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `pnpm run lint`
- `pnpm run build`

## 🔍 レビューのポイント

- OpenAPI 由来の `packages/types/src/*.ts` が API ごとに更新されていること
- `zod` と `@zodios/core` の依存追加または更新内容が妥当であること
- 生成ファイルの差分がバックエンドの最新 API 仕様と整合していること

## 📖 関連情報

### 関連Issue・タスク

Closes #該当なし
Fixes #該当なし
Relates to kpool09122/kpool-backend#146

## ⚠️ 注意事項

生成ファイルはバックエンドの OpenAPI をもとに自動生成しています。手修正が必要な場合は、先に生成元または生成処理を更新してください。


---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
