### PR TITLE
Wiki下書き保存の認証とpayload形式を修正

### DIFF
--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -95,18 +95,18 @@ describe("wikiEditModel", () => {
     expect(deleted[0]?.contents).toEqual([]);
   });
 
-  it("converts editable contents into the backend SectionContentMapper array shape", () => {
+  it("converts editable contents into the backend section content array shape", () => {
     const wiki = createMockWikiDetail("aurora-echo");
     const payload = toWikiSectionContentPayload(wiki.sections);
 
     expect(payload[0]).toMatchObject({
       type: "section",
       title: "Overview",
-      display_order: 10,
+      displayOrder: 10,
       contents: [
         {
-          block_type: "text",
-          display_order: 10,
+          type: "text",
+          displayOrder: 10,
           content:
             "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
         },
@@ -200,46 +200,46 @@ describe("wikiEditModel", () => {
       {
         type: "section",
         title: "Overview",
-        display_order: 10,
+        displayOrder: 10,
         contents: [
           {
-            block_type: "text",
-            display_order: 10,
+            type: "text",
+            displayOrder: 10,
             content: "Aurora Echo keeps a fast release cycle.",
           },
           {
-            block_type: "text",
-            display_order: 20,
+            type: "text",
+            displayOrder: 20,
             content: "[[분류:테스트]]",
           },
           {
-            block_type: "text",
-            display_order: 30,
+            type: "text",
+            displayOrder: 30,
             content: "[* 주석 예시]",
           },
           {
-            block_type: "list",
-            display_order: 40,
-            list_type: "bullet",
+            type: "list",
+            displayOrder: 40,
+            listType: "bullet",
             items: ["Debut single", "Follow-up single"],
           },
           {
             type: "section",
             title: "Highlights",
-            display_order: 50,
+            displayOrder: 50,
             contents: [
               {
-                block_type: "table",
-                display_order: 10,
+                type: "table",
+                displayOrder: 10,
                 headers: ["Release", "Year"],
-                header_cells: [{ content: "Release" }, { content: "Year" }],
+                headerCells: [{ content: "Release" }, { content: "Year" }],
                 rows: [["Low Tide, High Lights", "2022"]],
-                row_cells: [[{ content: "Low Tide, High Lights" }, { content: "2022" }]],
-                table_width: null,
+                rowCells: [[{ content: "Low Tide, High Lights" }, { content: "2022" }]],
+                tableWidth: null,
               },
               {
-                block_type: "text",
-                display_order: 20,
+                type: "text",
+                displayOrder: 20,
                 content: "[include(틀:Discography)]",
               },
             ],
@@ -323,13 +323,13 @@ describe("wikiEditModel", () => {
       {
         type: "section",
         title: "Overview",
-        display_order: 10,
+        displayOrder: 10,
         contents: [
           {
-            block_type: "embed",
-            display_order: 10,
+            type: "embed",
+            displayOrder: 10,
             provider: "youtube",
-            embed_id: "jNQXAC9IVRw",
+            embedId: "jNQXAC9IVRw",
             caption: null,
           },
         ],
@@ -355,16 +355,16 @@ describe("wikiEditModel", () => {
       {
         type: "section",
         title: "Highlights",
-        display_order: 10,
+        displayOrder: 10,
         contents: [
           {
-            block_type: "table",
-            display_order: 10,
+            type: "table",
+            displayOrder: 10,
             headers: ["Release", "Year"],
-            header_cells: [{ content: "Release" }, { content: "Year" }],
+            headerCells: [{ content: "Release" }, { content: "Year" }],
             rows: [["Aurora Echo"]],
-            row_cells: [[{ content: "Aurora Echo", colspan: 2 }]],
-            table_width: 320,
+            rowCells: [[{ content: "Aurora Echo", colspan: 2 }]],
+            tableWidth: 320,
           },
         ],
       },

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -16,28 +16,28 @@ export type WikiSectionContentPayload =
   | {
       type: "section";
       title: string;
-      display_order: number;
+      displayOrder: number;
       contents: WikiSectionContentPayload[];
     }
   | {
-      block_type: WikiBlockType;
-      display_order: number;
+      type: WikiBlockType;
+      displayOrder: number;
       content?: string;
-      image_identifier?: string;
-      image_identifiers?: string[];
+      imageIdentifier?: string;
+      imageIdentifiers?: string[];
       caption?: string | null;
       alt?: string | null;
       provider?: string;
-      embed_id?: string;
+      embedId?: string;
       source?: string | null;
-      list_type?: string;
+      listType?: string;
       items?: string[];
       rows?: string[][];
       headers?: string[] | null;
-      row_cells?: Array<Array<{ content: string; colspan?: number }>>;
-      header_cells?: Array<{ content: string; colspan?: number }> | null;
-      table_width?: number | null;
-      wiki_identifiers?: string[];
+      rowCells?: Array<Array<{ content: string; colspan?: number }>>;
+      headerCells?: Array<{ content: string; colspan?: number }> | null;
+      tableWidth?: number | null;
+      wikiIdentifiers?: string[];
       title?: string | null;
     };
 
@@ -1350,7 +1350,7 @@ const toWikiContentPayload = (
     return {
       type: "section",
       title: content.title,
-      display_order: content.displayOrder,
+      displayOrder: content.displayOrder,
       contents: sortWikiSectionContents(content.contents).map(toWikiContentPayload),
     };
   }
@@ -1358,62 +1358,62 @@ const toWikiContentPayload = (
   switch (content.blockType) {
     case "text":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
         content: content.content,
       };
     case "image":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
-        image_identifier: content.imageIdentifier,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
+        imageIdentifier: content.imageIdentifier,
         caption: content.caption,
         alt: content.alt,
       };
     case "image_gallery":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
-        image_identifiers: content.images.map((image) => image.imageIdentifier),
+        type: content.blockType,
+        displayOrder: content.displayOrder,
+        imageIdentifiers: content.images.map((image) => image.imageIdentifier),
         caption: content.caption,
       };
     case "embed":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
         provider: content.provider,
-        embed_id: content.embedId,
+        embedId: content.embedId,
         caption: content.caption,
       };
     case "quote":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
         content: content.content,
         source: content.source,
       };
     case "list":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
-        list_type: content.listType,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
+        listType: content.listType,
         items: content.items,
       };
     case "table":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
         rows: content.rows,
         headers: content.headers,
-        row_cells: content.rowCells,
-        header_cells: content.headerCells ?? null,
-        table_width: content.tableWidth ?? null,
+        rowCells: content.rowCells,
+        headerCells: content.headerCells ?? null,
+        tableWidth: content.tableWidth ?? null,
       };
     case "profile_card_list":
       return {
-        block_type: content.blockType,
-        display_order: content.displayOrder,
-        wiki_identifiers: content.wikiIdentifiers,
+        type: content.blockType,
+        displayOrder: content.displayOrder,
+        wikiIdentifiers: content.wikiIdentifiers,
         title: content.title,
       };
   }

--- a/src/app/api/wiki/drafts/[wikiId]/route.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/route.ts
@@ -5,6 +5,7 @@ import {
   getDraftWikiErrorMessage,
   saveDraftWiki,
 } from "../../../../wiki/draftWiki";
+import { getForwardedWikiApiHeaders } from "../../wikiRouteSupport";
 
 type WikiDraftSaveRouteContext = {
   params: Promise<{
@@ -12,8 +13,19 @@ type WikiDraftSaveRouteContext = {
   }>;
 };
 
+const stringifyLogValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
 export async function POST(request: NextRequest, context: WikiDraftSaveRouteContext) {
-  const client = createDraftWikiApiClient();
+  const client = createDraftWikiApiClient(
+    undefined,
+    getForwardedWikiApiHeaders(request.headers),
+  );
 
   if (!client) {
     return NextResponse.json(
@@ -22,13 +34,19 @@ export async function POST(request: NextRequest, context: WikiDraftSaveRouteCont
     );
   }
 
+  const { wikiId } = await context.params;
+
   try {
-    const { wikiId } = await context.params;
     const body = await request.json();
     const result = await saveDraftWiki(client, wikiId, body);
 
     return NextResponse.json(result, { status: 201 });
   } catch (error) {
+    console.error("Failed to save wiki draft.", {
+      wikiId,
+      error: stringifyLogValue(error),
+    });
+
     return NextResponse.json(
       { message: getDraftWikiErrorMessage(error) },
       { status: 502 },

--- a/src/app/wiki/draftWiki.test.ts
+++ b/src/app/wiki/draftWiki.test.ts
@@ -235,8 +235,53 @@ describe("draftWiki", () => {
       expect.objectContaining({
         cache: "no-store",
         headers: {
-          accept: "application/json",
+          Accept: "application/json",
         },
+      }),
+    );
+  });
+
+  it("forwards cookie headers when saving a draft wiki through fetch", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          language: "ja",
+          name: "Aurora Echo",
+          resourceType: "group",
+          status: "draft",
+        }),
+        { status: 200 },
+      ),
+    );
+    const client = createDraftWikiApiClient("http://127.0.0.1:8080", {
+      Accept: "application/json",
+      "Accept-Language": "ja,en;q=0.9",
+      Cookie: "laravel_session=session-value",
+    });
+    const body = {
+      resourceType: "group",
+      basic: { name: "Aurora Echo" },
+      sections: [],
+      themeColor: "#4c5cff",
+    };
+
+    await expect(client!.saveDraftWiki("wiki-1", body)).resolves.toEqual({
+      language: "ja",
+      name: "Aurora Echo",
+      resourceType: "group",
+      status: "draft",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:8080/api/wiki/wiki/wiki-1/edit",
+      expect.objectContaining({
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          "Accept-Language": "ja,en;q=0.9",
+          "Content-Type": "application/json",
+          Cookie: "laravel_session=session-value",
+        },
+        method: "POST",
       }),
     );
   });

--- a/src/app/wiki/draftWiki.ts
+++ b/src/app/wiki/draftWiki.ts
@@ -129,6 +129,7 @@ export const saveDraftWiki = async (
 
 export const createDraftWikiApiClient = (
   baseUrl: string = defaultApiBaseUrl ?? "",
+  forwardedHeaders: HeadersInit = {},
 ): DraftWikiApiClient | null => {
   const apiBaseUrl = baseUrl ? withWikiApiPrefix(baseUrl) : "";
 
@@ -140,7 +141,8 @@ export const createDraftWikiApiClient = (
             `${apiBaseUrl}${getDraftWikiEndpointPath(language, resourceType, slug)}`,
             {
               headers: {
-                accept: "application/json",
+                ...forwardedHeaders,
+                Accept: "application/json",
               },
               cache: "no-store",
             },
@@ -160,7 +162,8 @@ export const createDraftWikiApiClient = (
             {
               method: "POST",
               headers: {
-                accept: "application/json",
+                ...forwardedHeaders,
+                Accept: "application/json",
                 "Content-Type": "application/json",
               },
               body: JSON.stringify(body),


### PR DESCRIPTION
## 📝 変更内容

- Wiki 下書き保存 API から Laravel 側へ `Cookie` / `Accept-Language` を転送するように修正
- Wiki 下書き保存 payload の section / block content を API 境界仕様に合わせて camelCase に変更
  - `block_type` → `type`
  - `display_order` → `displayOrder`
  - `embed_id` / `list_type` / `row_cells` なども camelCase 化
- 下書き保存失敗時に Next.js サーバーログへ詳細な例外内容を出力
- Cookie 転送と payload 形式のユニットテストを更新・追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki 下書き保存時に Laravel の認証 Cookie がバックエンドへ転送されず、保存 API が 401 を返していました。

また、保存 payload の `sections[].contents[]` が `block_type` / `display_order` の snake_case で送信されており、backend が期待する `type` / `displayOrder` 形式と一致していませんでした。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- UI 変更なし

## 🔍 レビューのポイント

- `POST /api/wiki/drafts/[wikiId]` で `Cookie` / `Accept-Language` が Laravel 側へ転送されること
- `toWikiSectionContentPayload` の出力が backend の期待する camelCase 形式になっていること
- table / embed / list / image 系ブロックのキー変換に漏れがないこと

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- UI 変更なし
- 環境変数追加なし
- 型生成ファイルの更新なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
