### PR TITLE
Wiki編集ページでタイトル編集を追加

### DIFF
--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -15,6 +15,8 @@ import {
   WikiSectionEditor,
   WikiStatePanel,
   cardSurfaceStyle,
+  EditIcon,
+  getString,
   mainBackgroundStyle,
   type WikiImageUsageRequestInput,
 } from "../../../../components/Wiki";
@@ -117,6 +119,10 @@ function WikiEditContent({
   const editBasic = () => {
     setIsBasicFlipped(true);
     setEditingId("basic");
+  };
+  const editTitle = () => {
+    setIsBasicFlipped(false);
+    setEditingId("title");
   };
   const isBusy = saveState.status === "saving" || saveState.status === "submitting";
   const clearChanges = () => {
@@ -227,10 +233,65 @@ function WikiEditContent({
     >
       <div className="mx-auto flex max-w-6xl flex-col gap-8">
         <header>
-          <div>
-            <h1 className="text-4xl font-semibold tracking-[-0.05em] text-text-strong lg:text-5xl">
-              {draft.basic.name}
-            </h1>
+          <div className="max-w-3xl">
+            {editingId === "title" ? (
+              <form
+                className="grid gap-3"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  const formData = new FormData(event.currentTarget);
+                  const name = getString(formData, "title");
+
+                  updateBasic({
+                    ...draft.basic,
+                    name,
+                  });
+                  closeEditor();
+                }}
+              >
+                <label className="grid gap-2 text-sm font-semibold text-text-strong">
+                  Title
+                  <input
+                    autoFocus
+                    className="rounded-2xl border border-stroke-subtle bg-surface-raised px-4 py-3 text-3xl font-semibold text-text-strong outline-none focus:border-text-muted lg:text-4xl"
+                    defaultValue={draft.basic.name}
+                    name="title"
+                  />
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-strong"
+                    style={cardSurfaceStyle}
+                    type="submit"
+                  >
+                    Save
+                  </button>
+                  <button
+                    className="rounded-full border border-stroke-subtle px-5 py-2 text-sm font-semibold text-text-muted"
+                    onClick={closeEditor}
+                    style={cardSurfaceStyle}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <div className="flex items-start gap-3">
+                <h1 className="min-w-0 text-4xl font-semibold text-text-strong lg:text-5xl">
+                  {draft.basic.name}
+                </h1>
+                <button
+                  aria-label="Edit wiki title"
+                  className="mt-1 rounded-full border border-stroke-subtle p-3 text-text-strong transition hover:bg-brand-highlight/30"
+                  onClick={editTitle}
+                  style={cardSurfaceStyle}
+                  type="button"
+                >
+                  <EditIcon />
+                </button>
+              </div>
+            )}
             {saveState.showMessage ? (
               <p
                 className="mt-3 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted"

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -564,6 +564,32 @@ describe("WikiEditPage", () => {
     expect(screen.getByLabelText("Quote")).toBeInTheDocument();
   });
 
+  it("edits the wiki title and saves it with the draft", async () => {
+    const saveAdapter = vi.fn().mockResolvedValue({ ok: true });
+
+    renderPage(successState, saveAdapter);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit wiki title" }));
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Aurora Echo Updated" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.getByRole("heading", { name: "Aurora Echo Updated" })).toBeInTheDocument();
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
+
+    await waitFor(() => expect(saveAdapter).toHaveBeenCalled());
+    expect(saveAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        basic: expect.objectContaining({
+          name: "Aurora Echo Updated",
+        }),
+      }),
+    );
+  });
+
   it("shows the formatting toolbar only while editing a text block", () => {
     renderPage();
 

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -95,9 +95,9 @@ export const useWikiEditDraft = (
   const [code, setCode] = useState(initialCode);
   const [codeParseError, setCodeParseError] = useState<string | null>(null);
   const [codeWarnings, setCodeWarnings] = useState(() => getWarningsFromCode(initialCode));
-  const [editingId, setEditingId] = useState<WikiContentEditorId | "basic" | "hero" | null>(
-    null,
-  );
+  const [editingId, setEditingId] = useState<
+    WikiContentEditorId | "basic" | "hero" | "title" | null
+  >(null);
   const [saveState, setSaveState] = useState<WikiSaveState>({
     status: "saved",
     message: "Saved",


### PR DESCRIPTION
## 📝 変更内容

Wiki編集ページでWikiタイトルを直接編集できるようにしました。

- ヘッダーのタイトル横に編集ボタンを追加
- タイトル編集フォームを追加し、保存時に `draft.basic.name` を更新
- タイトル編集状態を `editingId` の型に追加
- タイトル編集後に下書き保存へ反映されることをテストで確認

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki編集ページ上で本文や基本情報は編集できる一方、ページタイトルを編集する導線がありませんでした。
編集画面内でタイトルも更新できるようにし、下書き保存時に変更内容が永続化されるようにします。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- タイトル編集ボタンから入力フォームを開けることをテストで確認
- タイトル変更後に画面上の見出しが更新されることをテストで確認
- 下書き保存時に変更後の `basic.name` が保存処理へ渡されることをテストで確認

## 🔍 レビューのポイント

- タイトル編集状態を既存の `editingId` 管理に含める方針で問題ないか
- タイトル編集フォームの保存・キャンセル挙動が既存編集UIと整合しているか
- `draft.basic.name` 更新が下書き保存処理に正しく反映されているか

## ⚠️ 注意事項

特になし

## 📸 スクリーンショット・デモ

UI変更はありますが、スクリーンショットは未添付です。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
