### PR TITLE
Wiki APIのエラー処理と関連プロフィール取得を改善

### DIFF
--- a/packages/wiki/src/index.test.ts
+++ b/packages/wiki/src/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import * as wikiPublicApi from "./index";
+
+describe("wiki public API", () => {
+  it("does not expose route-only related profile failure messages", () => {
+    expect("wikiRelatedProfilesUnavailableMessage" in wikiPublicApi).toBe(false);
+  });
+
+  it("does not expose route-only image error helpers", () => {
+    expect("getWikiImageErrorMessage" in wikiPublicApi).toBe(false);
+  });
+});

--- a/packages/wiki/src/types/wiki.ts
+++ b/packages/wiki/src/types/wiki.ts
@@ -29,13 +29,17 @@ export type WikiTableCell = {
   colspan?: number;
 };
 
-export type WikiResourceType = "agency" | "group" | "song" | "talent";
+export const wikiResourceTypes = ["agency", "group", "song", "talent"] as const;
+
+export const wikiResourceTypeSchema = z.enum(wikiResourceTypes);
+
+export type WikiResourceType = z.infer<typeof wikiResourceTypeSchema>;
 
 const wikiProfileCardSummarySchema = z.object({
   wikiIdentifier: z.string(),
   slug: z.string(),
   language: z.string(),
-  resourceType: z.enum(["agency", "group", "song", "talent"]),
+  resourceType: wikiResourceTypeSchema,
   name: z.string(),
   normalizedName: z.string(),
   imageUrl: z.string().nullable().optional(),
@@ -212,7 +216,7 @@ const wikiBlockSchema = z.discriminatedUnion("blockType", [
   }),
   wikiBlockBaseSchema.extend({
     blockType: z.literal("profile_card_list"),
-    relatedResourceType: z.enum(["agency", "group", "song", "talent"]).nullable().optional(),
+    relatedResourceType: wikiResourceTypeSchema.nullable().optional(),
     profiles: z.array(wikiProfileCardSummarySchema).optional(),
     wikiIdentifiers: z.array(z.string()),
     title: z.string().nullable(),
@@ -234,7 +238,7 @@ const wikiSectionSchema: z.ZodType<WikiSection> = z.lazy(() =>
 export const wikiBasicSchema = z.object({
   name: z.string(),
   normalizedName: z.string(),
-  resourceType: z.enum(["agency", "group", "song", "talent"]),
+  resourceType: wikiResourceTypeSchema,
   groupType: z.string().optional(),
   status: z.string().optional(),
   generation: z.string().optional(),
@@ -273,7 +277,7 @@ const wikiDetailBaseSchema = z.object({
   translationSetIdentifier: z.string(),
   slug: z.string(),
   language: z.string(),
-  resourceType: z.enum(["agency", "group", "song", "talent"]),
+  resourceType: wikiResourceTypeSchema,
   themeColor: z.string().nullable().optional(),
   heroImage: z.object({
     imageIdentifier: z.string().nullable().optional(),

--- a/packages/wiki/src/wikiImageModel.ts
+++ b/packages/wiki/src/wikiImageModel.ts
@@ -1,10 +1,7 @@
 import { wikiPrivateApiTypes } from "@kpool/types";
 import { z } from "zod";
 
-import {
-  getWikiApiErrorMessage,
-  trimTrailingSlashes,
-} from "./wikiApiModel";
+import { trimTrailingSlashes } from "./wikiApiModel";
 
 const parseWikiSchema = <T>(schema: z.ZodType<T>, body: unknown): T => {
   const result = schema.safeParse(body);
@@ -259,11 +256,3 @@ export const normalizeWikiDraftImageListResponse = (body: unknown): unknown => {
     }),
   };
 };
-
-export const getWikiImageErrorMessage = (error: unknown): string =>
-  getWikiApiErrorMessage(error, {
-    notFound: "Wiki image resource was not found.",
-    requestFailedPrefix: "Wiki image request failed with status",
-    responseSchemaPrefix: "Wiki image response did not match the expected schema",
-    unavailable: "Wiki images are temporarily unavailable. Please try again later.",
-  });

--- a/packages/wiki/src/wikiRelatedProfilesModel.test.ts
+++ b/packages/wiki/src/wikiRelatedProfilesModel.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { wikiResourceTypes } from "./types/wiki";
+import { getSelectableRelatedProfileResourceTypes } from "./wikiRelatedProfilesModel";
+
+describe("wikiRelatedProfilesModel", () => {
+  it("builds selectable related profile resource types from the routing contract", () => {
+    expect(getSelectableRelatedProfileResourceTypes("group")).toEqual(
+      wikiResourceTypes.filter((resourceType) => resourceType !== "group"),
+    );
+  });
+});

--- a/packages/wiki/src/wikiRelatedProfilesModel.ts
+++ b/packages/wiki/src/wikiRelatedProfilesModel.ts
@@ -1,8 +1,8 @@
 import { wikiPrivateApiTypes } from "@kpool/types";
-import { z } from "zod";
+import type { z } from "zod";
 
 import { trimTrailingSlashes } from "./wikiApiModel";
-import type { WikiResourceType } from "./types/wiki";
+import { wikiResourceTypes, type WikiResourceType } from "./types/wiki";
 
 export const wikiRelatedProfilesResponseSchema =
   wikiPrivateApiTypes.schemas.ListRelatedProfilesResponseBody;
@@ -33,56 +33,4 @@ export const createWikiRelatedProfilesUrl = ({
 export const getSelectableRelatedProfileResourceTypes = (
   sourceResourceType: WikiResourceType,
 ): WikiResourceType[] =>
-  (["agency", "group", "song", "talent"] as const).filter(
-    (resourceType) => resourceType !== sourceResourceType,
-  );
-
-export const getWikiRelatedProfilesErrorMessage = (
-  error: unknown,
-  fallback = "Related profiles are temporarily unavailable. Please try again later.",
-): string => {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "response" in error &&
-    typeof (error as { response?: unknown }).response === "object" &&
-    (error as { response?: unknown }).response !== null
-  ) {
-    const response = (error as {
-      response: {
-        status?: number;
-        data?: unknown;
-      };
-    }).response;
-    const detail =
-      typeof response.data === "object" &&
-      response.data !== null &&
-      "message" in response.data &&
-      typeof (response.data as { message: unknown }).message === "string"
-        ? (response.data as { message: string }).message
-        : null;
-
-    if (detail) {
-      return detail;
-    }
-
-    if (response.status) {
-      return `Related profiles request failed with status ${response.status}.`;
-    }
-  }
-
-  if (error instanceof z.ZodError) {
-    return `Related profiles response did not match the expected schema: ${error.issues[0]?.message ?? "invalid response"}`;
-  }
-
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof (error as { message: unknown }).message === "string"
-  ) {
-    return (error as { message: string }).message;
-  }
-
-  return fallback;
-};
+  wikiResourceTypes.filter((resourceType) => resourceType !== sourceResourceType);

--- a/packages/wiki/src/wikiRouting.test.ts
+++ b/packages/wiki/src/wikiRouting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { wikiResourceTypeSchema, wikiResourceTypes } from "./types/wiki";
 import {
   buildWikiEditPath,
   buildWikiPath,
@@ -47,5 +48,11 @@ describe("wikiRouting", () => {
     expect(getWikiResourceLabel("group")).toBe("Group");
     expect(getWikiResourceLabel("song")).toBe("Song");
     expect(getWikiResourceLabel("talent")).toBe("Talent");
+  });
+
+  it("uses the shared resource type contract for routing decisions", () => {
+    expect(
+      wikiResourceTypes.map((resourceType) => wikiResourceTypeSchema.safeParse(resourceType).success),
+    ).toEqual([true, true, true, true]);
   });
 });

--- a/packages/wiki/src/wikiRouting.ts
+++ b/packages/wiki/src/wikiRouting.ts
@@ -1,6 +1,7 @@
-import type { WikiResourceType } from "./types/wiki";
+import { wikiResourceTypes, type WikiResourceType } from "./types/wiki";
 
-export const wikiResourceTypes = ["agency", "group", "song", "talent"] as const;
+export const isWikiResourceType = (value: string): value is WikiResourceType =>
+  wikiResourceTypes.some((resourceType) => resourceType === value);
 
 export const wikiResourceTypePrefixes: Record<WikiResourceType, string> = {
   agency: "ag-",

--- a/src/app/api/wiki/[language]/[slug]/related-profiles/route.test.ts
+++ b/src/app/api/wiki/[language]/[slug]/related-profiles/route.test.ts
@@ -3,6 +3,8 @@ import { NextRequest } from "next/server";
 
 import { GET } from "./route";
 
+const internalBackendMessage = "Internal backend path /var/app";
+
 const createRequest = (url: string, headers: Record<string, string> = {}): NextRequest =>
   new NextRequest(url, {
     method: "GET",
@@ -91,12 +93,31 @@ describe("wiki related profiles route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("passes backend failures through as related profile load failures", async () => {
+  it("returns a route error without calling backend when resourceType is invalid", async () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET(
+      createRequest(
+        "https://app.example.test/api/wiki/ja/gr-twice/related-profiles?resourceType=invalid",
+      ),
+      createContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.message).toBe("resourceType is required.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a generic related profile load failure for backend errors", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ message: "Cannot load related profiles" }), {
+        new Response(JSON.stringify({ message: internalBackendMessage }), {
           status: 422,
         }),
       ),
@@ -111,6 +132,13 @@ describe("wiki related profiles route", () => {
     const body = await response.json();
 
     expect(response.status).toBe(422);
-    expect(body.message).toBe("Cannot load related profiles");
+    expect(body.message).toBe(
+      "Related profiles are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki related profiles backend request failed",
+      expect.objectContaining({ status: 422 }),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(internalBackendMessage);
   });
 });

--- a/src/app/api/wiki/[language]/[slug]/related-profiles/route.ts
+++ b/src/app/api/wiki/[language]/[slug]/related-profiles/route.ts
@@ -3,25 +3,26 @@ import { z } from "zod";
 
 import {
   createWikiRelatedProfilesUrl,
-  getWikiRelatedProfilesErrorMessage,
+  wikiResourceTypeSchema,
   wikiRelatedProfilesResponseSchema,
-  type WikiResourceType,
 } from "@kpool/wiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   readJsonResponseBody,
 } from "../../../wikiRouteSupport";
 
-const relatedProfileResourceTypeSchema = z.enum(["agency", "group", "song", "talent"]);
+const relatedProfileResourceTypeSchema = wikiResourceTypeSchema;
+const wikiRelatedProfilesUnavailableMessage =
+  "Related profiles are temporarily unavailable. Please try again later.";
 
 export async function GET(
   request: NextRequest,
   context: { params: Promise<{ language: string; slug: string }> },
 ) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki API is not configured.", 500);
@@ -42,7 +43,7 @@ export async function GET(
       createWikiRelatedProfilesUrl({
         baseUrl,
         language,
-        resourceType: resourceTypeResult.data as WikiResourceType,
+        resourceType: resourceTypeResult.data,
         slug,
       }),
       {
@@ -54,11 +55,13 @@ export async function GET(
     const body = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki related profiles backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
         {
-          message: getWikiRelatedProfilesErrorMessage({
-            response: { status: apiResponse.status, data: body },
-          }),
+          message: wikiRelatedProfilesUnavailableMessage,
         },
         { status: apiResponse.status },
       );
@@ -73,14 +76,18 @@ export async function GET(
     );
   } catch (error) {
     if (error instanceof z.ZodError) {
+      console.error("Wiki related profiles response schema validation failed", error);
+
       return NextResponse.json(
-        { message: getWikiRelatedProfilesErrorMessage(error) },
+        { message: wikiRelatedProfilesUnavailableMessage },
         { status: 502 },
       );
     }
 
+    console.error("Wiki related profiles route failed", error);
+
     return NextResponse.json(
-      { message: getWikiRelatedProfilesErrorMessage(error) },
+      { message: wikiRelatedProfilesUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/draft-images/[imageId]/reviewRoute.test.ts
+++ b/src/app/api/wiki/draft-images/[imageId]/reviewRoute.test.ts
@@ -106,13 +106,25 @@ describe("wiki draft image review route", () => {
 
   it("returns backend errors without parsing them as successful review responses", async () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ title: "Forbidden" }, 403)));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Internal backend path /var/app" }, 403),
+      ),
+    );
 
     const response = await approvePOST(createRequest(), createContext());
     const body = await response.json();
 
     expect(response.status).toBe(403);
-    expect(body.message).toContain("403");
+    expect(body.message).toBe("Wiki images are temporarily unavailable. Please try again later.");
+    expect(body.message).not.toContain("/var/app");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki draft image approve backend request failed",
+      { status: 403 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
   });
 
   it("returns 502 when the backend response does not match the schema", async () => {

--- a/src/app/api/wiki/draft-images/[imageId]/reviewRoute.ts
+++ b/src/app/api/wiki/draft-images/[imageId]/reviewRoute.ts
@@ -1,19 +1,18 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { z } from "zod";
 
 import {
   createWikiDraftImageReviewUrl,
-  getWikiImageErrorMessage,
   wikiDraftImageReviewCsrfHeaderName,
   wikiDraftImageReviewCsrfHeaderValue,
   wikiImageReviewResponseSchema,
 } from "@kpool/wiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   readJsonResponseBody,
+  wikiImageUnavailableMessage,
 } from "../../wikiRouteSupport";
 
 type WikiDraftImageReviewRouteContext = {
@@ -33,7 +32,7 @@ export const createWikiDraftImageReviewRoute =
       return jsonErrorResponse("Wiki image review request is not allowed.", 403);
     }
 
-    const baseUrl = getWikiImageApiBaseUrl();
+    const baseUrl = getWikiPrivateApiBaseUrl();
 
     if (!baseUrl) {
       return jsonErrorResponse("Wiki image API is not configured.", 500);
@@ -56,8 +55,12 @@ export const createWikiDraftImageReviewRoute =
       const body = await readJsonResponseBody(apiResponse);
 
       if (!apiResponse.ok) {
+        console.error(`Wiki draft image ${action} backend request failed`, {
+          status: apiResponse.status,
+        });
+
         return NextResponse.json(
-          { message: getWikiImageErrorMessage({ response: { status: apiResponse.status, data: body } }) },
+          { message: wikiImageUnavailableMessage },
           { status: apiResponse.status },
         );
       }
@@ -66,15 +69,10 @@ export const createWikiDraftImageReviewRoute =
         parseWithSchemaLog(responseLabel, wikiImageReviewResponseSchema, body),
       );
     } catch (error) {
-      if (error instanceof z.ZodError) {
-        return NextResponse.json(
-          { message: getWikiImageErrorMessage(error) },
-          { status: 502 },
-        );
-      }
+      console.error(`Wiki draft image ${action} route failed`, error);
 
       return NextResponse.json(
-        { message: getWikiImageErrorMessage(error) },
+        { message: wikiImageUnavailableMessage },
         { status: 502 },
       );
     }

--- a/src/app/api/wiki/draft-images/route.test.ts
+++ b/src/app/api/wiki/draft-images/route.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+const createRequest = (url: string, headers: Record<string, string> = {}): NextRequest =>
+  new NextRequest(url, {
+    method: "GET",
+    headers,
+  });
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("wiki draft images route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
+  });
+
+  it("logs backend failure status without exposing the backend error body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Internal backend path /var/app" }, 503),
+      ),
+    );
+
+    const response = await GET(
+      createRequest("https://app.example.test/api/wiki/draft-images?status=pending"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.message).toBe(
+      "Wiki images are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki draft images backend request failed",
+      { status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
+  });
+});

--- a/src/app/api/wiki/draft-images/route.ts
+++ b/src/app/api/wiki/draft-images/route.ts
@@ -1,25 +1,24 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { wikiPrivateApiTypes } from "@kpool/types";
-import { z } from "zod";
 
 import {
   createWikiDraftImagesUrl,
   defaultWikiImagePerPage,
-  getWikiImageErrorMessage,
   normalizeWikiDraftImageListResponse,
   wikiDraftImageListResponseSchema,
 } from "@kpool/wiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   parsePositiveIntegerParam,
   readJsonResponseBody,
+  wikiImageUnavailableMessage,
 } from "../wikiRouteSupport";
 
 export async function GET(request: NextRequest) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki image API is not configured.", 500);
@@ -54,8 +53,12 @@ export async function GET(request: NextRequest) {
     const body = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki draft images backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
-        { message: getWikiImageErrorMessage({ response: { status: apiResponse.status, data: body } }) },
+        { message: wikiImageUnavailableMessage },
         { status: apiResponse.status },
       );
     }
@@ -68,15 +71,10 @@ export async function GET(request: NextRequest) {
       ),
     );
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { message: getWikiImageErrorMessage(error) },
-        { status: 502 },
-      );
-    }
+    console.error("Wiki draft images route failed", error);
 
     return NextResponse.json(
-      { message: getWikiImageErrorMessage(error) },
+      { message: wikiImageUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/draft-wikis/route.test.ts
+++ b/src/app/api/wiki/draft-wikis/route.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+const createRequest = (url: string, headers: Record<string, string> = {}): NextRequest =>
+  new NextRequest(url, {
+    method: "GET",
+    headers,
+  });
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("wiki draft wikis route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
+  });
+
+  it("logs backend failure status without exposing the backend error body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Internal backend path /var/app" }, 503),
+      ),
+    );
+
+    const response = await GET(
+      createRequest("https://app.example.test/api/wiki/draft-wikis?status=pending"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.message).toBe(
+      "Wiki drafts are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki draft wikis backend request failed",
+      { status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
+  });
+});

