### PR TITLE
Wiki編集導線に認証ゲートを追加

### DIFF
--- a/src/app/wiki/[language]/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[language]/[slug]/edit/page.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cookies: vi.fn(),
+  fetchAuthenticatedIdentity: vi.fn(),
+  getCurrentWikiPrincipalForRequest: vi.fn(),
+  loadDraftWikiState: vi.fn(),
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mocks.cookies,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("../../../../authIdentity", () => ({
+  fetchAuthenticatedIdentity: mocks.fetchAuthenticatedIdentity,
+}));
+
+vi.mock("../../../draftWiki", () => ({
+  loadDraftWikiState: mocks.loadDraftWikiState,
+}));
+
+vi.mock("../../../wikiPrincipal", () => ({
+  getCurrentWikiPrincipalForRequest: mocks.getCurrentWikiPrincipalForRequest,
+}));
+
+vi.mock("../../../[slug]/edit/WikiEditPage", () => ({
+  WikiEditPage: ({ wikiState }: { wikiState: { status: string } }) => (
+    <div data-testid="wiki-edit-page">{wikiState.status}</div>
+  ),
+}));
+
+import Page from "./page";
+
+const routeProps = (searchParams: Record<string, string> = {}) => ({
+  params: Promise.resolve({
+    language: "ja",
+    slug: "gr-aurora-echo",
+  }),
+  searchParams: Promise.resolve(searchParams),
+});
+
+describe("Wiki edit route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cookies.mockResolvedValue({
+      toString: () => "session=abc",
+    });
+    mocks.loadDraftWikiState.mockResolvedValue({
+      status: "success",
+      data: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loads the draft directly when the edit auth gate is absent", async () => {
+    render(await Page(routeProps()));
+
+    expect(screen.getByTestId("wiki-edit-page")).toHaveTextContent("success");
+    expect(mocks.fetchAuthenticatedIdentity).not.toHaveBeenCalled();
+    expect(mocks.getCurrentWikiPrincipalForRequest).not.toHaveBeenCalled();
+    expect(mocks.loadDraftWikiState).toHaveBeenCalledWith("ja", "gr-aurora-echo");
+  });
+
+  it("redirects gated unauthenticated edits to login with the edit return path", async () => {
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue(null);
+
+    await expect(Page(routeProps({ authGate: "1" }))).rejects.toThrow(
+      "redirect:/login?returnTo=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit%3FauthGate%3D1",
+    );
+  });
+
+  it("redirects gated edits to mypage when the principal is missing", async () => {
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
+      identityIdentifier: "identity-1",
+    });
+    mocks.getCurrentWikiPrincipalForRequest.mockResolvedValue({ status: "missing" });
+
+    await expect(Page(routeProps({ authGate: "1" }))).rejects.toThrow(
+      "redirect:/mypage",
+    );
+  });
+
+  it("loads the draft for gated edits when identity and principal are available", async () => {
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
+      identityIdentifier: "identity-1",
+    });
+    mocks.getCurrentWikiPrincipalForRequest.mockResolvedValue({
+      status: "available",
+      principal: {},
+    });
+
+    render(await Page(routeProps({ authGate: "1" })));
+
+    expect(screen.getByTestId("wiki-edit-page")).toHaveTextContent("success");
+    expect(mocks.getCurrentWikiPrincipalForRequest).toHaveBeenCalledWith({
+      cookieHeader: "session=abc",
+    });
+    expect(mocks.loadDraftWikiState).toHaveBeenCalledWith("ja", "gr-aurora-echo");
+  });
+});

--- a/src/app/wiki/[language]/[slug]/edit/page.tsx
+++ b/src/app/wiki/[language]/[slug]/edit/page.tsx
@@ -1,5 +1,11 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { fetchAuthenticatedIdentity } from "../../../../authIdentity";
 import { loadDraftWikiState } from "../../../draftWiki";
 import { WikiEditPage } from "../../../[slug]/edit/WikiEditPage";
