### PR TITLE
Zodスキーマの更新

### DIFF
--- a/packages/types/src/wiki-private-api.ts
+++ b/packages/types/src/wiki-private-api.ts
@@ -2,6 +2,48 @@ import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
 import { z } from "zod";
 
 const KPool_Common_Uuid = z.string();
+const wikiIdentifier = KPool_Common_Uuid.nullish();
+const DraftImageStatus = z.enum([
+  "approved",
+  "pending",
+  "rejected",
+  "under_review",
+]);
+const DraftImageListItem = z
+  .object({
+    imageIdentifier: KPool_Common_Uuid,
+    publishedImageIdentifier: KPool_Common_Uuid.nullable(),
+    url: z.string(),
+    resourceType: z.string(),
+    wikiIdentifier: KPool_Common_Uuid,
+    imageUsage: z.string(),
+    displayOrder: z.number().int(),
+    sourceUrl: z.string(),
+    sourceName: z.string(),
+    altText: z.string(),
+    status: DraftImageStatus,
+    uploadedAt: z.string().nullable(),
+  })
+  .passthrough();
+const ListDraftImagesResponseBody = z
+  .object({
+    images: z.array(DraftImageListItem),
+    current_page: z.number().int(),
+    last_page: z.number().int(),
+    total: z.number().int(),
+    per_page: z.number().int(),
+  })
+  .passthrough();
+const KPool_Common_ProblemDetails = z
+  .object({
+    type: z.string(),
+    status: z.number().int(),
+    title: z.string(),
+    detail: z.string(),
+    instance: z.string(),
+  })
+  .partial()
+  .passthrough();
 const UploadImageRequestBody = z
   .object({
     publishedImageIdentifier: KPool_Common_Uuid.optional(),
@@ -23,16 +65,6 @@ const ImageDraftSummary = z
     imageUsage: z.string(),
     status: z.string(),
   })
-  .passthrough();
-const KPool_Common_ProblemDetails = z
-  .object({
-    type: z.string(),
-    status: z.number().int(),
-    title: z.string(),
-    detail: z.string(),
-    instance: z.string(),
-  })
-  .partial()
   .passthrough();
 const ReviewImageHideRequestBody = z
   .object({ reviewerComment: z.string() })
@@ -458,9 +490,13 @@ const ListWikisResponseBody = z
 
 export const schemas = {
   KPool_Common_Uuid,
+  wikiIdentifier,
+  DraftImageStatus,
+  DraftImageListItem,
+  ListDraftImagesResponseBody,
+  KPool_Common_ProblemDetails,
   UploadImageRequestBody,
   ImageDraftSummary,
-  KPool_Common_ProblemDetails,
   ReviewImageHideRequestBody,
   ImageHideReviewSummary,
   ImageSummary,
@@ -514,6 +550,48 @@ export const schemas = {
 };
 
 const endpoints = makeApi([
+  {
+    method: "get",
+    path: "/draft-images",
+    alias: "DraftImageListOperations_listDraftImages",
+    description: `List draft images.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "wikiIdentifier",
+        type: "Query",
+        schema: wikiIdentifier,
+      },
+      {
+        name: "status",
+        type: "Query",
+        schema: z.enum(["approved", "pending", "rejected", "under_review"]),
+      },
+      {
+        name: "perPage",
+        type: "Query",
+        schema: z.number().int().optional(),
+      },
+    ],
+    response: ListDraftImagesResponseBody,
+    errors: [
+      {
+        status: 401,
+        description: `Access is unauthorized.`,
+        schema: KPool_Common_ProblemDetails,
+      },
+      {
+        status: 422,
+        description: `Client error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+      {
+        status: 500,
+        description: `Server error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+    ],
+  },
   {
     method: "delete",
     path: "/image/:imageId",
@@ -1292,6 +1370,26 @@ const endpoints = makeApi([
       {
         status: 422,
         description: `Client error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+      {
+        status: 500,
+        description: `Server error`,
+        schema: KPool_Common_ProblemDetails,
+      },
+    ],
+  },
+  {
+    method: "get",
+    path: "/principal/me",
+    alias: "PrincipalOperations_getCurrentPrincipal",
+    description: `Get the principal associated with the authenticated identity.`,
+    requestFormat: "json",
+    response: PrincipalSummary,
+    errors: [
+      {
+        status: 404,
+        description: `The server cannot find the requested resource.`,
         schema: KPool_Common_ProblemDetails,
       },
       {


### PR DESCRIPTION
## 📝 変更内容

バックエンドの最新 OpenAPI 定義から生成した Zod スキーマを更新し、フロントエンドで利用する依存関係を同期しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

バックエンドの API 仕様とフロントエンドの Zod スキーマを手動実行 workflow で同期できるようにするためです。

## 🧪 テスト

### テストの実行確認

- [ ] `make check` を実行し、すべてのテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `pnpm run lint`
- `pnpm run build`

## 🔍 レビューのポイント

- OpenAPI 由来の `packages/types/src/*.ts` が API ごとに更新されていること
- `zod` と `@zodios/core` の依存追加または更新内容が妥当であること
- 生成ファイルの差分がバックエンドの最新 API 仕様と整合していること

## 📖 関連情報

### 関連Issue・タスク

Closes #該当なし
Fixes #該当なし
Relates to kpool09122/kpool-backend#146

## ⚠️ 注意事項

生成ファイルはバックエンドの OpenAPI をもとに自動生成しています。手修正が必要な場合は、先に生成元または生成処理を更新してください。


---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [ ] 破壊的変更がある場合は適切に文書化した
