### PR TITLE
Wikiの長いURL折り返しとリスト編集UIを改善

### DIFF
--- a/src/components/Wiki/WikiBasicFieldsList/WikiBasicFieldsList.test.tsx
+++ b/src/components/Wiki/WikiBasicFieldsList/WikiBasicFieldsList.test.tsx
@@ -6,6 +6,16 @@ import { wikiStoryBasic } from "../storybook/fixtures";
 import { cardSurfaceStyle } from "../styles";
 import { WikiBasicFieldsList } from "./index";
 
+const longSocialUrl =
+  "https://www.youtube.com/HYBELABELShttps://twitter.com/HYBEOFFICIALtwt-super-long-unbroken-profile-link-value";
+const expectWrappedText = (element: Element | null) => {
+  expect(element).not.toBeNull();
+  expect(element).toHaveClass("min-w-0");
+  expect(element).toHaveClass("break-words");
+  expect(element?.className).toContain("[overflow-wrap:anywhere]");
+  expect(element?.className).toContain("[word-break:break-word]");
+};
+
 describe("WikiBasicFieldsList", () => {
   afterEach(() => cleanup());
 
@@ -48,6 +58,49 @@ describe("WikiBasicFieldsList", () => {
     expect(screen.getByRole("link", { name: "TWICE" })).toHaveAttribute(
       "href",
       "/wiki/ko/gr-twice",
+    );
+  });
+
+  it("applies wrapping classes to long social link values", () => {
+    render(
+      <WikiBasicFieldsList
+        basic={{
+          ...wikiStoryBasic,
+          resourceType: "agency",
+          socialLinks: [longSocialUrl],
+        }}
+        className="grid gap-4"
+        itemClassName="rounded-xl"
+        itemStyle={cardSurfaceStyle}
+      />,
+    );
+
+    expectWrappedText(screen.getByText(longSocialUrl));
+  });
+
+  it("applies wrapping classes to basic relation links", () => {
+    render(
+      <WikiBasicFieldsList
+        basic={{
+          ...wikiStoryBasic,
+          groups: [
+            {
+              wikiIdentifier: "group-wiki-1",
+              slug: "gr-super-long-unbroken-profile-slug-value",
+              language: "ko",
+              name: "SUPERLONGUNBROKENGROUPNAMETHATSHOULDWRAP",
+              normalizedName: "superlongunbrokengroupnamethatshouldwrap",
+            },
+          ],
+        }}
+        className="grid gap-4"
+        itemClassName="rounded-xl"
+        itemStyle={cardSurfaceStyle}
+      />,
+    );
+
+    expectWrappedText(
+      screen.getByRole("link", { name: "SUPERLONGUNBROKENGROUPNAMETHATSHOULDWRAP" }),
     );
   });
 });

--- a/src/components/Wiki/WikiBasicFieldsList/index.tsx
+++ b/src/components/Wiki/WikiBasicFieldsList/index.tsx
@@ -9,6 +9,9 @@ type WikiBasicFieldsListProps = {
   itemStyle: CSSProperties;
 };
 