--- a/src/app/api/wiki/draft-wikis/route.ts
+++ b/src/app/api/wiki/draft-wikis/route.ts
@@ -1,20 +1,19 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { wikiPrivateApiTypes } from "@kpool/types";
-import { z } from "zod";
 
 import {
   createWikiDraftWikisUrl,
   defaultWikiDraftPerPage,
-  getDraftWikiErrorMessage,
   wikiDraftWikiListResponseSchema,
 } from "@/gateways/wiki/draftWiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   parsePositiveIntegerParam,
   readJsonResponseBody,
+  wikiDraftUnavailableMessage,
 } from "../wikiRouteSupport";
 
 const parseBooleanParam = (value: string | null): boolean | undefined => {
@@ -26,7 +25,7 @@ const parseBooleanParam = (value: string | null): boolean | undefined => {
 };
 
 export async function GET(request: NextRequest) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki draft API is not configured.", 500);
@@ -64,8 +63,12 @@ export async function GET(request: NextRequest) {
     const body = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki draft wikis backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
-        { message: getDraftWikiErrorMessage({ response: { status: apiResponse.status, data: body } }) },
+        { message: wikiDraftUnavailableMessage },
         { status: apiResponse.status },
       );
     }
@@ -78,15 +81,10 @@ export async function GET(request: NextRequest) {
       ),
     );
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { message: getDraftWikiErrorMessage(error) },
-        { status: 502 },
-      );
-    }
+    console.error("Wiki draft wikis route failed", error);
 
     return NextResponse.json(
-      { message: getDraftWikiErrorMessage(error) },
+      { message: wikiDraftUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/drafts/[wikiId]/reviewRoute.test.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/reviewRoute.test.ts
@@ -11,6 +11,9 @@ import { POST as rejectPOST } from "./reject/route";
 import { POST as translatePOST } from "./translate/route";
 
 const wikiId = "44444444-4444-4444-4444-444444444444";
+const internalBackendMessage = "Internal backend path /var/app";
+const wikiDraftUnavailableMessage =
+  "Wiki drafts are temporarily unavailable. Please try again later.";
 
 const createRequest = (body: unknown, headers: Record<string, string> = {}): NextRequest =>
   new Request(`https://app.example.test/api/wiki/drafts/${wikiId}/approve`, {
@@ -205,5 +208,34 @@ describe("wiki draft review route", () => {
 
     expect(response.status).toBe(403);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not expose backend messages from review errors", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: internalBackendMessage }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    const response = await approvePOST(
+      createRequest({ resourceType: "group", wikiId }),
+      createContext(),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.message).toBe(wikiDraftUnavailableMessage);
+    expect(body.message).not.toContain("/var/app");
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to approve wiki draft.",
+      { wikiId, status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(internalBackendMessage);
   });
 });

--- a/src/app/api/wiki/drafts/[wikiId]/reviewRoute.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/reviewRoute.ts
@@ -2,26 +2,21 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import {
   createDraftWikiApiClient,
-  getDraftWikiErrorMessage,
   reviewDraftWiki,
   type WikiDraftWorkflowAction,
   wikiDraftReviewCsrfHeaderName,
   wikiDraftReviewCsrfHeaderValue,
 } from "@/gateways/wiki/draftWiki";
-import { getForwardedWikiApiHeaders } from "../../wikiRouteSupport";
+import {
+  getForwardedWikiApiHeaders,
+  getWikiRouteErrorStatus,
+  wikiDraftUnavailableMessage,
+} from "../../wikiRouteSupport";
 
 type WikiDraftReviewRouteContext = {
   params: Promise<{
     wikiId: string;
   }>;
-};
-
-const stringifyLogValue = (value: unknown): string => {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 };
 
 const hasReviewRequestHeader = (request: NextRequest): boolean =>
@@ -59,11 +54,11 @@ export const createWikiDraftReviewRoute =
     } catch (error) {
       console.error(`Failed to ${action} wiki draft.`, {
         wikiId,
-        error: stringifyLogValue(error),
+        status: getWikiRouteErrorStatus(error),
       });
 
       return NextResponse.json(
-        { message: getDraftWikiErrorMessage(error) },
+        { message: wikiDraftUnavailableMessage },
         { status: 502 },
       );
     }

--- a/src/app/api/wiki/drafts/[wikiId]/route.test.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/route.test.ts
@@ -12,7 +12,7 @@ const createRequest = (
   body: unknown,
   headers: Record<string, string> = {},
 ): NextRequest =>
-  new Request(`https://app.example.test/api/wiki/drafts/${wikiId}/submit`, {
+  new Request(`https://app.example.test/api/wiki/drafts/${wikiId}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -31,25 +31,26 @@ const jsonResponse = (body: unknown, status = 201): Response =>
     headers: { "Content-Type": "application/json" },
   });
 
-describe("wiki draft submit route", () => {
+describe("wiki draft save route", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     delete process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
   });
 
-  it("forwards submit requests with body, cookie, and accept-language headers", async () => {
+  it("forwards save requests with body, cookie, and accept-language headers", async () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
         language: "ja",
-        name: "Aurora Echo",
+        name: "Saved Aurora Echo",
         resourceType: "group",
-        status: "under_review",
+        status: "editing",
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
 
     const body = {
+      name: "Aurora Echo",
       resourceType: "group",
       wikiId,
     };
@@ -63,7 +64,7 @@ describe("wiki draft submit route", () => {
 
     expect(response.status).toBe(201);
     expect(fetchMock).toHaveBeenCalledWith(
-      `https://api.example.test/api/wiki/wiki/${wikiId}/submit`,
+      `https://api.example.test/api/wiki/wiki/${wikiId}/edit`,
       expect.objectContaining({
         body: JSON.stringify(body),
         method: "POST",
@@ -77,25 +78,7 @@ describe("wiki draft submit route", () => {
     );
   });
 
-  it("returns 500 when the backend base URL is not configured", async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const response = await POST(
-      createRequest({
-        resourceType: "group",
-        wikiId,
-      }),
-      createContext(),
-    );
-    const body = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(body.message).toBe("Wiki draft API is not configured.");
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("does not expose backend messages from submit errors", async () => {
+  it("does not expose backend messages from save errors", async () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal(
@@ -109,10 +92,7 @@ describe("wiki draft submit route", () => {
     );
 
     const response = await POST(
-      createRequest({
-        resourceType: "group",
-        wikiId,
-      }),
+      createRequest({ resourceType: "group", wikiId }),
       createContext(),
     );
     const body = await response.json();
@@ -121,7 +101,7 @@ describe("wiki draft submit route", () => {
     expect(body.message).toBe(wikiDraftUnavailableMessage);
     expect(body.message).not.toContain("/var/app");
     expect(consoleError).toHaveBeenCalledWith(
-      "Failed to submit wiki draft.",
+      "Failed to save wiki draft.",
       { wikiId, status: 503 },
     );
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain(internalBackendMessage);

--- a/src/app/api/wiki/drafts/[wikiId]/route.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/route.ts
@@ -2,23 +2,18 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import {
   createDraftWikiApiClient,
-  getDraftWikiErrorMessage,
   saveDraftWiki,
 } from "@/gateways/wiki/draftWiki";
-import { getForwardedWikiApiHeaders } from "../../wikiRouteSupport";
+import {
+  getForwardedWikiApiHeaders,
+  getWikiRouteErrorStatus,
+  wikiDraftUnavailableMessage,
+} from "../../wikiRouteSupport";
 
 type WikiDraftSaveRouteContext = {
   params: Promise<{
     wikiId: string;
   }>;
-};
-
-const stringifyLogValue = (value: unknown): string => {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 };
 
 export async function POST(request: NextRequest, context: WikiDraftSaveRouteContext) {
@@ -44,11 +39,11 @@ export async function POST(request: NextRequest, context: WikiDraftSaveRouteCont
   } catch (error) {
     console.error("Failed to save wiki draft.", {
       wikiId,
-      error: stringifyLogValue(error),
+      status: getWikiRouteErrorStatus(error),
     });
 
     return NextResponse.json(
-      { message: getDraftWikiErrorMessage(error) },
+      { message: wikiDraftUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/drafts/[wikiId]/submit/route.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/submit/route.ts
@@ -2,23 +2,18 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import {
   createDraftWikiApiClient,
-  getDraftWikiErrorMessage,
   submitDraftWiki,
 } from "@/gateways/wiki/draftWiki";
-import { getForwardedWikiApiHeaders } from "../../../wikiRouteSupport";
+import {
+  getForwardedWikiApiHeaders,
+  getWikiRouteErrorStatus,
+  wikiDraftUnavailableMessage,
+} from "../../../wikiRouteSupport";
 
 type WikiDraftSubmitRouteContext = {
   params: Promise<{
     wikiId: string;
   }>;
-};
-
-const stringifyLogValue = (value: unknown): string => {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
 };
 
 export async function POST(request: NextRequest, context: WikiDraftSubmitRouteContext) {
@@ -44,11 +39,11 @@ export async function POST(request: NextRequest, context: WikiDraftSubmitRouteCo
   } catch (error) {
     console.error("Failed to submit wiki draft.", {
       wikiId,
-      error: stringifyLogValue(error),
+      status: getWikiRouteErrorStatus(error),
     });
 
     return NextResponse.json(
-      { message: getDraftWikiErrorMessage(error) },
+      { message: wikiDraftUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/images/route.test.ts
+++ b/src/app/api/wiki/images/route.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET } from "./route";
+
+const createRequest = (url: string, headers: Record<string, string> = {}): NextRequest =>
+  new NextRequest(url, {
+    method: "GET",
+    headers,
+  });
+
+const jsonResponse = (body: unknown, status: number): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("wiki images route", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
+  });
+
+  it("logs backend failure status without exposing the backend error body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Internal backend path /var/app" }, 503),
+      ),
+    );
+
+    const response = await GET(
+      createRequest(
+        "https://app.example.test/api/wiki/images?translationSetIdentifier=55555555-5555-5555-5555-555555555555",
+      ),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.message).toBe(
+      "Wiki images are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki images backend request failed",
+      { status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
+  });
+});

--- a/src/app/api/wiki/images/route.ts
+++ b/src/app/api/wiki/images/route.ts
@@ -1,23 +1,22 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { z } from "zod";
 
 import {
   createWikiImagesUrl,
   defaultWikiImagePerPage,
-  getWikiImageErrorMessage,
   wikiImageListResponseSchema,
 } from "@kpool/wiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   parsePositiveIntegerParam,
   readJsonResponseBody,
+  wikiImageUnavailableMessage,
 } from "../wikiRouteSupport";
 
 export async function GET(request: NextRequest) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki image API is not configured.", 500);
@@ -49,8 +48,12 @@ export async function GET(request: NextRequest) {
     const body = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki images backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
-        { message: getWikiImageErrorMessage({ response: { status: apiResponse.status, data: body } }) },
+        { message: wikiImageUnavailableMessage },
         { status: apiResponse.status },
       );
     }
@@ -59,15 +62,10 @@ export async function GET(request: NextRequest) {
       parseWithSchemaLog("wiki image list response", wikiImageListResponseSchema, body),
     );
   } catch (error) {
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { message: getWikiImageErrorMessage(error) },
-        { status: 502 },
-      );
-    }
+    console.error("Wiki images route failed", error);
 
     return NextResponse.json(
-      { message: getWikiImageErrorMessage(error) },
+      { message: wikiImageUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/images/upload/route.test.ts
+++ b/src/app/api/wiki/images/upload/route.test.ts
@@ -101,6 +101,7 @@ describe("wiki image upload route", () => {
 
   it("returns 422 when the encoded image exceeds the schema limit", async () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
@@ -111,6 +112,11 @@ describe("wiki image upload route", () => {
 
     expect(response.status).toBe(422);
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki image upload route failed",
+      expect.any(Error),
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(body.base64EncodedImage);
   });
 
   it("forwards valid uploads to the backend image upload endpoint", async () => {
@@ -142,5 +148,66 @@ describe("wiki image upload route", () => {
         }),
       }),
     );
+    const forwardedRequest = fetchMock.mock.calls[0]?.[1];
+    expect(forwardedRequest).toEqual(
+      expect.objectContaining({
+        body: expect.any(String),
+      }),
+    );
+    const forwardedBody = JSON.parse((forwardedRequest as RequestInit).body as string);
+    expect(forwardedBody).toEqual(body);
+    expect(forwardedBody).not.toHaveProperty("data");
+    expect(forwardedBody).not.toHaveProperty("message");
+  });
+
+  it("logs backend failure status without exposing the backend error body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({ message: "Internal backend path /var/app" }, 503),
+      ),
+    );
+
+    const body = createUploadBody();
+    const response = await POST(
+      createRequest(body, { "content-length": String(JSON.stringify(body).length) }),
+    );
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(responseBody.message).toBe(
+      "Wiki images are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki image upload backend request failed",
+      { status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(body.base64EncodedImage);
+  });
+
+  it("logs upload route exceptions without exposing the upload request body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const uploadError = new Error("network unavailable");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(uploadError));
+
+    const body = createUploadBody();
+    const response = await POST(
+      createRequest(body, { "content-length": String(JSON.stringify(body).length) }),
+    );
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(responseBody.message).toBe(
+      "Wiki images are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki image upload route failed",
+      uploadError,
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(body.base64EncodedImage);
   });
 });

--- a/src/app/api/wiki/images/upload/route.ts
+++ b/src/app/api/wiki/images/upload/route.ts
@@ -2,18 +2,18 @@ import { NextResponse, type NextRequest } from "next/server";
 import { z } from "zod";
 
 import {
-  getWikiImageErrorMessage,
   wikiImageMaxUploadBodyBytes,
   wikiImageUploadRequestSchema,
   wikiImageUploadResponseSchema,
 } from "@kpool/wiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { trimTrailingSlashes } from "@kpool/wiki";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   readJsonResponseBody,
+  wikiImageUnavailableMessage,
 } from "../../wikiRouteSupport";
 
 const validateUploadContentLength = (headers: Headers): Response | null => {
@@ -37,7 +37,7 @@ const validateUploadContentLength = (headers: Headers): Response | null => {
 };
 
 export async function POST(request: NextRequest) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki image API is not configured.", 500);
@@ -50,7 +50,11 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const body = parseWithSchemaLog("wiki image upload request", wikiImageUploadRequestSchema, await request.json());
+    const body = parseWithSchemaLog(
+      "wiki image upload request",
+      wikiImageUploadRequestSchema,
+      await request.json(),
+    );
     const apiResponse = await fetch(`${trimTrailingSlashes(baseUrl)}/image/upload`, {
       method: "POST",
       headers: {
@@ -63,11 +67,13 @@ export async function POST(request: NextRequest) {
     const responseBody = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki image upload backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
         {
-          message: getWikiImageErrorMessage({
-            response: { status: apiResponse.status, data: responseBody },
-          }),
+          message: wikiImageUnavailableMessage,
         },
         { status: apiResponse.status },
       );
@@ -82,15 +88,17 @@ export async function POST(request: NextRequest) {
       { status: 201 },
     );
   } catch (error) {
+    console.error("Wiki image upload route failed", error);
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
-        { message: getWikiImageErrorMessage(error) },
+        { message: wikiImageUnavailableMessage },
         { status: 422 },
       );
     }
 
     return NextResponse.json(
-      { message: getWikiImageErrorMessage(error) },
+      { message: wikiImageUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/version-inconsistent-wikis/route.test.ts
+++ b/src/app/api/wiki/version-inconsistent-wikis/route.test.ts
@@ -70,4 +70,36 @@ describe("wiki version inconsistent wikis route", () => {
     );
     await expect(response.json()).resolves.toEqual(expect.objectContaining({ total: 25 }));
   });
+
+  it("logs backend failure status without exposing the backend error body", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ message: "Internal backend path /var/app" }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const response = await GET(
+      createRequest("https://app.example.test/api/wiki/version-inconsistent-wikis"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.message).toBe(
+      "Wiki drafts are temporarily unavailable. Please try again later.",
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "Wiki version inconsistent backend request failed",
+      { status: 503 },
+    );
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("/var/app");
+  });
 });

--- a/src/app/api/wiki/version-inconsistent-wikis/route.ts
+++ b/src/app/api/wiki/version-inconsistent-wikis/route.ts
@@ -4,16 +4,16 @@ import { z } from "zod";
 import {
   createVersionInconsistentWikisUrl,
   defaultWikiDraftPerPage,
-  getDraftWikiErrorMessage,
   wikiVersionInconsistentWikiListResponseSchema,
 } from "@/gateways/wiki/draftWiki";
-import { getWikiImageApiBaseUrl } from "@/gateways/wiki/wikiImageServerApi";
+import { getWikiPrivateApiBaseUrl } from "@/gateways/wiki/wikiPrivateServerApi";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
 import {
   getForwardedWikiApiHeaders,
   jsonErrorResponse,
   parsePositiveIntegerParam,
   readJsonResponseBody,
+  wikiDraftUnavailableMessage,
 } from "../wikiRouteSupport";
 
 const sortParamSchema = z.enum(["updatedAt", "name"]);
@@ -33,7 +33,7 @@ const parseEnumParam = <T extends z.ZodEnum<[string, ...string[]]>>(
 };
 
 export async function GET(request: NextRequest) {
-  const baseUrl = getWikiImageApiBaseUrl();
+  const baseUrl = getWikiPrivateApiBaseUrl();
 
   if (!baseUrl) {
     return jsonErrorResponse("Wiki draft API is not configured.", 500);
@@ -61,8 +61,12 @@ export async function GET(request: NextRequest) {
     const body = await readJsonResponseBody(apiResponse);
 
     if (!apiResponse.ok) {
+      console.error("Wiki version inconsistent backend request failed", {
+        status: apiResponse.status,
+      });
+
       return NextResponse.json(
-        { message: getDraftWikiErrorMessage({ response: { status: apiResponse.status, data: body } }) },
+        { message: wikiDraftUnavailableMessage },
         { status: apiResponse.status },
       );
     }
@@ -75,8 +79,10 @@ export async function GET(request: NextRequest) {
       ),
     );
   } catch (error) {
+    console.error("Wiki version inconsistent route failed", error);
+
     return NextResponse.json(
-      { message: getDraftWikiErrorMessage(error) },
+      { message: wikiDraftUnavailableMessage },
       { status: 502 },
     );
   }

--- a/src/app/api/wiki/wikiRouteErrorMessages.test.ts
+++ b/src/app/api/wiki/wikiRouteErrorMessages.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET as getDraftImages } from "./draft-images/route";
+import { GET as getDraftWikis } from "./draft-wikis/route";
+import { GET as getImages } from "./images/route";
+import { POST as uploadImage } from "./images/upload/route";
+import { GET as getVersionInconsistentWikis } from "./version-inconsistent-wikis/route";
+
+const internalBackendMessage = "SQL failed at /var/app/wiki/internal";
+const wikiImageUnavailableMessage =
+  "Wiki images are temporarily unavailable. Please try again later.";
+const wikiDraftUnavailableMessage =
+  "Wiki drafts are temporarily unavailable. Please try again later.";
+
+const jsonResponse = (status: number): Response =>
+  new Response(JSON.stringify({ message: internalBackendMessage }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const createRequest = (url: string, init: RequestInit = {}): NextRequest =>
+  new NextRequest(url, init);
+
+const createUploadBody = () => ({
+  resourceType: "group",
+  translationSetIdentifier: "55555555-5555-5555-5555-555555555555",
+  base64EncodedImage: "aGVsbG8=",
+  displayOrder: 1,
+  sourceUrl: "https://commons.wikimedia.org/wiki/File:Upload.png",
+  sourceName: "Wikimedia Commons",
+  altText: "Stage upload",
+  agreedToTermsAt: "2026-05-09T00:00:00.000Z",
+  rightsConfirmationAgreed: true,
+});
+
+describe("wiki API route error messages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL;
+  });
+
+  it("does not expose backend messages from image routes", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(500))));
+    const uploadBody = createUploadBody();
+    const uploadBodyText = JSON.stringify(uploadBody);
+
+    const responses = await Promise.all([
+      getImages(
+        createRequest(
+          "https://app.example.test/api/wiki/images?translationSetIdentifier=55555555-5555-5555-5555-555555555555",
+        ),
+      ),
+      uploadImage(
+        createRequest("https://app.example.test/api/wiki/images/upload", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "content-length": String(uploadBodyText.length),
+          },
+          body: uploadBodyText,
+        }),
+      ),
+      getDraftImages(
+        createRequest("https://app.example.test/api/wiki/draft-images?status=pending"),
+      ),
+    ]);
+
+    for (const response of responses) {
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.message).toBe(wikiImageUnavailableMessage);
+      expect(body.message).not.toContain("/var/app");
+    }
+
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(internalBackendMessage);
+  });
+
+  it("does not expose backend messages from draft wiki list routes", async () => {
+    process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(503))));
+
+    const responses = await Promise.all([
+      getDraftWikis(
+        createRequest("https://app.example.test/api/wiki/draft-wikis?status=pending"),
+      ),
+      getVersionInconsistentWikis(
+        createRequest("https://app.example.test/api/wiki/version-inconsistent-wikis"),
+      ),
+    ]);
+
+    for (const response of responses) {
+      const body = await response.json();
+
+      expect(response.status).toBe(503);
+      expect(body.message).toBe(wikiDraftUnavailableMessage);
+      expect(body.message).not.toContain("/var/app");
+    }
+
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(internalBackendMessage);
+  });
+});

