### PR TITLE
fix: Wiki公開レスポンスの識別子をテストに反映

### DIFF
--- a/src/app/api/wiki/drafts/[wikiId]/reviewRoute.test.ts
+++ b/src/app/api/wiki/drafts/[wikiId]/reviewRoute.test.ts
@@ -110,6 +110,7 @@ describe("wiki draft review route", () => {
     process.env.KPOOL_WIKI_PRIVATE_API_BASE_URL = "https://api.example.test";
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
+        wikiIdentifier: "published-wiki-1",
         language: "ja",
         name: "Aurora Echo",
         resourceType: "group",

--- a/src/gateways/wiki/draftWiki.test.ts
+++ b/src/gateways/wiki/draftWiki.test.ts
@@ -1173,6 +1173,7 @@ describe("draftWiki", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
+          wikiIdentifier: "published-wiki-1",
           language: "ja",
           name: "Aurora Echo",
           resourceType: "group",
@@ -1540,6 +1541,7 @@ describe("draftWiki", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
+          wikiIdentifier: "published-wiki-1",
           language: "ja",
           name: "Aurora Echo",
           resourceType: "group",
@@ -1761,6 +1763,7 @@ describe("draftWiki", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
+          wikiIdentifier: "published-wiki-1",
           language: "ja",
           name: "Aurora Echo",
           resourceType: "group",
@@ -1779,6 +1782,7 @@ describe("draftWiki", () => {
     };
 
     await expect(client!.reviewDraftWiki("wiki-1", "publish", body)).resolves.toEqual({
+      wikiIdentifier: "published-wiki-1",
       language: "ja",
       name: "Aurora Echo",
       resourceType: "group",
@@ -1884,6 +1888,7 @@ describe("draftWiki", () => {
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
+            wikiIdentifier: "published-wiki-1",
             language: "ja",
             name: "Aurora Echo",
             resourceType: "group",


### PR DESCRIPTION
## 📝 変更内容

Wiki下書き公開レビュー API / gateway のテストで、公開後レスポンスに含まれる `wikiIdentifier` をモックレスポンスと期待値に追加しました。

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wiki公開レスポンス型に `wikiIdentifier` が含まれるようになったため、既存テストのモックと期待値を実際のレスポンス形に合わせます。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `reviewDraftWiki` の公開時レスポンス期待値に `wikiIdentifier` が含まれていること
- API route / gateway のテストモックがレスポンス型と一致していること

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