+const basicFieldTextWrapClassName =
+  "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
+
 export function WikiBasicFieldsList({
   basic,
   className,
@@ -20,18 +23,18 @@ export function WikiBasicFieldsList({
   return (
     <dl className={className}>
       {fields.map((field) => (
-        <div className={itemClassName} key={field.label} style={itemStyle}>
+        <div className={`${basicFieldTextWrapClassName} ${itemClassName}`} key={field.label} style={itemStyle}>
           <dt className="text-xs font-semibold uppercase tracking-[0.22em] text-text-muted">
             {field.label}
           </dt>
-          <dd className="mt-1 text-sm leading-6 text-text-strong">
+          <dd className={`${basicFieldTextWrapClassName} mt-1 text-sm leading-6 text-text-strong`}>
             {field.links ? (
-              <span className="flex flex-wrap gap-x-2 gap-y-1">
+              <span className={`${basicFieldTextWrapClassName} flex flex-wrap gap-x-2 gap-y-1`}>
                 {field.links.map((link, index) => (
-                  <span key={`${link.href}-${index}`}>
+                  <span className={basicFieldTextWrapClassName} key={`${link.href}-${index}`}>
                     {index > 0 ? <span className="mr-2 text-text-muted">,</span> : null}
                     <Link
-                      className="font-semibold text-brand-primary underline-offset-4 hover:underline"
+                      className={`${basicFieldTextWrapClassName} font-semibold text-brand-primary underline-offset-4 hover:underline`}
                       href={link.href}
                     >
                       {link.label}
@@ -40,7 +43,7 @@ export function WikiBasicFieldsList({
                 ))}
               </span>
             ) : (
-              field.value
+              <span className={basicFieldTextWrapClassName}>{field.value}</span>
             )}
           </dd>
         </div>

--- a/src/components/Wiki/WikiBasicPanel/index.tsx
+++ b/src/components/Wiki/WikiBasicPanel/index.tsx
@@ -25,10 +25,12 @@ type WikiBasicPanelProps = {
 };
 
 const basicInputClassName =
-  "rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2";
+  "min-w-0 break-words rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2 [overflow-wrap:anywhere] [word-break:break-word]";
 const basicTextareaClassName =
-  "min-h-24 rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2";
-const basicLabelClassName = "grid gap-2 text-sm font-semibold text-text-strong";
+  "min-h-24 min-w-0 whitespace-pre-wrap break-words rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2 [overflow-wrap:anywhere] [word-break:break-word]";
+const basicLabelClassName = "grid min-w-0 gap-2 text-sm font-semibold text-text-strong";
+const basicTextWrapClassName =
+  "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
 
 const getOptionalString = (formData: FormData, name: string): string | undefined =>
   getString(formData, name).trim() || undefined;
@@ -142,21 +144,21 @@ function BasicRelationLinks({
   }
 
   return (
-    <div className="rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2">
-      <p className="text-sm font-semibold text-text-strong">{label}</p>
-      <div className="mt-2 flex flex-wrap gap-x-2 gap-y-1 text-sm leading-6">
+    <div className={`${basicTextWrapClassName} rounded-xl border border-stroke-subtle bg-surface-raised px-3 py-2`}>
+      <p className={`${basicTextWrapClassName} text-sm font-semibold text-text-strong`}>{label}</p>
+      <div className={`${basicTextWrapClassName} mt-2 flex flex-wrap gap-x-2 gap-y-1 text-sm leading-6`}>
         {relations.map((relation, index) => (
-          <span key={`${relation.wikiIdentifier}-${index}`}>
+          <span className={basicTextWrapClassName} key={`${relation.wikiIdentifier}-${index}`}>
             {index > 0 ? <span className="mr-2 text-text-muted">,</span> : null}
             {relation.slug && relation.language ? (
               <Link
-                className="font-semibold text-brand-primary underline-offset-4 hover:underline"
+                className={`${basicTextWrapClassName} font-semibold text-brand-primary underline-offset-4 hover:underline`}
                 href={buildWikiPath(relation.language, relation.slug)}
               >
                 {relation.name}
               </Link>
             ) : (
-              <span className="text-text-strong">{relation.name}</span>
+              <span className={`${basicTextWrapClassName} text-text-strong`}>{relation.name}</span>
             )}
           </span>
         ))}

--- a/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
@@ -4,6 +4,16 @@ import { describe, expect, it } from "vitest";
 
 import { WikiBlockDisplay } from "./index";
 
+const longUrl =
+  "https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQHs3TB7sXKlDyoxSSyk2DSanTdj2tnV5_AB96T_61RoI7d4QX532769HJP43NSO31B_gXlGXwFY6Mz1vDM4D_v11M8R5KKBBro17S3QcKK3QsBnpDcGK48hItgtoSyRX5W7D2-EUw==";
+const expectWrappedText = (element: Element | null) => {
+  expect(element).not.toBeNull();
+  expect(element).toHaveClass("min-w-0");
+  expect(element).toHaveClass("break-words");
+  expect(element?.className).toContain("[overflow-wrap:anywhere]");
+  expect(element?.className).toContain("[word-break:break-word]");
+};
+
 describe("WikiBlockDisplay", () => {
   it("renders list blocks", () => {
     render(
@@ -136,5 +146,74 @@ describe("WikiBlockDisplay", () => {
     expect(textBlock).not.toBeNull();
     expect(textBlock).toHaveTextContent("first linesecond line");
     expect(container.querySelector("br")).not.toBeNull();
+  });
+
+  it("applies wrapping classes to long text blocks and inline links", () => {
+    const { container } = render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "text-long-url",
+          blockType: "text",
+          content: `weverse.io (${longUrl}) [source](${longUrl})`,
+          displayOrder: 40,
+        }}
+      />,
+    );
+
+    expectWrappedText(container.querySelector("p"));
+    expectWrappedText(screen.getByRole("link", { name: "source" }));
+  });
+
+  it("applies wrapping classes to long list items", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "list-long-url",
+          blockType: "list",
+          displayOrder: 50,
+          listType: "bullet",
+          items: [`title (${longUrl})`],
+        }}
+      />,
+    );
+
+    expectWrappedText(screen.getByText(`title (${longUrl})`));
+  });
+
+  it("applies wrapping classes to long quote content", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "quote-long-url",
+          blockType: "quote",
+          content: longUrl,
+          displayOrder: 60,
+          source: `source-${longUrl}`,
+        }}
+      />,
+    );
+
+    expectWrappedText(screen.getByText(longUrl));
+    expectWrappedText(screen.getByText(`source-${longUrl}`));
+  });
+
+  it("applies wrapping classes to long table header and cell content", () => {
+    render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "table-long-url",
+          blockType: "table",
+          displayOrder: 70,
+          headers: [longUrl],
+          headerCells: [{ content: longUrl }],
+          rows: [[`cell-${longUrl}`]],
+          rowCells: [[{ content: `cell-${longUrl}` }]],
+          tableWidth: 320,
+        }}
+      />,
+    );
+
+    expectWrappedText(screen.getByText(longUrl, { selector: "th" }));
+    expectWrappedText(screen.getByText(`cell-${longUrl}`, { selector: "td" }));
   });
 });

--- a/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/WikiBlockDisplay.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { WikiBlockDisplay } from "./index";
 
@@ -15,6 +15,8 @@ const expectWrappedText = (element: Element | null) => {
 };
 
 describe("WikiBlockDisplay", () => {
+  afterEach(() => cleanup());
+
   it("renders list blocks", () => {
     render(
       <WikiBlockDisplay
@@ -115,6 +117,37 @@ describe("WikiBlockDisplay", () => {
     expect(screen.getByRole("link", { name: "site" })).toHaveAttribute("target", "_blank");
   });
 
+  it("renders supported inline markdown inside list items", () => {
+    const { container } = render(
+      <WikiBlockDisplay
+        block={{
+          blockIdentifier: "list-inline-markdown",
+          blockType: "list",
+          displayOrder: 15,
+          listType: "bullet",
+          items: [
+            "**bold** _italic_ ~~strike~~ [site](https://example.com) [[HYBE|agency]]",
+          ],
+        }}
+        language="ko"
+      />,
+    );
+    const listItem = container.querySelector("li");
+
+    expect(listItem).not.toBeNull();
+    expect(within(listItem as HTMLElement).getByText("bold", { selector: "strong" })).toBeInTheDocument();
+    expect(within(listItem as HTMLElement).getByText("italic", { selector: "em" })).toBeInTheDocument();
+    expect(within(listItem as HTMLElement).getByText("strike", { selector: "del" })).toBeInTheDocument();
+    expect(within(listItem as HTMLElement).getByRole("link", { name: "site" })).toHaveAttribute(
+      "href",
+      "https://example.com",
+    );
+    expect(within(listItem as HTMLElement).getByRole("link", { name: "agency" })).toHaveAttribute(
+      "href",
+      "/wiki/ko/HYBE",
+    );
+  });
+
   it("shows invalid markdown as plain text", () => {
     render(
       <WikiBlockDisplay
@@ -165,7 +198,7 @@ describe("WikiBlockDisplay", () => {
   });
 
   it("applies wrapping classes to long list items", () => {
-    render(
+    const { container } = render(
       <WikiBlockDisplay
         block={{
           blockIdentifier: "list-long-url",
@@ -177,7 +210,7 @@ describe("WikiBlockDisplay", () => {
       />,
     );
 
-    expectWrappedText(screen.getByText(`title (${longUrl})`));
+    expectWrappedText(container.querySelector("li"));
   });
 
   it("applies wrapping classes to long quote content", () => {

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -179,11 +179,11 @@ export function WikiBlockDisplay({
     case "list":
       return block.listType === "numbered" ? (
         <ol className={`${textWrapClassName} list-decimal space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
-          {block.items.map((item) => <li className={textWrapClassName} key={item}>{item}</li>)}
+          {block.items.map((item) => <li className={textWrapClassName} key={item}>{renderInlineTokens(item)}</li>)}
         </ol>
       ) : (
         <ul className={`${textWrapClassName} list-disc space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
-          {block.items.map((item) => <li className={textWrapClassName} key={item}>{item}</li>)}
+          {block.items.map((item) => <li className={textWrapClassName} key={item}>{renderInlineTokens(item)}</li>)}
         </ul>
       );
     case "table":

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -17,6 +17,11 @@ type WikiBlockDisplayProps = {
   textClassName?: string;
 };
 
+const textWrapClassName = "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
+const inlineLinkClassName = `${textWrapClassName} text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800`;
+const captionClassName = `${textWrapClassName} mt-2 text-sm text-text-muted`;
+const tableCellClassName = `${textWrapClassName} border-b border-stroke-subtle px-3 py-2`;
+
 export function WikiBlockDisplay({
   block,
   language = "ja",
@@ -42,7 +47,7 @@ export function WikiBlockDisplay({
       } else {
         nodes.push(
           <a
-            className="text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800"
+            className={inlineLinkClassName}
             href={buildWikiPath(language, target)}
             key={`${keyPrefix}-namu-link-${match.index}`}
             rel="noopener noreferrer"
@@ -85,7 +90,7 @@ export function WikiBlockDisplay({
 
           return (
             <a
-              className="text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800"
+              className={inlineLinkClassName}
               href={href}
               key={`link-${index}`}
               rel="noopener noreferrer"
@@ -108,7 +113,7 @@ export function WikiBlockDisplay({
         case "include":
           return (
             <span
-              className="inline-flex rounded-full border border-stroke-subtle px-2 py-0.5 text-xs font-semibold text-text-muted"
+              className={`${textWrapClassName} inline-flex max-w-full rounded-full border border-stroke-subtle px-2 py-0.5 text-xs font-semibold text-text-muted`}
               key={`include-${index}`}
             >
               Included from {token.target}
@@ -130,7 +135,7 @@ export function WikiBlockDisplay({
   };
 
   const renderTextBlock = (content: string) => (
-    <p className={textClassName}>
+    <p className={`${textWrapClassName} ${textClassName}`}>
       {renderInlineTokens(content)}
     </p>
   );
@@ -145,7 +150,7 @@ export function WikiBlockDisplay({
             <Image alt={block.alt ?? ""} className="object-cover" fill sizes="100vw" src={block.imageSrc} unoptimized />
             {showEditableImageOverlay ? <ImageEditableOverlay /> : null}
           </div>
-          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+          {block.caption ? <figcaption className={captionClassName}>{block.caption}</figcaption> : null}
         </figure>
       );
     case "image_gallery":
@@ -159,26 +164,26 @@ export function WikiBlockDisplay({
               </div>
             ))}
           </div>
-          {block.caption ? <figcaption className="mt-2 text-sm text-text-muted">{block.caption}</figcaption> : null}
+          {block.caption ? <figcaption className={captionClassName}>{block.caption}</figcaption> : null}
         </figure>
       );
     case "embed":
       return <WikiEmbedFrame block={block} />;
     case "quote":
       return (
-        <blockquote className="border-l-4 border-text-muted/30 pl-4 text-base leading-8 text-text-strong">
+        <blockquote className={`${textWrapClassName} border-l-4 border-text-muted/30 pl-4 text-base leading-8 text-text-strong`}>
           {block.content}
-          {block.source ? <cite className="mt-2 block text-sm text-text-muted">{block.source}</cite> : null}
+          {block.source ? <cite className={`${textWrapClassName} mt-2 block text-sm text-text-muted`}>{block.source}</cite> : null}
         </blockquote>
       );
     case "list":
       return block.listType === "numbered" ? (
-        <ol className="list-decimal space-y-2 pl-6 text-sm leading-7 text-text-strong">
-          {block.items.map((item) => <li key={item}>{item}</li>)}
+        <ol className={`${textWrapClassName} list-decimal space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
+          {block.items.map((item) => <li className={textWrapClassName} key={item}>{item}</li>)}
         </ol>
       ) : (
-        <ul className="list-disc space-y-2 pl-6 text-sm leading-7 text-text-strong">
-          {block.items.map((item) => <li key={item}>{item}</li>)}
+        <ul className={`${textWrapClassName} list-disc space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
+          {block.items.map((item) => <li className={textWrapClassName} key={item}>{item}</li>)}
         </ul>
       );
     case "table":
@@ -198,7 +203,7 @@ export function WikiBlockDisplay({
                 <tr>
                   {headerCells.map((header, index) => (
                     <th
-                      className="border-b border-stroke-subtle px-3 py-2"
+                      className={tableCellClassName}
                       colSpan={header.colspan ?? 1}
                       key={`${header.content}-${index}`}
                     >
@@ -213,7 +218,7 @@ export function WikiBlockDisplay({
                 <tr key={`row-${rowIndex}`}>
                   {row.map((cell, cellIndex) => (
                     <td
-                      className="border-b border-stroke-subtle px-3 py-2 text-text-strong"
+                      className={`${tableCellClassName} text-text-strong`}
                       colSpan={cell.colspan ?? 1}
                       key={`${cell.content}-${cellIndex}`}
                     >

--- a/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
+++ b/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
@@ -147,6 +147,7 @@ describe("WikiBlockForm", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
 
+    expect(screen.getByRole("dialog")).toHaveClass("left-0");
     expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
   });
 
@@ -169,7 +170,36 @@ describe("WikiBlockForm", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
 
+    expect(screen.getByRole("dialog")).toHaveClass("left-0");
     expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
+  });
+
+  it("closes the previous list link popover when another one opens", () => {
+    render(
+      <WikiBlockForm
+        block={{
+          blockIdentifier: "list-2",
+          blockType: "list",
+          displayOrder: 10,
+          items: ["First item", "Second item"],
+          listType: "bullet",
+        }}
+        onCancel={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    const linkButtons = screen.getAllByRole("button", { name: "Insert link" });
+
+    fireEvent.click(linkButtons[0]);
+
+    expect(linkButtons[0]).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    fireEvent.click(linkButtons[1]);
+
+    expect(linkButtons[0]).toHaveAttribute("aria-expanded", "false");
+    expect(linkButtons[1]).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
   });
 
   it("submits list item inline markdown without requiring raw textarea editing", () => {

--- a/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
+++ b/src/components/Wiki/WikiBlockForm/WikiBlockForm.test.tsx
@@ -150,6 +150,55 @@ describe("WikiBlockForm", () => {
     expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
   });
 
+  it("opens the link editor from a list item toolbar", () => {
+    render(
+      <WikiBlockForm
+        block={{
+          blockIdentifier: "list-1",
+          blockType: "list",
+          displayOrder: 10,
+          items: ["First item"],
+          listType: "bullet",
+        }}
+        onCancel={() => {}}
+        onSave={() => {}}
+      />,
+    );
+
+    expect(screen.queryByLabelText("Link destination")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert link" }));
+
+    expect(screen.getByLabelText("Link destination")).toBeInTheDocument();
+  });
+
+  it("submits list item inline markdown without requiring raw textarea editing", () => {
+    const onSave = vi.fn();
+
+    render(
+      <WikiBlockForm
+        block={{
+          blockIdentifier: "list-2",
+          blockType: "list",
+          displayOrder: 10,
+          items: ["**bold** _italic_ ~~strike~~ [site](https://example.com)"],
+          listType: "numbered",
+        }}
+        onCancel={() => {}}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Items")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      items: ["**bold** _italic_ ~~strike~~ [site](https://example.com)"],
+      listType: "numbered",
+    });
+  });
+
   it("loads related profile slugs from selected resource type", async () => {
     const onSave = vi.fn();
     const fetchMock = vi.fn().mockResolvedValue(

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -85,6 +85,10 @@ type TableCellSelection =
 const getRenderedColumnCount = (cells: WikiTableCell[]): number =>
   cells.reduce((count, cell) => count + Math.max(1, cell.colspan ?? 1), 0);
 
+const formTextWrapClassName = "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
+const textInputClassName = `${formTextWrapClassName} w-full rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2`;
+const textAreaClassName = `${textInputClassName} min-h-24 whitespace-pre-wrap`;
+
 const createEmptyTableCell = (): WikiTableCell => ({ content: "" });
 
 const createEmptyTableRow = (columnCount: number): WikiTableCell[] =>
@@ -532,7 +536,7 @@ function WikiTableBlockForm({ block, onCancel, onSave }: TableBlockFormProps) {
         <label className="grid gap-2 text-sm font-semibold text-text-strong">
           Table width
           <input
-            className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
+            className={textInputClassName}
             min="1"
             onChange={(event) =>
               setTableState((current) => ({
@@ -608,7 +612,7 @@ function WikiTableBlockForm({ block, onCancel, onSave }: TableBlockFormProps) {
                         Header {cellIndex + 1}
                         <input
                           aria-label={`Header cell ${cellIndex + 1}`}
-                          className="rounded-lg border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-normal text-text-strong"
+                          className={`${formTextWrapClassName} w-full rounded-lg border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-normal text-text-strong`}
                           onClick={(event) =>
                             selectCell({ kind: "header", cellIndex }, event.shiftKey)
                           }
@@ -638,7 +642,7 @@ function WikiTableBlockForm({ block, onCancel, onSave }: TableBlockFormProps) {
                     <div className="p-3">
                       <input
                         aria-label={`Row ${rowIndex + 1} cell ${cellIndex + 1}`}
-                        className="w-full rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm font-normal text-text-strong outline-none transition focus:border-stroke-subtle focus:bg-surface-base"
+                        className={`${formTextWrapClassName} w-full rounded-lg border border-transparent bg-transparent px-3 py-2 text-sm font-normal text-text-strong outline-none transition focus:border-stroke-subtle focus:bg-surface-base`}
                         onClick={(event) =>
                           selectCell({ kind: "body", rowIndex, cellIndex }, event.shiftKey)
                         }
@@ -672,7 +676,7 @@ function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
       attributes: {
         "aria-labelledby": editorLabelId,
         class:
-          "min-h-32 whitespace-pre-wrap break-words px-3 py-3 outline-none before:text-text-muted empty:before:content-['Write_something…'] [&_a]:text-sky-700 [&_a]:underline [&_a]:decoration-sky-500 [&_a]:underline-offset-2",
+          "min-h-32 min-w-0 whitespace-pre-wrap break-words px-3 py-3 outline-none [overflow-wrap:anywhere] [word-break:break-word] before:text-text-muted empty:before:content-['Write_something…'] [&_a]:break-words [&_a]:[overflow-wrap:anywhere] [&_a]:[word-break:break-word] [&_a]:text-sky-700 [&_a]:underline [&_a]:decoration-sky-500 [&_a]:underline-offset-2",
         role: "textbox",
       },
       handleKeyDown(view, event) {
@@ -846,7 +850,7 @@ function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
                 Link destination
               </label>
               <input
-                className="min-w-0 flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal"
+                className={`${formTextWrapClassName} flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal`}
                 id={`wiki-link-${block.blockIdentifier}`}
                 onChange={(event) => setLinkUrl(event.target.value)}
                 placeholder="Paste a link"
@@ -944,7 +948,7 @@ function WikiProfileCardListBlockForm({
       <label className="grid gap-2 text-sm font-semibold text-text-strong">
         Title
         <input
-          className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
+          className={textInputClassName}
           name="title"
           onChange={(event) => setTitle(event.target.value)}
           value={title}
@@ -1041,10 +1045,22 @@ export function WikiBlockForm({
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ imageIdentifier: getString(data, "imageIdentifier"), imageSrc: getString(data, "imageSrc"), caption: getString(data, "caption") || null, alt: getString(data, "alt") || null }))}>
           <div className="grid gap-3">
-            <label className="grid gap-2 text-sm font-semibold text-text-strong">Image identifier<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.imageIdentifier} name="imageIdentifier" /></label>
-            <label className="grid gap-2 text-sm font-semibold text-text-strong">Image URL<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.imageSrc} name="imageSrc" /></label>
-            <label className="grid gap-2 text-sm font-semibold text-text-strong">Alt<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.alt ?? ""} name="alt" /></label>
-            <label className="grid gap-2 text-sm font-semibold text-text-strong">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+              Image identifier
+              <input className={textInputClassName} defaultValue={block.imageIdentifier} name="imageIdentifier" />
+            </label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+              Image URL
+              <input className={textInputClassName} defaultValue={block.imageSrc} name="imageSrc" />
+            </label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+              Alt
+              <input className={textInputClassName} defaultValue={block.alt ?? ""} name="alt" />
+            </label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+              Caption
+              <input className={textInputClassName} defaultValue={block.caption ?? ""} name="caption" />
+            </label>
           </div>
           <WikiFormActions onCancel={onCancel} />
         </form>
@@ -1052,8 +1068,14 @@ export function WikiBlockForm({
     case "image_gallery":
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ images: getLines(data, "images").map((line, index) => ({ imageIdentifier: line, imageSrc: block.images[index]?.imageSrc ?? block.images[0]?.imageSrc ?? "", alt: block.images[index]?.alt ?? line })), caption: getString(data, "caption") || null }))}>
-          <label className="grid gap-2 text-sm font-semibold text-text-strong">Image identifiers<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.images.map((image) => image.imageIdentifier).join("\n")} name="images" /></label>
-          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+          <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+            Image identifiers
+            <textarea className={textAreaClassName} defaultValue={block.images.map((image) => image.imageIdentifier).join("\n")} name="images" />
+          </label>
+          <label className="mt-3 grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+            Caption
+            <input className={textInputClassName} defaultValue={block.caption ?? ""} name="caption" />
+          </label>
           <WikiFormActions onCancel={onCancel} />
         </form>
       );
@@ -1062,8 +1084,14 @@ export function WikiBlockForm({
         <form onSubmit={(event) => submit(event, (data) => ({ provider: getString(data, "provider") as WikiEmbedProvider, embedId: getString(data, "embedId"), caption: getString(data, "caption") || null }))}>
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="grid gap-2 text-sm font-semibold text-text-strong">Provider<select className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.provider} name="provider"><option value="youtube">youtube</option><option value="spotify">spotify</option><option value="x">x</option><option value="tiktok">tiktok</option></select></label>
-            <label className="grid gap-2 text-sm font-semibold text-text-strong">Embed ID<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.embedId} name="embedId" /></label>
-            <label className="grid gap-2 text-sm font-semibold text-text-strong sm:col-span-2">Caption<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.caption ?? ""} name="caption" /></label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+              Embed ID
+              <input className={textInputClassName} defaultValue={block.embedId} name="embedId" />
+            </label>
+            <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong sm:col-span-2">
+              Caption
+              <input className={textInputClassName} defaultValue={block.caption ?? ""} name="caption" />
+            </label>
           </div>
           <WikiFormActions onCancel={onCancel} />
         </form>
@@ -1071,8 +1099,14 @@ export function WikiBlockForm({
     case "quote":
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ content: getString(data, "content"), source: getString(data, "source") || null }))}>
-          <label className="grid gap-2 text-sm font-semibold text-text-strong">Quote<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.content} name="content" /></label>
-          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Source<input className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.source ?? ""} name="source" /></label>
+          <label className="grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+            Quote
+            <textarea className={textAreaClassName} defaultValue={block.content} name="content" />
+          </label>
+          <label className="mt-3 grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+            Source
+            <input className={textInputClassName} defaultValue={block.source ?? ""} name="source" />
+          </label>
           <WikiFormActions onCancel={onCancel} />
         </form>
       );
@@ -1080,7 +1114,10 @@ export function WikiBlockForm({
       return (
         <form onSubmit={(event) => submit(event, (data) => ({ listType: getString(data, "listType") as WikiListType, items: getLines(data, "items") }))}>
           <label className="grid gap-2 text-sm font-semibold text-text-strong">List type<select className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.listType} name="listType"><option value="bullet">bullet</option><option value="numbered">numbered</option></select></label>
-          <label className="mt-3 grid gap-2 text-sm font-semibold text-text-strong">Items<textarea className="min-h-24 rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.items.join("\n")} name="items" /></label>
+          <label className="mt-3 grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
+            Items
+            <textarea className={textAreaClassName} defaultValue={block.items.join("\n")} name="items" />
+          </label>
           <WikiFormActions onCancel={onCancel} />
         </form>
       );

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -5,7 +5,7 @@ import { EditorContent, useEditor, useEditorState } from "@tiptap/react";
 import Image from "next/image";
 import Link from "@tiptap/extension-link";
 import StarterKit from "@tiptap/starter-kit";
-import { type FormEvent, type MouseEvent, useState } from "react";
+import { type FormEvent, type KeyboardEvent, type MouseEvent, useEffect, useState } from "react";
 import {
   getSelectableRelatedProfileResourceTypes,
   isWikiResourceType,
@@ -96,6 +96,7 @@ const getRenderedColumnCount = (cells: WikiTableCell[]): number =>
 const formTextWrapClassName = "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
 const textInputClassName = `${formTextWrapClassName} w-full rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2`;
 const textAreaClassName = `${textInputClassName} min-h-24 whitespace-pre-wrap`;
+const linkPopoverOpenEventName = "wiki:inline-link-popover-open";
 
 const createEmptyTableCell = (): WikiTableCell => ({ content: "" });
 
@@ -784,12 +785,51 @@ function InlineMarkdownEditor({
     editor.chain().focus().toggleStrike().run();
   };
 
-  const openLinkEditor = () => setIsLinkEditorOpen(true);
+  const openLinkEditor = () => {
+    window.dispatchEvent(
+      new CustomEvent(linkPopoverOpenEventName, {
+        detail: { editorId },
+      }),
+    );
+    setIsLinkEditorOpen(true);
+  };
 
-  const closeLinkEditor = () => {
+  const closeLinkEditor = ({ restoreFocus = true }: { restoreFocus?: boolean } = {}) => {
     setIsLinkEditorOpen(false);
     setLinkUrl("");
-    editor?.commands.focus();
+    if (restoreFocus) {
+      editor?.commands.focus();
+    }
+  };
+
+  useEffect(() => {
+    const closeOtherLinkEditor = (event: Event) => {
+      const openedEditorId = (event as CustomEvent<{ editorId?: string }>).detail?.editorId;
+
+      if (openedEditorId && openedEditorId !== editorId) {
+        setIsLinkEditorOpen(false);
+        setLinkUrl("");
+      }
+    };
+
+    window.addEventListener(linkPopoverOpenEventName, closeOtherLinkEditor);
+
+    return () => {
+      window.removeEventListener(linkPopoverOpenEventName, closeOtherLinkEditor);
+    };
+  }, [editorId]);
+
+  const handleLinkInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeLinkEditor();
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      applyFormat("link");
+    }
   };
 
   const preserveSelection = (event: MouseEvent<HTMLButtonElement>) => event.preventDefault();
@@ -814,7 +854,7 @@ function InlineMarkdownEditor({
       <label className="text-sm font-semibold text-text-strong" id={editorLabelId}>
         {label}
       </label>
-      <div className="overflow-hidden rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
+      <div className="rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
         <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle px-3 py-2">
           <button
             aria-label="Bold"
@@ -847,35 +887,46 @@ function InlineMarkdownEditor({
             S
           </button>
           <span aria-hidden="true" className="h-5 w-px bg-stroke-subtle" />
-          <button
-            aria-expanded={isLinkEditorOpen}
-            aria-label="Insert link"
-            aria-pressed={editorState.isLinkActive}
-            className={getIconButtonClassName(editorState.isLinkActive)}
-            onClick={openLinkEditor}
-            onMouseDown={preserveSelection}
-            type="button"
-          >
-            <Link2Icon aria-hidden="true" className="size-4" />
-          </button>
+          <span className="relative inline-flex">
+            <button
+              aria-controls={`${editorId}-link-popover`}
+              aria-expanded={isLinkEditorOpen}
+              aria-label="Insert link"
+              aria-pressed={editorState.isLinkActive}
+              className={getIconButtonClassName(editorState.isLinkActive)}
+              onClick={openLinkEditor}
+              onMouseDown={preserveSelection}
+              type="button"
+            >
+              <Link2Icon aria-hidden="true" className="size-4" />
+            </button>
+            {isLinkEditorOpen ? (
+              <div
+                className="absolute left-0 top-full z-20 mt-2 w-72 max-w-[calc(100vw-2rem)] rounded-xl border border-stroke-subtle bg-surface-raised p-3 shadow-soft"
+                id={`${editorId}-link-popover`}
+                role="dialog"
+              >
+                <label className="sr-only" htmlFor={`${editorId}-link`}>
+                  Link destination
+                </label>
+                <input
+                  autoFocus
+                  className={`${formTextWrapClassName} w-full rounded-lg border border-stroke-subtle bg-surface-base px-3 py-2 text-sm font-normal`}
+                  id={`${editorId}-link`}
+                  onChange={(event) => setLinkUrl(event.target.value)}
+                  onKeyDown={handleLinkInputKeyDown}
+                  placeholder="Paste a link"
+                  type="url"
+                  value={linkUrl}
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                  <button className="rounded-md px-2 py-2 text-sm text-text-muted transition hover:bg-surface-base" onClick={() => closeLinkEditor()} type="button">Cancel</button>
+                  <button className="rounded-md border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:opacity-50" disabled={!linkUrl.trim()} onClick={() => applyFormat("link")} onMouseDown={(event) => event.preventDefault()} type="button">Apply</button>
+                </div>
+              </div>
+            ) : null}
+          </span>
         </div>
-        {isLinkEditorOpen ? (
-          <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle bg-surface-base px-3 py-2">
-            <label className="sr-only" htmlFor={`${editorId}-link`}>
-              Link destination
-            </label>
-            <input
-              className={`${formTextWrapClassName} flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal`}
-              id={`${editorId}-link`}
-              onChange={(event) => setLinkUrl(event.target.value)}
-              placeholder="Paste a link"
-              type="url"
-              value={linkUrl}
-            />
-            <button className="rounded-md border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:opacity-50" disabled={!linkUrl.trim()} onClick={() => applyFormat("link")} onMouseDown={(event) => event.preventDefault()} type="button">Apply</button>
-            <button className="rounded-md px-2 py-2 text-sm text-text-muted transition hover:bg-surface-base" onClick={closeLinkEditor} type="button">Cancel</button>
-          </div>
-        ) : null}
         <EditorContent editor={editor} />
       </div>
     </div>

--- a/src/components/Wiki/WikiBlockForm/index.tsx
+++ b/src/components/Wiki/WikiBlockForm/index.tsx
@@ -51,6 +51,14 @@ type TextBlockFormProps = {
   onSave: (changes: Partial<WikiBlock>) => void;
 };
 
+type WikiListBlock = Extract<WikiBlock, { blockType: "list" }>;
+
+type ListBlockFormProps = {
+  block: WikiListBlock;
+  onCancel: () => void;
+  onSave: (changes: Partial<WikiBlock>) => void;
+};
+
 type TableBlockFormProps = {
   block: WikiTableBlock;
   onCancel: () => void;
@@ -666,17 +674,29 @@ function WikiTableBlockForm({ block, onCancel, onSave }: TableBlockFormProps) {
   );
 }
 
-function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
-  const editorLabelId = `wiki-text-label-${block.blockIdentifier}`;
+function InlineMarkdownEditor({
+  content,
+  editorId,
+  label,
+  minHeightClassName = "min-h-32",
+  onChange,
+}: {
+  content: string;
+  editorId: string;
+  label: string;
+  minHeightClassName?: string;
+  onChange: (content: string) => void;
+}) {
+  const editorLabelId = `${editorId}-label`;
   const [linkUrl, setLinkUrl] = useState("");
   const [isLinkEditorOpen, setIsLinkEditorOpen] = useState(false);
   const editor = useEditor({
-    content: inlineMarkdownToTiptapHtml(block.content),
+    content: inlineMarkdownToTiptapHtml(content),
     editorProps: {
       attributes: {
         "aria-labelledby": editorLabelId,
         class:
-          "min-h-32 min-w-0 whitespace-pre-wrap break-words px-3 py-3 outline-none [overflow-wrap:anywhere] [word-break:break-word] before:text-text-muted empty:before:content-['Write_something…'] [&_a]:break-words [&_a]:[overflow-wrap:anywhere] [&_a]:[word-break:break-word] [&_a]:text-sky-700 [&_a]:underline [&_a]:decoration-sky-500 [&_a]:underline-offset-2",
+          `${minHeightClassName} min-w-0 whitespace-pre-wrap break-words px-3 py-3 outline-none [overflow-wrap:anywhere] [word-break:break-word] before:text-text-muted empty:before:content-['Write_something…'] [&_a]:break-words [&_a]:[overflow-wrap:anywhere] [&_a]:[word-break:break-word] [&_a]:text-sky-700 [&_a]:underline [&_a]:decoration-sky-500 [&_a]:underline-offset-2`,
         role: "textbox",
       },
       handleKeyDown(view, event) {
@@ -713,6 +733,9 @@ function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
         openOnClick: false,
       }),
     ],
+    onUpdate({ editor: currentEditor }) {
+      onChange(serializeTiptapJsonToInlineMarkdown(currentEditor.getJSON()));
+    },
     immediatelyRender: false,
   });
   const editorState = useEditorState({
@@ -729,9 +752,6 @@ function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
     isStrikeActive: false,
     isLinkActive: false,
   };
-
-  const getMarkdownContent = () =>
-    editor ? serializeTiptapJsonToInlineMarkdown(editor.getJSON()) : block.content;
 
   const applyFormat = (format: "bold" | "italic" | "strike" | "link") => {
     if (!editor) {
@@ -790,80 +810,177 @@ function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
     ].join(" ");
 
   return (
+    <div className="grid gap-2">
+      <label className="text-sm font-semibold text-text-strong" id={editorLabelId}>
+        {label}
+      </label>
+      <div className="overflow-hidden rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
+        <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle px-3 py-2">
+          <button
+            aria-label="Bold"
+            aria-pressed={editorState.isBoldActive}
+            className={getToolbarButtonClassName(editorState.isBoldActive, "font-bold")}
+            onClick={() => applyFormat("bold")}
+            onMouseDown={preserveSelection}
+            type="button"
+          >
+            B
+          </button>
+          <button
+            aria-label="Italic"
+            aria-pressed={editorState.isItalicActive}
+            className={getToolbarButtonClassName(editorState.isItalicActive, "italic")}
+            onClick={() => applyFormat("italic")}
+            onMouseDown={preserveSelection}
+            type="button"
+          >
+            I
+          </button>
+          <button
+            aria-label="Strike"
+            aria-pressed={editorState.isStrikeActive}
+            className={getToolbarButtonClassName(editorState.isStrikeActive, "line-through")}
+            onClick={() => applyFormat("strike")}
+            onMouseDown={preserveSelection}
+            type="button"
+          >
+            S
+          </button>
+          <span aria-hidden="true" className="h-5 w-px bg-stroke-subtle" />
+          <button
+            aria-expanded={isLinkEditorOpen}
+            aria-label="Insert link"
+            aria-pressed={editorState.isLinkActive}
+            className={getIconButtonClassName(editorState.isLinkActive)}
+            onClick={openLinkEditor}
+            onMouseDown={preserveSelection}
+            type="button"
+          >
+            <Link2Icon aria-hidden="true" className="size-4" />
+          </button>
+        </div>
+        {isLinkEditorOpen ? (
+          <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle bg-surface-base px-3 py-2">
+            <label className="sr-only" htmlFor={`${editorId}-link`}>
+              Link destination
+            </label>
+            <input
+              className={`${formTextWrapClassName} flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal`}
+              id={`${editorId}-link`}
+              onChange={(event) => setLinkUrl(event.target.value)}
+              placeholder="Paste a link"
+              type="url"
+              value={linkUrl}
+            />
+            <button className="rounded-md border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:opacity-50" disabled={!linkUrl.trim()} onClick={() => applyFormat("link")} onMouseDown={(event) => event.preventDefault()} type="button">Apply</button>
+            <button className="rounded-md px-2 py-2 text-sm text-text-muted transition hover:bg-surface-base" onClick={closeLinkEditor} type="button">Cancel</button>
+          </div>
+        ) : null}
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}
+
+function WikiTextBlockForm({ block, onCancel, onSave }: TextBlockFormProps) {
+  const [content, setContent] = useState(block.content);
+
+  return (
     <form onSubmit={(event) => {
       event.preventDefault();
-      onSave({ content: getMarkdownContent() });
+      onSave({ content });
     }}
     >
-      <div className="grid gap-2">
-        <label className="text-sm font-semibold text-text-strong" id={editorLabelId}>
-          Text
-        </label>
-        <div className="overflow-hidden rounded-2xl border border-stroke-subtle" style={cardSurfaceStyle}>
-          <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle px-3 py-2">
+      <InlineMarkdownEditor
+        content={content}
+        editorId={`wiki-text-${block.blockIdentifier}`}
+        label="Text"
+        onChange={setContent}
+      />
+      <WikiFormActions onCancel={onCancel} />
+    </form>
+  );
+}
+
+function WikiListBlockForm({ block, onCancel, onSave }: ListBlockFormProps) {
+  const [listType, setListType] = useState<WikiListType>(block.listType);
+  const [nextItemId, setNextItemId] = useState(block.items.length);
+  const [items, setItems] = useState(() =>
+    (block.items.length > 0 ? block.items : [""]).map((content, itemIndex) => ({
+      content,
+      id: `${block.blockIdentifier}-${itemIndex}`,
+    })),
+  );
+
+  const updateItem = (itemId: string, content: string) => {
+    setItems((current) =>
+      current.map((item) => (item.id === itemId ? { ...item, content } : item)),
+    );
+  };
+
+  const addItem = () => {
+    setItems((current) => [...current, { content: "", id: `${block.blockIdentifier}-${nextItemId}` }]);
+    setNextItemId((current) => current + 1);
+  };
+
+  const removeItem = (itemId: string) => {
+    setItems((current) => {
+      const nextItems = current.filter((item) => item.id !== itemId);
+
+      return nextItems.length > 0 ? nextItems : [{ content: "", id: `${block.blockIdentifier}-empty` }];
+    });
+  };
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave({
+          items: items.map((item) => item.content.trim()).filter(Boolean),
+          listType,
+        });
+      }}
+    >
+      <label className="grid gap-2 text-sm font-semibold text-text-strong">
+        List type
+        <select
+          className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2"
+          name="listType"
+          onChange={(event) => setListType(event.target.value as WikiListType)}
+          value={listType}
+        >
+          <option value="bullet">bullet</option>
+          <option value="numbered">numbered</option>
+        </select>
+      </label>
+      <div className="mt-3 grid gap-3">
+        {items.map((item, itemIndex) => (
+          <div className="grid gap-2" key={item.id}>
+            <InlineMarkdownEditor
+              content={item.content}
+              editorId={`wiki-list-${block.blockIdentifier}-${itemIndex}`}
+              label={`Item ${itemIndex + 1}`}
+              minHeightClassName="min-h-20"
+              onChange={(content) => updateItem(item.id, content)}
+            />
             <button
-              aria-label="Bold"
-              aria-pressed={editorState.isBoldActive}
-              className={getToolbarButtonClassName(editorState.isBoldActive, "font-bold")}
-              onClick={() => applyFormat("bold")}
-              onMouseDown={preserveSelection}
+              className="justify-self-start rounded-md px-2 py-1 text-sm text-text-muted transition hover:bg-surface-base disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={items.length === 1}
+              onClick={() => removeItem(item.id)}
               type="button"
             >
-              B
-            </button>
-            <button
-              aria-label="Italic"
-              aria-pressed={editorState.isItalicActive}
-              className={getToolbarButtonClassName(editorState.isItalicActive, "italic")}
-              onClick={() => applyFormat("italic")}
-              onMouseDown={preserveSelection}
-              type="button"
-            >
-              I
-            </button>
-            <button
-              aria-label="Strike"
-              aria-pressed={editorState.isStrikeActive}
-              className={getToolbarButtonClassName(editorState.isStrikeActive, "line-through")}
-              onClick={() => applyFormat("strike")}
-              onMouseDown={preserveSelection}
-              type="button"
-            >
-              S
-            </button>
-            <span aria-hidden="true" className="h-5 w-px bg-stroke-subtle" />
-            <button
-              aria-expanded={isLinkEditorOpen}
-              aria-label="Insert link"
-              aria-pressed={editorState.isLinkActive}
-              className={getIconButtonClassName(editorState.isLinkActive)}
-              onClick={openLinkEditor}
-              onMouseDown={preserveSelection}
-              type="button"
-            >
-              <Link2Icon aria-hidden="true" className="size-4" />
+              Remove item
             </button>
           </div>
-          {isLinkEditorOpen ? (
-            <div className="flex flex-wrap items-center gap-2 border-b border-stroke-subtle bg-surface-base px-3 py-2">
-              <label className="sr-only" htmlFor={`wiki-link-${block.blockIdentifier}`}>
-                Link destination
-              </label>
-              <input
-                className={`${formTextWrapClassName} flex-1 rounded-lg border border-stroke-subtle bg-surface-raised px-3 py-2 text-sm font-normal`}
-                id={`wiki-link-${block.blockIdentifier}`}
-                onChange={(event) => setLinkUrl(event.target.value)}
-                placeholder="Paste a link"
-                type="url"
-                value={linkUrl}
-              />
-              <button className="rounded-md border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong disabled:cursor-not-allowed disabled:opacity-50" disabled={!linkUrl.trim()} onClick={() => applyFormat("link")} onMouseDown={(event) => event.preventDefault()} type="button">Apply</button>
-              <button className="rounded-md px-2 py-2 text-sm text-text-muted transition hover:bg-surface-base" onClick={closeLinkEditor} type="button">Cancel</button>
-            </div>
-          ) : null}
-          <EditorContent editor={editor} />
-        </div>
+        ))}
       </div>
+      <button
+        className="mt-3 rounded-xl border border-stroke-subtle px-3 py-2 text-sm font-semibold text-text-strong"
+        onClick={addItem}
+        type="button"
+      >
+        + Item
+      </button>
       <WikiFormActions onCancel={onCancel} />
     </form>
   );
@@ -1111,16 +1228,7 @@ export function WikiBlockForm({
         </form>
       );
     case "list":
-      return (
-        <form onSubmit={(event) => submit(event, (data) => ({ listType: getString(data, "listType") as WikiListType, items: getLines(data, "items") }))}>
-          <label className="grid gap-2 text-sm font-semibold text-text-strong">List type<select className="rounded-xl border border-stroke-subtle bg-surface-base px-3 py-2" defaultValue={block.listType} name="listType"><option value="bullet">bullet</option><option value="numbered">numbered</option></select></label>
-          <label className="mt-3 grid min-w-0 gap-2 text-sm font-semibold text-text-strong">
-            Items
-            <textarea className={textAreaClassName} defaultValue={block.items.join("\n")} name="items" />
-          </label>
-          <WikiFormActions onCancel={onCancel} />
-        </form>
-      );
+      return <WikiListBlockForm block={block} onCancel={onCancel} onSave={onSave} />;
     case "table":
       return <WikiTableBlockForm block={block} onCancel={onCancel} onSave={onSave} />;
     case "profile_card_list":


### PR DESCRIPTION
## 📝 変更内容

- Wiki 表示で長い半角 URL / 連続文字列がカード幅をはみ出さないように折り返し指定を追加
- Wiki Basic の Social Links / Official Website / relation links でも長い文字列を折り返すよう修正
- List block 表示で text block と同じ inline markdown を描画
- List block 編集 UI を item ごとの inline editor に変更し、Bold / Italic / Strike / Link を toolbar から操作可能に変更
- Link 入力 UI を toolbar 下の差し込み表示から popover 表示に変更

## 🏷️ 変更の種類

- [x] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki の本文、リスト、引用、テーブル、Basic 情報で長い URL が表示領域を押し広げる問題があったため、表示・編集 UI の両方で折り返しを統一しました。

また、List block でも text block と同じ inline 装飾を使いたいため、Markdown 記法を直接知らなくても toolbar からリンクや装飾を設定できるようにしました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- Wiki block / Basic field の長い URL 折り返し class をテストで確認
- List block の inline markdown 表示と編集 UI をテストで確認
- Link popover の表示位置と排他制御をテストで確認

## 🔍 レビューのポイント

- `WikiBlockDisplay` の折り返し指定が既存の table 横スクロールや `tableWidth` を壊していないか
- `WikiBasicFieldsList` / `WikiBasicPanel` の折り返し指定が Basic 表示・編集に過剰な副作用を出していないか
- List block の item ごとの inline editor が既存の `items: string[]` 保存形式と整合しているか

## 📖 関連情報

### 関連Issue・タスク

Closes #145

## ⚠️ 注意事項

破壊的変更やマイグレーションはありません。

## 📸 スクリーンショット・デモ

未添付

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