--- a/src/app/api/wiki/wikiRouteSupport.test.ts
+++ b/src/app/api/wiki/wikiRouteSupport.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getForwardedWikiApiHeaders } from "./wikiRouteSupport";
+import {
+  getForwardedWikiApiHeaders,
+  getWikiRouteErrorStatus,
+  readJsonResponseBody,
+} from "./wikiRouteSupport";
 
 describe("getForwardedWikiApiHeaders", () => {
   it("forwards the shared Wiki API request headers", () => {
@@ -24,5 +28,54 @@ describe("getForwardedWikiApiHeaders", () => {
     expect(forwardedHeaders).toEqual({
       Accept: "application/json",
     });
+  });
+});
+
+describe("readJsonResponseBody", () => {
+  it("allows an empty response body only for backend error responses", async () => {
+    await expect(readJsonResponseBody(new Response("", { status: 503 }))).resolves.toEqual({});
+  });
+
+  it("throws when a successful backend response contains malformed JSON", async () => {
+    await expect(
+      readJsonResponseBody(
+        new Response("{broken", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).rejects.toThrow("Wiki API response body is not valid JSON.");
+  });
+
+  it("throws when a backend error response contains malformed JSON", async () => {
+    await expect(
+      readJsonResponseBody(
+        new Response("{broken", {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    ).rejects.toThrow("Wiki API response body is not valid JSON.");
+  });
+});
+
+describe("getWikiRouteErrorStatus", () => {
+  it("extracts only the backend status from gateway errors", () => {
+    const status = getWikiRouteErrorStatus({
+      response: {
+        status: 503,
+        data: { message: "Internal backend path /var/app" },
+      },
+    });
+
+    expect(status).toBe(503);
+  });
+
+  it("does not expose non-status error details as a fallback", () => {
+    const status = getWikiRouteErrorStatus({
+      message: "Internal backend path /var/app",
+    });
+
+    expect(status).toBeUndefined();
   });
 });

--- a/src/app/api/wiki/wikiRouteSupport.ts
+++ b/src/app/api/wiki/wikiRouteSupport.ts
@@ -19,10 +19,20 @@ export const getForwardedWikiApiHeaders = (headers: Headers): HeadersInit => {
 };
 
 export const readJsonResponseBody = async (response: Response): Promise<unknown> => {
+  const text = await response.text();
+
+  if (text.trim() === "") {
+    if (!response.ok) {
+      return {};
+    }
+
+    throw new Error("Wiki API response body is empty.");
+  }
+
   try {
-    return await response.json();
-  } catch {
-    return {};
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new Error("Wiki API response body is not valid JSON.", { cause: error });
   }
 };
 
@@ -37,3 +47,22 @@ export const parsePositiveIntegerParam = (
 
 export const jsonErrorResponse = (message: string, status: number): Response =>
   NextResponse.json({ message }, { status });
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const getWikiRouteErrorStatus = (error: unknown): number | undefined => {
+  if (!isObjectRecord(error) || !isObjectRecord(error.response)) {
+    return undefined;
+  }
+
+  const { status } = error.response;
+
+  return typeof status === "number" ? status : undefined;
+};
+
+export const wikiImageUnavailableMessage =
+  "Wiki images are temporarily unavailable. Please try again later.";
+
+export const wikiDraftUnavailableMessage =
+  "Wiki drafts are temporarily unavailable. Please try again later.";

--- a/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
+++ b/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
@@ -279,7 +279,50 @@ describe("WikiBlockForm", () => {
     );
   });
 
-  it("keeps existing profile slugs when loading related profiles fails", async () => {
+  it("does not submit stale profiles after changing resource type before loading", () => {
+    const onSave = vi.fn();
+    const block = {
+      ...wikiStoryProfileListBlock,
+      relatedResourceType: "talent",
+      wikiIdentifiers: ["11111111-1111-1111-1111-111111111111"],
+      profiles: [
+        {
+          wikiIdentifier: "11111111-1111-1111-1111-111111111111",
+          slug: "tl-momo",
+          language: "ja",
+          resourceType: "talent",
+          name: "MOMO",
+          normalizedName: "momo",
+          imageUrl: null,
+          imageAltText: null,
+        },
+      ],
+    } as typeof wikiStoryProfileListBlock;
+
+    render(
+      <WikiBlockForm
+        block={block}
+        onCancel={() => {}}
+        onSave={onSave}
+        sourceWiki={{ language: "ja", resourceType: "group", slug: "gr-twice" }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Resource type"), {
+      target: { value: "agency" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relatedResourceType: "agency",
+        profiles: [],
+        wikiIdentifiers: [],
+      }),
+    );
+  });
+
+  it("shows a generic related profiles error when loading fails", async () => {
     const onSave = vi.fn();
     vi.stubGlobal(
       "fetch",
@@ -304,12 +347,13 @@ describe("WikiBlockForm", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "Load related profiles" }));
 
-    expect(await screen.findByText("Related profiles failed")).toBeInTheDocument();
+    expect(await screen.findByText("関連プロフィールの取得に失敗しました")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        wikiIdentifiers: wikiStoryProfileListBlock.wikiIdentifiers,
+        profiles: [],
+        wikiIdentifiers: [],
       }),
     );
   });

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -8,15 +8,18 @@ import StarterKit from "@tiptap/starter-kit";
 import { type FormEvent, type MouseEvent, useState } from "react";
 import {
   getSelectableRelatedProfileResourceTypes,
+  isWikiResourceType,
   type WikiBlock,
   type WikiEmbedProvider,
   type WikiListType,
   type WikiProfileCardSummary,
   type WikiProfileCardListBlock,
+  type WikiRelatedProfile,
   type WikiResourceType,
   type WikiTableBlock,
   type WikiTableCell,
   type WikiTextBlock,
+  wikiResourceTypes,
 } from "@kpool/wiki";
 
 import { fetchWikiRelatedProfiles } from "@/gateways/wiki/wikiRelatedProfilesBrowserApi";
@@ -90,30 +93,24 @@ const createEmptyTableRow = (columnCount: number): WikiTableCell[] =>
 const getProfileCardLabel = (profile: WikiProfileCardSummary): string =>
   profile.name.trim() || profile.slug;
 
-const toWikiResourceType = (value: string): WikiResourceType =>
-  value === "agency" || value === "group" || value === "song" || value === "talent"
-    ? value
-    : "talent";
+const toProfileCardSummary = (
+  profile: WikiRelatedProfile,
+): WikiProfileCardSummary | null => {
+  if (!isWikiResourceType(profile.resourceType)) {
+    return null;
+  }
 
-const toProfileCardSummary = (profile: {
-  wikiIdentifier: string;
-  slug: string;
-  language: string;
-  resourceType: string;
-  name: string;
-  normalizedName: string;
-  imageUrl?: string | null;
-  imageAltText?: string | null;
-}): WikiProfileCardSummary => ({
-  wikiIdentifier: profile.wikiIdentifier,
-  slug: profile.slug,
-  language: profile.language,
-  resourceType: toWikiResourceType(profile.resourceType),
-  name: profile.name,
-  normalizedName: profile.normalizedName,
-  imageUrl: profile.imageUrl ?? null,
-  imageAltText: profile.imageAltText ?? null,
-});
+  return {
+    wikiIdentifier: profile.wikiIdentifier,
+    slug: profile.slug,
+    language: profile.language,
+    resourceType: profile.resourceType,
+    name: profile.name,
+    normalizedName: profile.normalizedName,
+    imageUrl: profile.imageUrl ?? null,
+    imageAltText: profile.imageAltText ?? null,
+  };
+};
 
 function WikiRelatedProfilePreviewCard({ profile }: { profile: WikiProfileCardSummary }) {
   const label = getProfileCardLabel(profile);
@@ -876,7 +873,7 @@ function WikiProfileCardListBlockForm({
 }: ProfileCardListBlockFormProps) {
   const selectableResourceTypes = sourceWiki
     ? getSelectableRelatedProfileResourceTypes(sourceWiki.resourceType)
-    : (["agency", "group", "song", "talent"] as const);
+    : wikiResourceTypes;
   const initialResourceType =
     block.relatedResourceType && selectableResourceTypes.includes(block.relatedResourceType)
       ? block.relatedResourceType
@@ -908,17 +905,26 @@ function WikiProfileCardListBlockForm({
       slug: sourceWiki.slug,
     }).then((response) => {
       const loadedProfiles = response.profiles.map(toProfileCardSummary);
+      const validProfiles = loadedProfiles.filter(
+        (profile): profile is WikiProfileCardSummary => profile !== null,
+      );
 
-      setProfiles(loadedProfiles);
-      setWikiIdentifiers(loadedProfiles.map((profile) => profile.wikiIdentifier));
+      if (validProfiles.length !== loadedProfiles.length) {
+        setLoadState({
+          status: "error",
+          message: "関連プロフィールの取得に失敗しました",
+        });
+        return;
+      }
+
+      setProfiles(validProfiles);
+      setWikiIdentifiers(validProfiles.map((profile) => profile.wikiIdentifier));
       setLoadState({ status: "success" });
     }).catch((error: unknown) => {
+      console.error("Failed to load wiki related profiles", error);
       setLoadState({
         status: "error",
-        message:
-          error instanceof Error
-            ? error.message
-            : "関連プロフィールの取得に失敗しました",
+        message: "関連プロフィールの取得に失敗しました",
       });
     });
   };
@@ -950,7 +956,24 @@ function WikiProfileCardListBlockForm({
           className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
           disabled={!canLoadRelatedProfiles || loadState.status === "loading"}
           name="relatedResourceType"
-          onChange={(event) => setRelatedResourceType(event.target.value as WikiResourceType)}
+          onChange={(event) => {
+            const nextResourceType = selectableResourceTypes.find(
+              (resourceType) => resourceType === event.target.value,
+            );
+
+            if (!nextResourceType) {
+              setLoadState({
+                status: "error",
+                message: "関連プロフィールの種類が不正です",
+              });
+              return;
+            }
+
+            setRelatedResourceType(nextResourceType);
+            setProfiles([]);
+            setWikiIdentifiers([]);
+            setLoadState({ status: "idle" });
+          }}
           value={relatedResourceType}
         >
           {selectableResourceTypes.map((resourceType) => (

--- a/src/gateways/wiki/wikiBrowserRouteSupport.ts
+++ b/src/gateways/wiki/wikiBrowserRouteSupport.ts
@@ -1,0 +1,25 @@
+export const readWikiRouteJsonResponse = async (
+  response: Response,
+  fallbackErrorMessage: string,
+): Promise<unknown> => {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      return { message: fallbackErrorMessage };
+    }
+
+    throw new Error(fallbackErrorMessage, { cause: error });
+  }
+};
+
+export const getWikiRouteErrorMessage = (
+  body: unknown,
+  fallbackErrorMessage: string,
+): string =>
+  typeof body === "object" &&
+  body !== null &&
+  "message" in body &&
+  typeof (body as { message: unknown }).message === "string"
+    ? (body as { message: string }).message
+    : fallbackErrorMessage;

--- a/src/gateways/wiki/wikiImageBrowserApi.test.ts
+++ b/src/gateways/wiki/wikiImageBrowserApi.test.ts
@@ -11,7 +11,6 @@ import {
   rejectWikiDraftImage,
   uploadWikiImageRequest,
 } from "./wikiImageBrowserApi";
-import { fetchWikiRelatedProfiles } from "./wikiRelatedProfilesBrowserApi";
 
 const imageIdentifier = "44444444-4444-4444-4444-444444444444";
 
@@ -188,36 +187,4 @@ describe("wikiImageBrowserApi", () => {
     ).rejects.toThrow();
   });
 
-  it("fetches related profiles through the browser related profiles route", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse({
-        profiles: [
-          {
-            wikiIdentifier: "11111111-1111-1111-1111-111111111111",
-            slug: "tl-momo",
-            language: "ja",
-            resourceType: "talent",
-            name: "MOMO",
-            normalizedName: "momo",
-            imageIdentifier: null,
-            imageUrl: null,
-            imageAltText: null,
-          },
-        ],
-      }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-
-    const result = await fetchWikiRelatedProfiles({
-      fallbackErrorMessage: "Related profiles failed",
-      language: "ja",
-      resourceType: "talent",
-      slug: "gr-twice",
-    });
-
-    expect(result.profiles.map((profile) => profile.slug)).toEqual(["tl-momo"]);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/wiki/ja/gr-twice/related-profiles?resourceType=talent",
-    );
-  });
 });

--- a/src/gateways/wiki/wikiImageBrowserApi.ts
+++ b/src/gateways/wiki/wikiImageBrowserApi.ts
@@ -14,22 +14,10 @@ import {
   type WikiImageUploadResponse,
 } from "@kpool/wiki";
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
-
-const readJsonResponse = async (response: Response): Promise<unknown> => {
-  try {
-    return await response.json();
-  } catch {
-    return {};
-  }
-};
-
-const getRouteErrorMessage = (body: unknown, fallback: string): string =>
-  typeof body === "object" &&
-  body !== null &&
-  "message" in body &&
-  typeof (body as { message: unknown }).message === "string"
-    ? (body as { message: string }).message
-    : fallback;
+import {
+  getWikiRouteErrorMessage,
+  readWikiRouteJsonResponse,
+} from "./wikiBrowserRouteSupport";
 
 export const fetchWikiDraftImages = async ({
   page,
@@ -55,10 +43,10 @@ export const fetchWikiDraftImages = async ({
   }
 
   const response = await fetch(`${url.pathname}${url.search}`);
-  const body = await readJsonResponse(response);
+  const body = await readWikiRouteJsonResponse(response, fallbackErrorMessage);
 
   if (!response.ok) {
-    throw new Error(getRouteErrorMessage(body, fallbackErrorMessage));
+    throw new Error(getWikiRouteErrorMessage(body, fallbackErrorMessage));
   }
 
   return parseWithSchemaLog("wiki draft image list response", wikiDraftImageListResponseSchema, normalizeWikiDraftImageListResponse(body));
@@ -82,10 +70,10 @@ export const fetchWikiImages = async ({
   url.searchParams.set("page", String(page));
 
   const response = await fetch(`${url.pathname}${url.search}`);
-  const body = await readJsonResponse(response);
+  const body = await readWikiRouteJsonResponse(response, fallbackErrorMessage);
 
   if (!response.ok) {
-    throw new Error(getRouteErrorMessage(body, fallbackErrorMessage));
+    throw new Error(getWikiRouteErrorMessage(body, fallbackErrorMessage));
   }
 
   return parseWithSchemaLog("wiki image list response", wikiImageListResponseSchema, body);
@@ -105,10 +93,10 @@ export const uploadWikiImageRequest = async ({
     },
     body: JSON.stringify(requestBody),
   });
-  const body = await readJsonResponse(response);
+  const body = await readWikiRouteJsonResponse(response, fallbackErrorMessage);
 
   if (!response.ok) {
-    throw new Error(getRouteErrorMessage(body, fallbackErrorMessage));
+    throw new Error(getWikiRouteErrorMessage(body, fallbackErrorMessage));
   }
 
   return parseWithSchemaLog("wiki image upload response", wikiImageUploadResponseSchema, body);
@@ -134,10 +122,10 @@ const reviewWikiDraftImage = async ({
       },
     },
   );
-  const body = await readJsonResponse(response);
+  const body = await readWikiRouteJsonResponse(response, fallbackErrorMessage);
 
   if (!response.ok) {
-    throw new Error(getRouteErrorMessage(body, fallbackErrorMessage));
+    throw new Error(getWikiRouteErrorMessage(body, fallbackErrorMessage));
   }
 
   return parseWithSchemaLog("wiki image review response", wikiImageReviewResponseSchema, body);

--- a/src/gateways/wiki/wikiPrivateServerApi.ts
+++ b/src/gateways/wiki/wikiPrivateServerApi.ts
@@ -1,6 +1,6 @@
 import { withWikiApiPrefix } from "@kpool/wiki";
 
-export const getWikiImageApiBaseUrl = (): string =>
+export const getWikiPrivateApiBaseUrl = (): string =>
   process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL
     ? withWikiApiPrefix(process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL)
     : "";

--- a/src/gateways/wiki/wikiRelatedProfilesBrowserApi.test.ts
+++ b/src/gateways/wiki/wikiRelatedProfilesBrowserApi.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchWikiRelatedProfiles } from "./wikiRelatedProfilesBrowserApi";
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("wikiRelatedProfilesBrowserApi", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches related profiles through the browser related profiles route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        profiles: [
+          {
+            wikiIdentifier: "11111111-1111-1111-1111-111111111111",
+            slug: "tl-momo",
+            language: "ja",
+            resourceType: "talent",
+            name: "MOMO",
+            normalizedName: "momo",
+            imageIdentifier: null,
+            imageUrl: null,
+            imageAltText: null,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchWikiRelatedProfiles({
+      fallbackErrorMessage: "Related profiles failed",
+      language: "ja",
+      resourceType: "talent",
+      slug: "gr-twice",
+    });
+
+    expect(result.profiles.map((profile) => profile.slug)).toEqual(["tl-momo"]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/wiki/ja/gr-twice/related-profiles?resourceType=talent",
+    );
+  });
+
+  it("throws route error messages for non-2xx responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ message: "Related profiles failed" }, 503)),
+    );
+
+    await expect(
+      fetchWikiRelatedProfiles({
+        fallbackErrorMessage: "Fallback related profiles failed",
+        language: "ja",
+        resourceType: "talent",
+        slug: "gr-twice",
+      }),
+    ).rejects.toThrow("Related profiles failed");
+  });
+
+  it("throws the fallback message when a non-2xx response has no route message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: true }, 503)));
+
+    await expect(
+      fetchWikiRelatedProfiles({
+        fallbackErrorMessage: "Fallback related profiles failed",
+        language: "ja",
+        resourceType: "talent",
+        slug: "gr-twice",
+      }),
+    ).rejects.toThrow("Fallback related profiles failed");
+  });
+
+  it("rejects invalid successful route responses", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ profiles: null })));
+
+    await expect(
+      fetchWikiRelatedProfiles({
+        fallbackErrorMessage: "Fallback related profiles failed",
+        language: "ja",
+        resourceType: "talent",
+        slug: "gr-twice",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws the fallback message when a route response is malformed JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("{", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchWikiRelatedProfiles({
+        fallbackErrorMessage: "Fallback related profiles failed",
+        language: "ja",
+        resourceType: "talent",
+        slug: "gr-twice",
+      }),
+    ).rejects.toThrow("Fallback related profiles failed");
+  });
+});

--- a/src/gateways/wiki/wikiRelatedProfilesBrowserApi.ts
+++ b/src/gateways/wiki/wikiRelatedProfilesBrowserApi.ts
@@ -5,22 +5,10 @@ import {
 } from "@kpool/wiki";
 
 import { parseWithSchemaLog } from "@/gateways/support/zodErrorLog";
-
-const readJsonResponse = async (response: Response): Promise<unknown> => {
-  try {
-    return await response.json();
-  } catch {
-    return {};
-  }
-};
-
-const getRouteErrorMessage = (body: unknown, fallback: string): string =>
-  typeof body === "object" &&
-  body !== null &&
-  "message" in body &&
-  typeof (body as { message: unknown }).message === "string"
-    ? (body as { message: string }).message
-    : fallback;
+import {
+  getWikiRouteErrorMessage,
+  readWikiRouteJsonResponse,
+} from "./wikiBrowserRouteSupport";
 
 export const fetchWikiRelatedProfiles = async ({
   fallbackErrorMessage,
@@ -41,10 +29,10 @@ export const fetchWikiRelatedProfiles = async ({
   url.searchParams.set("resourceType", resourceType);
 
   const response = await fetch(`${url.pathname}${url.search}`);
-  const body = await readJsonResponse(response);
+  const body = await readWikiRouteJsonResponse(response, fallbackErrorMessage);
 
   if (!response.ok) {
-    throw new Error(getRouteErrorMessage(body, fallbackErrorMessage));
+    throw new Error(getWikiRouteErrorMessage(body, fallbackErrorMessage));
   }
 
   return parseWithSchemaLog(


### PR DESCRIPTION
## 📝 変更内容

- Wiki系API Routeでバックエンド由来の詳細エラーメッセージをクライアントへ返さず、汎用メッセージを返すように変更
- Wiki private API base URL取得処理を `getWikiPrivateApiBaseUrl` に統一
- 画像・下書き・関連プロフィール取得のブラウザ側レスポンス処理を共通化
- 関連プロフィールフォームで resource type 変更時に古いプロフィール選択をクリアするように変更
- Wiki API Route、関連プロフィール取得、WikiBlockForm のテストを追加・更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki関連のAPI Routeでバックエンドの内部エラー詳細がレスポンスやログに露出しうる箇所があったため、クライアント向けには汎用メッセージを返し、ログもステータス中心に抑えるようにしました。

あわせて、関連プロフィール取得時の型検証とフォーム状態更新を見直し、resource type変更後に古い選択状態が送信されないようにしています。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- Wiki API Routeで内部エラーメッセージを返さない方針になっているか
- `readJsonResponseBody` / `readWikiRouteJsonResponse` の空・不正JSONレスポンスの扱いが妥当か
- 関連プロフィールフォームで resource type 変更時に stale な `profiles` / `wikiIdentifiers` が残らないか

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
