### PR TITLE
fix: 公開Wiki画像を直接読み込む

### DIFF
--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -8,7 +8,7 @@ import {
 import { useId } from "react";
 
 import {
-  WikiPublicHeroBasicSection,
+  WikiPublicHeroImage,
   WikiSectionAccordion,
   WikiStatePanel,
   mainBackgroundStyle,
@@ -85,7 +85,7 @@ export function WikiDetailPage({
           </div>
         </header>
 
-        <WikiPublicHeroBasicSection
+        <WikiPublicHeroImage
           basic={data.basic}
           editHref={`${buildWikiEditPath(language, slug)}?authGate=1`}
           flipCardId={flipCardId}

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -142,7 +142,7 @@ export function WikiBlockDisplay({
       return (
         <figure>
           <div className="relative min-h-64 overflow-hidden rounded-2xl border border-stroke-subtle">
-            <Image alt={block.alt ?? ""} className="object-cover" fill sizes="100vw" src={block.imageSrc} />
+            <Image alt={block.alt ?? ""} className="object-cover" fill sizes="100vw" src={block.imageSrc} unoptimized />
             {showEditableImageOverlay ? <ImageEditableOverlay /> : null}
           </div>
           {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
@@ -154,7 +154,7 @@ export function WikiBlockDisplay({
           <div className="grid gap-3 sm:grid-cols-2">
             {block.images.map((image) => (
               <div className="relative min-h-40 overflow-hidden rounded-2xl border border-stroke-subtle" key={image.imageIdentifier}>
-                <Image alt={image.alt ?? ""} className="object-cover" fill sizes="50vw" src={image.imageSrc} />
+                <Image alt={image.alt ?? ""} className="object-cover" fill sizes="50vw" src={image.imageSrc} unoptimized />
                 {showEditableImageOverlay ? <ImageEditableOverlay /> : null}
               </div>
             ))}

--- a/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.stories.tsx
+++ b/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.stories.tsx
@@ -1,11 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { wikiStoryBasic, wikiStoryHeroImage } from "../storybook/fixtures";
-import { WikiPublicHeroBasicSection } from "../WikiPublicHeroBasicSection";
+import { WikiPublicHeroImage } from "../WikiPublicHeroImage";
 
 const meta = {
-  title: "Wiki/WikiPublicHeroBasicSection",
-  component: WikiPublicHeroBasicSection,
+  title: "Wiki/WikiPublicHeroImage",
+  component: WikiPublicHeroImage,
   args: {
     basic: wikiStoryBasic,
     heroImage: wikiStoryHeroImage,
@@ -15,7 +15,7 @@ const meta = {
     layout: "padded",
   },
   tags: ["autodocs"],
-} satisfies Meta<typeof WikiPublicHeroBasicSection>;
+} satisfies Meta<typeof WikiPublicHeroImage>;
 
 export default meta;
 
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => (
     <div className="wiki-theme-scope max-w-6xl" data-theme="light">
-      <WikiPublicHeroBasicSection {...args} />
+      <WikiPublicHeroImage {...args} />
     </div>
   ),
 };

--- a/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.test.tsx
+++ b/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.test.tsx
@@ -3,14 +3,14 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { wikiStoryBasic, wikiStoryHeroImage } from "../storybook/fixtures";
-import { WikiPublicHeroBasicSection } from "./index";
+import { WikiPublicHeroImage } from "./index";
 
-describe("WikiPublicHeroBasicSection", () => {
+describe("WikiPublicHeroImage", () => {
   afterEach(() => cleanup());
 
   it("renders the hero intro copy", () => {
     render(
-      <WikiPublicHeroBasicSection
+      <WikiPublicHeroImage
         basic={wikiStoryBasic}
         flipCardId="public-flip-card"
         heroImage={wikiStoryHeroImage}
@@ -22,7 +22,7 @@ describe("WikiPublicHeroBasicSection", () => {
 
   it("toggles the mobile helper copy when flipped", () => {
     render(
-      <WikiPublicHeroBasicSection
+      <WikiPublicHeroImage
         basic={wikiStoryBasic}
         flipCardId="public-flip-card"
         heroImage={wikiStoryHeroImage}

--- a/src/components/Wiki/WikiPublicHeroImage/index.tsx
+++ b/src/components/Wiki/WikiPublicHeroImage/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "../styles";
 import { EditIcon } from "../icons";
 
-type WikiPublicHeroBasicSectionProps = {
+type WikiPublicHeroImageProps = {
   basic: WikiBasic;
   heroImage: WikiDetail["heroImage"];
   editHref?: string;
@@ -22,13 +22,13 @@ type WikiPublicHeroBasicSectionProps = {
   profileLabel?: string;
 };
 
-export function WikiPublicHeroBasicSection({
+export function WikiPublicHeroImage({
   basic,
   editHref,
   heroImage,
   flipCardId,
   profileLabel = "Basic profile",
-}: WikiPublicHeroBasicSectionProps) {
+}: WikiPublicHeroImageProps) {
   const [isFlipped, setIsFlipped] = useState(false);
 
   return (
@@ -66,6 +66,7 @@ export function WikiPublicHeroBasicSection({
                       fill
                       sizes="100vw"
                       src={heroImage.src}
+                      unoptimized
                     />
                   </div>
                   <div className="absolute inset-0" style={heroOverlayStyle} />
@@ -161,6 +162,7 @@ export function WikiPublicHeroBasicSection({
               fill
               sizes="(min-width: 1024px) 55vw, 100vw"
               src={heroImage.src}
+              unoptimized
             />
           </div>
         </div>

--- a/src/components/Wiki/index.ts
+++ b/src/components/Wiki/index.ts
@@ -9,7 +9,7 @@ export { WikiEditSidebar } from "./WikiEditSidebar/index";
 export { WikiHeroBasicFlipCard } from "./WikiHeroBasicFlipCard/index";
 export { WikiHeroPanel } from "./WikiHeroPanel/index";
 export { WikiImageLibrary, type WikiImageUsageRequestInput } from "./WikiImageLibrary/index";
-export { WikiPublicHeroBasicSection } from "./WikiPublicHeroBasicSection/index";
+export { WikiPublicHeroImage } from "./WikiPublicHeroImage/index";
 export { WikiSectionAccordion } from "./WikiSectionAccordion/index";
 export { WikiSectionEditor } from "./WikiSectionEditor/index";
 export { WikiStatePanel } from "./WikiStatePanel/index";


### PR DESCRIPTION
## 📝 変更内容

公開 Wiki のトップ画像と本文画像で `next/image` の最適化を通さず、画像 URL を直接読み込むようにしました。

- 公開 Wiki 詳細ページのヒーロー表示コンポーネントを `WikiPublicHeroImage` に整理
- ヒーロー画像、本文画像、画像グリッドに `unoptimized` を追加
- 関連 Storybook / unit test のコンポーネント名を更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)

## 🎯 変更理由・背景

公開 Wiki の画像表示で Next.js の画像最適化を経由すると、ローカル backend 画像などを draft 側と同じ経路で表示できないケースがあるため、公開画面でも画像を直接読み込むようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- `task check`: 成功
  - Unit test: 47 files / 267 tests passed
- `pnpm build`: 成功

## 🔍 レビューのポイント

- `next/image` に `unoptimized` を付ける対象が公開 Wiki の画像表示に限定されていること
- `WikiPublicHeroBasicSection` から `WikiPublicHeroImage` へのリネームで export / import / test / story が整合していること
- draft 側と同じ画像経路で公開 Wiki 画像を表示する意図に合っていること

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- 環境変数の追加はありません
- 型生成ファイルの更新はありません
- 破壊的変更はありません

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