+import { getCurrentWikiPrincipalForRequest } from "../../../wikiPrincipal";
+import { buildWikiEditPath } from "../../../wikiRouting";
 
 type WikiEditRouteProps = {
   params: Promise<{
@@ -7,23 +13,82 @@ type WikiEditRouteProps = {
     slug: string;
   }>;
   searchParams: Promise<{
+    authGate?: string | string[];
     themeColor?: string | string[];
   }>;
 };
 
-const getThemeColor = (value: string | string[] | undefined): string | undefined =>
+const getSingleSearchParam = (value: string | string[] | undefined): string | undefined =>
   Array.isArray(value) ? value[0] : value;
+
+const buildGatedEditReturnPath = ({
+  editPath,
+  themeColor,
+}: {
+  editPath: string;
+  themeColor?: string;
+}): string => {
+  const params = new URLSearchParams({ authGate: "1" });
+
+  if (themeColor) {
+    params.set("themeColor", themeColor);
+  }
+
+  return `${editPath}?${params.toString()}`;
+};
 
 export default async function Page({ params, searchParams }: WikiEditRouteProps) {
   const { language, slug } = await params;
-  const { themeColor } = await searchParams;
+  const { authGate, themeColor } = await searchParams;
+  const normalizedThemeColor = getSingleSearchParam(themeColor);
+  const editPath = buildWikiEditPath(language, slug);
+  const shouldGateEditAccess = getSingleSearchParam(authGate) === "1";
+
+  if (shouldGateEditAccess) {
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore.toString();
+    const authenticatedIdentity = await fetchAuthenticatedIdentity({
+      cookieHeader,
+    });
+
+    if (!authenticatedIdentity) {
+      redirect(
+        `/login?returnTo=${encodeURIComponent(
+          buildGatedEditReturnPath({ editPath, themeColor: normalizedThemeColor }),
+        )}`,
+      );
+    }
+
+    const principalState = await getCurrentWikiPrincipalForRequest({
+      cookieHeader,
+    });
+
+    if (principalState.status === "missing") {
+      redirect("/mypage");
+    }
+
+    if (principalState.status === "error") {
+      return (
+        <WikiEditPage
+          language={language}
+          slug={slug}
+          themeColor={normalizedThemeColor}
+          wikiState={{
+            status: "error",
+            message: principalState.message,
+          }}
+        />
+      );
+    }
+  }
+
   const wikiState = await loadDraftWikiState(language, slug);
 
   return (
     <WikiEditPage
       language={language}
       slug={slug}
-      themeColor={getThemeColor(themeColor)}
+      themeColor={normalizedThemeColor}
       wikiState={wikiState}
     />
   );

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -14,7 +14,7 @@ import {
   mainBackgroundStyle,
 } from "../../../components/Wiki";
 import { useI18n } from "../../i18n/I18nProvider";
-import { getWikiResourceLabel } from "../wikiRouting";
+import { buildWikiEditPath, getWikiResourceLabel } from "../wikiRouting";
 import { buildWikiThemeCssVariables } from "./wikiThemePalette";
 
 type WikiDetailPageProps = {
@@ -26,6 +26,7 @@ type WikiDetailPageProps = {
 
 export function WikiDetailPage({
   language,
+  slug,
   themeColor,
   wikiState,
 }: WikiDetailPageProps) {
@@ -86,6 +87,7 @@ export function WikiDetailPage({
 
         <WikiPublicHeroBasicSection
           basic={data.basic}
+          editHref={`${buildWikiEditPath(language, slug)}?authGate=1`}
           flipCardId={flipCardId}
           heroImage={data.heroImage}
           profileLabel={`${getWikiResourceLabel(data.resourceType)} ${t.profileSuffix}`}

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -107,6 +107,10 @@ describe("WikiDetailPage", () => {
       "href",
       "/wiki/ja/gr-aurora-echo",
     );
+    expect(screen.getAllByRole("link", { name: "Edit basic" })[0]).toHaveAttribute(
+      "href",
+      "/wiki/ja/gr-aurora-echo/edit?authGate=1",
+    );
     expect(screen.getAllByLabelText(/Edit section/i)).toHaveLength(2);
     expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
   });

--- a/src/app/wiki/wikiPrincipal.test.ts
+++ b/src/app/wiki/wikiPrincipal.test.ts
@@ -5,6 +5,7 @@ import {
   createWikiPrincipal,
   getAccountIdentifierFromIdentity,
   getCurrentWikiPrincipal,
+  getCurrentWikiPrincipalForRequest,
 } from "./wikiPrincipal";
 
 const principal = {
@@ -67,6 +68,35 @@ describe("wiki principal helpers", () => {
     await expect(getCurrentWikiPrincipal({ fetchAdapter })).resolves.toEqual({
       status: "missing",
     });
+  });
+
+  it("loads the current principal from the private API with request cookies", async () => {
+    const fetchAdapter = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(principal),
+    });
+
+    await expect(
+      getCurrentWikiPrincipalForRequest({
+        baseUrl: "https://wiki.example.test/api",
+        cookieHeader: "session=abc",
+        fetchAdapter,
+      }),
+    ).resolves.toEqual({
+      status: "available",
+      principal,
+    });
+    expect(fetchAdapter).toHaveBeenCalledWith(
+      "https://wiki.example.test/api/principal/me",
+      {
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          Cookie: "session=abc",
+        },
+      },
+    );
   });
 
   it("does not treat server errors as a missing principal", async () => {

--- a/src/app/wiki/wikiPrincipal.ts
+++ b/src/app/wiki/wikiPrincipal.ts
@@ -158,6 +158,57 @@ export const getCurrentWikiPrincipal = async ({
   }
 };
 
+export const getCurrentWikiPrincipalForRequest = async ({
+  baseUrl = getWikiPrincipalApiBaseUrl(),
+  cookieHeader,
+  fetchAdapter = fetch,
+}: {
+  baseUrl?: string;
+  cookieHeader?: string;
+  fetchAdapter?: FetchAdapter;
+} = {}): Promise<Extract<WikiPrincipalState, { status: "available" | "missing" | "error" }>> => {
+  if (!baseUrl) {
+    return {
+      status: "error",
+      message: "Wiki principal API is not configured.",
+    };
+  }
+
+  try {
+    const response = await fetchAdapter(createWikiCurrentPrincipalUrl(baseUrl), {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+        ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+      },
+    });
+    const body = await readResponseBody(response);
+
+    if (response.status === 404) {
+      return { status: "missing" };
+    }
+
+    if (!response.ok) {
+      return {
+        status: "error",
+        message: toWikiPrincipalMessage({
+          response: { status: response.status, data: body },
+        }),
+      };
+    }
+
+    return {
+      status: "available",
+      principal: wikiPrincipalSummarySchema.parse(body),
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      message: toWikiPrincipalMessage(error),
+    };
+  }
+};
+
 export const createWikiPrincipal = async ({
   accountIdentifier,
   fetchAdapter = fetch,

--- a/src/components/Wiki/WikiPublicHeroBasicSection/index.tsx
+++ b/src/components/Wiki/WikiPublicHeroBasicSection/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useState } from "react";
 import { type WikiBasic, type WikiDetail } from "@kpool/wiki";
 
@@ -16,12 +17,14 @@ import { EditIcon } from "../icons";
 type WikiPublicHeroBasicSectionProps = {
   basic: WikiBasic;
   heroImage: WikiDetail["heroImage"];
+  editHref?: string;
   flipCardId: string;
   profileLabel?: string;
 };
 
 export function WikiPublicHeroBasicSection({
   basic,
+  editHref,
   heroImage,
   flipCardId,
   profileLabel = "Basic profile",
@@ -107,6 +110,17 @@ export function WikiPublicHeroBasicSection({
                         {profileLabel}
                       </p>
                     </div>
+                    {editHref ? (
+                      <Link
+                        aria-label="Edit basic"
+                        className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                        href={editHref}
+                        onClick={(event) => event.stopPropagation()}
+                        style={cardSurfaceStyle}
+                      >
+                        <EditIcon />
+                      </Link>
+                    ) : null}
                   </div>
                   <div
                     className="mt-5 min-h-0 flex-1 overflow-y-auto pr-1"
@@ -164,14 +178,16 @@ export function WikiPublicHeroBasicSection({
                 {profileLabel}
               </p>
             </div>
-            <button
-              aria-label="Edit basic"
-              type="button"
-              className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
-              style={cardSurfaceStyle}
-            >
-              <EditIcon />
-            </button>
+            {editHref ? (
+              <Link
+                aria-label="Edit basic"
+                className="rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                href={editHref}
+                style={cardSurfaceStyle}
+              >
+                <EditIcon />
+              </Link>
+            ) : null}
           </div>
           <WikiBasicFieldsList
             basic={basic}


### PR DESCRIPTION
## 📝 変更内容

- 個別Wikiページの編集アイコンを編集ページへのリンクに変更
- 編集ボタン経由の編集ページ遷移に `authGate=1` を付与
- `authGate=1` の編集ページアクセス時に以下の順で遷移制御
  - 未ログインの場合は `returnTo` 付きでログインページへ遷移
  - Wiki principal が存在しない場合はマイページへ遷移
  - identity / principal が揃っている場合は編集ページを表示
- サーバーリクエスト上で cookie を引き継いで current principal を取得する helper を追加
- 編集ルートの認証分岐と principal 取得 helper のテストを追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

個別ページの編集ボタンから編集画面へ進む際、未ログインや Wiki principal 未作成の状態でも編集ページへ直接進もうとしていたため、期待されるログイン・マイページ導線を挟む必要がありました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task test:e2e` は実行しましたが、既存の Wiki E2E が `Public wiki was not found` で失敗しました。今回追加した auth gate ではなく、E2E用のWikiデータ取得状態に起因する失敗です。

## 🔍 レビューのポイント

- 編集ボタン経由のみ `authGate=1` で認証/principal確認を行う設計で問題ないか
- 未ログイン時の `returnTo` が編集ページへ戻る導線として適切か
- principal 未作成時に `/mypage` へ送る判定が要件通りか

## ⚠️ 注意事項

- 環境変数の追加はありません。
- 既存の直接 `/wiki/:language/:slug/edit` アクセスは `authGate` なしの場合、従来通り draft 読み込みへ進みます。

## 📸 スクリーンショット・デモ

- 画面見た目の大きな変更はありません。編集アイコンの遷移先を編集ページリンクに変更しています。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
