### PR TITLE
認証必須ページのreturn_to連携を修正

### DIFF
--- a/packages/wiki/src/wikiApiModel.ts
+++ b/packages/wiki/src/wikiApiModel.ts
@@ -582,13 +582,27 @@ export const getWikiApiErrorMessage = (
         data?: unknown;
       };
     }).response;
-    const detail =
-      typeof response.data === "object" &&
-      response.data !== null &&
-      "message" in response.data &&
-      typeof (response.data as { message: unknown }).message === "string"
-        ? (response.data as { message: string }).message
-        : null;
+    const detail = (() => {
+      if (typeof response.data !== "object" || response.data === null) {
+        return null;
+      }
+
+      if (
+        "message" in response.data &&
+        typeof (response.data as { message: unknown }).message === "string"
+      ) {
+        return (response.data as { message: string }).message;
+      }
+
+      if (
+        "detail" in response.data &&
+        typeof (response.data as { detail: unknown }).detail === "string"
+      ) {
+        return (response.data as { detail: string }).detail;
+      }
+
+      return null;
+    })();
 
     if (response.status === 404) {
       return detail ?? messages.notFound;

--- a/src/app/api/identity/auth/login/route.test.ts
+++ b/src/app/api/identity/auth/login/route.test.ts
@@ -6,6 +6,7 @@ import { POST } from "./route";
 const loginRequestBody = {
   email: "member@example.com",
   password: "secret-password",
+  return_to: "/wiki/ja/gr-aurora-echo/edit",
 };
 
 const createRequest = (

--- a/src/app/api/identity/auth/social/[provider]/redirect/route.test.ts
+++ b/src/app/api/identity/auth/social/[provider]/redirect/route.test.ts
@@ -3,8 +3,11 @@ import type { NextRequest } from "next/server";
 
 import { GET } from "./route";
 
-const createRequest = (headers: Record<string, string> = {}): NextRequest =>
-  new Request("https://app.example.test/api/identity/auth/social/google/redirect", {
+const createRequest = (
+  headers: Record<string, string> = {},
+  search = "",
+): NextRequest =>
+  new Request(`https://app.example.test/api/identity/auth/social/google/redirect${search}`, {
     method: "GET",
     headers,
   }) as NextRequest;
@@ -26,10 +29,16 @@ describe("/api/identity/auth/social/[provider]/redirect route", () => {
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    await GET(createRequest({ cookie: "laravel_session=abc" }), createContext("google oauth"));
+    await GET(
+      createRequest(
+        { cookie: "laravel_session=abc" },
+        "?return_to=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit",
+      ),
+      createContext("google oauth"),
+    );
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://identity.example.test/api/identity/auth/social/google%20oauth/redirect",
+      "https://identity.example.test/api/identity/auth/social/google%20oauth/redirect?return_to=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit",
       {
         headers: {
           Accept: "application/json",

--- a/src/app/api/identity/auth/social/[provider]/redirect/route.ts
+++ b/src/app/api/identity/auth/social/[provider]/redirect/route.ts
@@ -30,8 +30,16 @@ export async function GET(request: NextRequest, context: SocialRedirectRouteCont
 
   try {
     const { provider } = await context.params;
+    const returnTo = new URL(request.url).searchParams.get("return_to");
+    const searchParams = new URLSearchParams();
+
+    if (returnTo) {
+      searchParams.set("return_to", returnTo);
+    }
+
+    const query = searchParams.toString();
     const apiResponse = await fetch(
-      `${baseUrl}/auth/social/${encodeURIComponent(provider)}/redirect`,
+      `${baseUrl}/auth/social/${encodeURIComponent(provider)}/redirect${query ? `?${query}` : ""}`,
         {
           headers: {
             Accept: "application/json",

--- a/src/app/api/wiki/principal/create/route.test.ts
+++ b/src/app/api/wiki/principal/create/route.test.ts
@@ -90,6 +90,23 @@ describe("/api/wiki/principal/create route", () => {
     expect(body.message).not.toContain("internal.wiki.example.test");
   });
 
+  it.each([
+    [401, "ログインが必要です。"],
+    [403, "このアカウントでは Wiki principal を作成できません。"],
+  ])("forwards upstream %s responses safely", async (status, detail) => {
+    vi.stubEnv("KPOOL_WIKI_PRIVATE_API_BASE_URL", "https://wiki.example.test");
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ detail }, { status }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await POST(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(status);
+    expect(body.message).toBe(detail);
+  });
+
   it("does not expose internal fetch errors to the client", async () => {
     vi.stubEnv("KPOOL_WIKI_PRIVATE_API_BASE_URL", "https://internal.wiki.example.test");
     const fetchMock = vi.fn().mockRejectedValue(

--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -53,7 +53,7 @@ export function LoginPage({
   navigate,
   refresh,
   returnTo,
-	}: LoginPageProps) {
+}: LoginPageProps) {
   const router = useRouter();
   const { dictionary } = useI18n();
   const t = dictionary.login;
@@ -71,13 +71,15 @@ export function LoginPage({
     setErrorMessage(null);
     setPendingAction({ type: "email" });
 
-    const result = await loginAdapter({ email, password });
+    const result = await loginAdapter({ email, password, return_to: destination });
 
     if (result.ok) {
+      const nextDestination = result.returnTo ?? destination;
+
       if (navigate) {
-        navigate(destination);
+        navigate(nextDestination);
       } else {
-        router.replace(destination);
+        router.replace(nextDestination);
         router.refresh();
       }
       refresh?.();
@@ -92,7 +94,7 @@ export function LoginPage({
     setErrorMessage(null);
     setPendingAction({ type: "social", provider });
 
-    const result = await socialRedirectAdapter(provider);
+    const result = await socialRedirectAdapter(provider, destination);
 
     if (result.ok) {
       if (navigate) {

--- a/src/app/login/page.test.tsx
+++ b/src/app/login/page.test.tsx
@@ -44,9 +44,34 @@ describe("LoginPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Googleでログイン" }));
 
     await waitFor(() =>
-      expect(socialRedirectAdapter).toHaveBeenCalledWith("google"),
+      expect(socialRedirectAdapter).toHaveBeenCalledWith("google", "/mypage"),
     );
     expect(navigate).toHaveBeenCalledWith("https://accounts.example.test/oauth");
+  });
+
+  it("passes the return destination to SSO redirect requests", async () => {
+    const socialRedirectAdapter = vi.fn().mockResolvedValue({
+      ok: true,
+      redirectUrl: "https://accounts.example.test/oauth",
+    });
+    const navigate = vi.fn();
+
+    render(
+      <LoginPage
+        socialRedirectAdapter={socialRedirectAdapter}
+        navigate={navigate}
+        returnTo="/wiki/ja/gr-aurora-echo/edit"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Googleでログイン" }));
+
+    await waitFor(() =>
+      expect(socialRedirectAdapter).toHaveBeenCalledWith(
+        "google",
+        "/wiki/ja/gr-aurora-echo/edit",
+      ),
+    );
   });
 
   it("logs in with email and password and opens mypage", async () => {
@@ -72,9 +97,43 @@ describe("LoginPage", () => {
       expect(loginAdapter).toHaveBeenCalledWith({
         email: "member@example.com",
         password: "secret-password",
+        return_to: "/mypage",
       }),
     );
     expect(navigate).toHaveBeenCalledWith("/mypage");
+  });
+
+  it("uses the safe return destination returned by email login", async () => {
+    const loginAdapter = vi.fn().mockResolvedValue({
+      ok: true,
+      returnTo: "/wiki/ja/gr-aurora-echo/edit",
+    });
+    const navigate = vi.fn();
+
+    render(
+      <LoginPage
+        loginAdapter={loginAdapter}
+        navigate={navigate}
+        returnTo="/mypage"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("メールアドレス"), {
+      target: { value: "member@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("パスワード"), {
+      target: { value: "secret-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "メールアドレスでログイン" }));
+
+    await waitFor(() =>
+      expect(loginAdapter).toHaveBeenCalledWith({
+        email: "member@example.com",
+        password: "secret-password",
+        return_to: "/mypage",
+      }),
+    );
+    expect(navigate).toHaveBeenCalledWith("/wiki/ja/gr-aurora-echo/edit");
   });
 
   it("shows an understandable error when email login fails", async () => {

--- a/src/app/mypage/MyPageClient.tsx
+++ b/src/app/mypage/MyPageClient.tsx
@@ -80,6 +80,7 @@ type MyPageClientProps = {
   draftImageAdapter?: MyPageDraftImageAdapter;
   draftWikiAdapter?: MyPageDraftWikiAdapter;
   principalAdapter?: MyPagePrincipalAdapter;
+  returnTo?: string | null;
 };
 
 type CreateDraftWikiDialogState = {
@@ -136,6 +137,7 @@ export function MyPageClient({
   initialIdentity,
   initialPrincipalState = { status: "idle" },
   principalAdapter = defaultPrincipalAdapter,
+  returnTo = null,
 }: MyPageClientProps) {
   const router = useRouter();
   const authIdentity = useAuthStore((state) => state.identity);
@@ -203,6 +205,14 @@ export function MyPageClient({
     () => loadDraftWikisPage("editingWikis", 1),
     [loadDraftWikisPage],
   );
+  const handlePrincipalReady = useCallback(() => {
+    if (returnTo) {
+      router.push(returnTo);
+      return;
+    }
+
+    return loadFirstDraftWikiPage();
+  }, [loadFirstDraftWikiPage, returnTo, router]);
   const principalMessages = useMemo(() => ({
     accountUnavailableMessage: t.accountUnavailableMessage,
     identityUnavailableMessage: t.identityUnavailableMessage,
@@ -216,7 +226,7 @@ export function MyPageClient({
     initialIdentity: currentIdentity,
     initialPrincipalState,
     messages: principalMessages,
-    onPrincipalReady: loadFirstDraftWikiPage,
+    onPrincipalReady: handlePrincipalReady,
     refreshIdentity: () => refreshIdentity({ preserveOnNull: true }),
   });
   const autoCreatableResourceTypes = useMemo(
@@ -1396,7 +1406,7 @@ const isDeletableDraftWiki = (
 const getDraftWikiHref = (wiki: MyPageWikiListItem, tab: MyPageDraftWikiActionTab): string =>
   tab === "untranslatedWikis"
     ? `/wiki/${encodeURIComponent(wiki.language)}/${encodeURIComponent(wiki.slug)}`
-    : `/wiki/${encodeURIComponent(wiki.language)}/${encodeURIComponent(wiki.slug)}/edit?authGate=1`;
+    : `/wiki/${encodeURIComponent(wiki.language)}/${encodeURIComponent(wiki.slug)}/edit`;
 
 const getDraftWikiDiffHref = (wiki: MyPageWikiListItem): string =>
   `/wiki/diff/${encodeURIComponent(wiki.wikiIdentifier)}?resourceType=${encodeURIComponent(wiki.resourceType)}`;

--- a/src/app/mypage/page.test.tsx
+++ b/src/app/mypage/page.test.tsx
@@ -783,7 +783,7 @@ describe("MyPageClient", () => {
     expect(draftWikiAdapter.listDraftWikis).not.toHaveBeenCalled();
     expect(screen.getByRole("link", { name: "編集中 Wiki" })).toHaveAttribute(
       "href",
-      "/wiki/ja/gr-review-wiki/edit?authGate=1",
+      "/wiki/ja/gr-review-wiki/edit",
     );
     expect(screen.getByRole("link", { name: "編集中 Wiki" }).closest("article")?.getAttribute("style")).toContain(
       'url("https://images.example.test/editing-wiki.webp")',
@@ -803,7 +803,7 @@ describe("MyPageClient", () => {
     );
     expect(screen.getByRole("link", { name: "編集中 Wiki" })).toHaveAttribute(
       "href",
-      "/wiki/ja/gr-review-wiki/edit?authGate=1",
+      "/wiki/ja/gr-review-wiki/edit",
     );
   });
 
@@ -1697,6 +1697,29 @@ describe("MyPageClient", () => {
       }),
     );
     expect(await screen.findByRole("tab", { name: "未承認の画像" })).toBeInTheDocument();
+  });
+
+  it("returns to the original edit page after creating a principal when returnTo is provided", async () => {
+    const adapter = createAdapter({
+      getCurrentPrincipal: vi.fn().mockResolvedValue({ status: "missing" }),
+      createPrincipal: vi.fn().mockResolvedValue({ status: "available", principal }),
+    });
+
+    renderWithQueryClient(
+      <MyPageClient
+        draftImageAdapter={createDraftImageAdapter()}
+        draftWikiAdapter={createDraftWikiAdapter()}
+        initialIdentity={identity}
+        initialPrincipalState={{ status: "missing" }}
+        principalAdapter={adapter}
+        returnTo="/wiki/ja/gr-review-wiki/edit"
+      />,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Wiki collaborator を有効化" }));
+
+    await waitFor(() =>
+      expect(navigationMocks.push).toHaveBeenCalledWith("/wiki/ja/gr-review-wiki/edit"),
+    );
   });
 
   it("shows a retry path when the principal lookup fails", async () => {

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 import { fetchAuthenticatedIdentity } from "@/gateways/identity/authIdentity";
 import {
@@ -23,12 +24,33 @@ const getPrincipalStateKey = (
   return principalState.status;
 };
 
-export default async function MyPage() {
+type MyPageProps = {
+  searchParams?: Promise<{
+    returnTo?: string | string[];
+  }>;
+};
+
+const getSingleSearchParam = (value: string | string[] | undefined): string | undefined =>
+  Array.isArray(value) ? value[0] : value;
+
+const normalizeOptionalReturnTo = (value: string | undefined): string | null =>
+  value && value.startsWith("/") && !value.startsWith("//") ? value : null;
+
+export default async function MyPage({ searchParams }: MyPageProps = {}) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const returnTo = normalizeOptionalReturnTo(
+    getSingleSearchParam(resolvedSearchParams.returnTo),
+  );
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
   const authenticatedIdentity = await fetchAuthenticatedIdentity({
     cookieHeader,
   });
+
+  if (!authenticatedIdentity) {
+    redirect("/login?returnTo=/mypage");
+  }
+
   const principalState = await getInitialWikiPrincipalForRequest({
     cookieHeader,
     hasAuthenticatedIdentity: Boolean(authenticatedIdentity),
@@ -43,6 +65,7 @@ export default async function MyPage() {
       initialDraftWikis={initialDraftWikis}
       initialIdentity={authenticatedIdentity}
       initialPrincipalState={principalState}
+      returnTo={returnTo}
     />
   );
 }

--- a/src/app/mypage/server-page.test.tsx
+++ b/src/app/mypage/server-page.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cookies: vi.fn(),
+  fetchAuthenticatedIdentity: vi.fn(),
+  getInitialWikiPrincipalForRequest: vi.fn(),
+  loadInitialDraftWikisForRequest: vi.fn(),
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mocks.cookies,
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+}));
+
+vi.mock("@/gateways/identity/authIdentity", () => ({
+  fetchAuthenticatedIdentity: mocks.fetchAuthenticatedIdentity,
+}));
+
+vi.mock("@/gateways/wiki/draftWiki", () => ({
+  createInitialDraftWikis: () => ({}),
+  loadInitialDraftWikisForRequest: mocks.loadInitialDraftWikisForRequest,
+}));
+
+vi.mock("@/gateways/wiki/wikiPrincipal", () => ({
+  getInitialWikiPrincipalForRequest: mocks.getInitialWikiPrincipalForRequest,
+}));
+
+vi.mock("./MyPageClient", () => ({
+  MyPageClient: ({ returnTo }: { returnTo: string | null }) => (
+    <div data-testid="mypage-client">{returnTo ?? "no-return"}</div>
+  ),
+}));
+
+import MyPage from "./page";
+
+describe("MyPage server route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cookies.mockResolvedValue({
+      toString: () => "session=abc",
+    });
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
+      identityIdentifier: "11111111-1111-1111-1111-111111111111",
+      username: "member",
+      email: "member@example.com",
+      language: "ja",
+    });
+    mocks.getInitialWikiPrincipalForRequest.mockResolvedValue({ status: "missing" });
+  });
+
+  it("redirects unauthenticated requests to login with the mypage return destination", async () => {
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue(null);
+
+    await expect(MyPage()).rejects.toThrow("redirect:/login?returnTo=/mypage");
+    expect(mocks.getInitialWikiPrincipalForRequest).not.toHaveBeenCalled();
+  });
+
+  it("passes safe returnTo query values to the client", async () => {
+    render(
+      await MyPage({
+        searchParams: Promise.resolve({
+          returnTo: "/wiki/ja/gr-aurora-echo/edit",
+        }),
+      }),
+    );
+
+    expect(screen.getByTestId("mypage-client")).toHaveTextContent(
+      "/wiki/ja/gr-aurora-echo/edit",
+    );
+  });
+});

--- a/src/app/wiki/[language]/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[language]/[slug]/edit/page.test.tsx
@@ -58,6 +58,13 @@ describe("Wiki edit route", () => {
       status: "success",
       data: {},
     });
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
+      identityIdentifier: "identity-1",
+    });
+    mocks.getCurrentWikiPrincipalForRequest.mockResolvedValue({
+      status: "available",
+      principal: {},
+    });
   });
 
   afterEach(() => {
@@ -69,12 +76,16 @@ describe("Wiki edit route", () => {
     expect(revalidate).toBe(0);
   });
 
-  it("loads the draft with forwarded cookies when the edit auth gate is absent", async () => {
+  it("loads the draft with forwarded cookies when authenticated principal is available", async () => {
     render(await Page(routeProps()));
 
     expect(screen.getByTestId("wiki-edit-page")).toHaveTextContent("success");
-    expect(mocks.fetchAuthenticatedIdentity).not.toHaveBeenCalled();
-    expect(mocks.getCurrentWikiPrincipalForRequest).not.toHaveBeenCalled();
+    expect(mocks.fetchAuthenticatedIdentity).toHaveBeenCalledWith({
+      cookieHeader: "session=abc",
+    });
+    expect(mocks.getCurrentWikiPrincipalForRequest).toHaveBeenCalledWith({
+      cookieHeader: "session=abc",
+    });
     expect(mocks.loadDraftWikiState).toHaveBeenCalledWith("ja", "gr-aurora-echo", {
       Cookie: "session=abc",
     });
@@ -88,40 +99,41 @@ describe("Wiki edit route", () => {
     render(await Page(routeProps()));
 
     expect(screen.getByTestId("wiki-edit-page")).toHaveTextContent("success");
-    expect(mocks.fetchAuthenticatedIdentity).not.toHaveBeenCalled();
-    expect(mocks.getCurrentWikiPrincipalForRequest).not.toHaveBeenCalled();
+    expect(mocks.fetchAuthenticatedIdentity).toHaveBeenCalledWith({
+      cookieHeader: "",
+    });
+    expect(mocks.getCurrentWikiPrincipalForRequest).toHaveBeenCalledWith({
+      cookieHeader: "",
+    });
     expect(mocks.loadDraftWikiState).toHaveBeenCalledWith("ja", "gr-aurora-echo");
   });
 
-  it("redirects gated unauthenticated edits to login with the edit return path", async () => {
+  it("redirects unauthenticated edits to login with the edit return path", async () => {
     mocks.fetchAuthenticatedIdentity.mockResolvedValue(null);
 
-    await expect(Page(routeProps({ authGate: "1" }))).rejects.toThrow(
-      "redirect:/login?returnTo=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit%3FauthGate%3D1",
+    await expect(Page(routeProps())).rejects.toThrow(
+      "redirect:/login?returnTo=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit",
     );
   });
 
-  it("redirects gated edits to mypage when the principal is missing", async () => {
-    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
-      identityIdentifier: "identity-1",
-    });
+  it("keeps allowed edit query values in the login return path", async () => {
+    mocks.fetchAuthenticatedIdentity.mockResolvedValue(null);
+
+    await expect(Page(routeProps({ themeColor: "#d94f70" }))).rejects.toThrow(
+      "redirect:/login?returnTo=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit%3FthemeColor%3D%2523d94f70",
+    );
+  });
+
+  it("redirects edits to mypage with the edit return path when the principal is missing", async () => {
     mocks.getCurrentWikiPrincipalForRequest.mockResolvedValue({ status: "missing" });
 
-    await expect(Page(routeProps({ authGate: "1" }))).rejects.toThrow(
-      "redirect:/mypage",
+    await expect(Page(routeProps())).rejects.toThrow(
+      "redirect:/mypage?returnTo=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit",
     );
   });
 
-  it("loads the draft for gated edits when identity and principal are available", async () => {
-    mocks.fetchAuthenticatedIdentity.mockResolvedValue({
-      identityIdentifier: "identity-1",
-    });
-    mocks.getCurrentWikiPrincipalForRequest.mockResolvedValue({
-      status: "available",
-      principal: {},
-    });
-
-    render(await Page(routeProps({ authGate: "1" })));
+  it("loads the draft when identity and principal are available without a gate query", async () => {
+    render(await Page(routeProps()));
 
     expect(screen.getByTestId("wiki-edit-page")).toHaveTextContent("success");
     expect(mocks.getCurrentWikiPrincipalForRequest).toHaveBeenCalledWith({

--- a/src/app/wiki/[language]/[slug]/edit/page.tsx
+++ b/src/app/wiki/[language]/[slug]/edit/page.tsx
@@ -13,7 +13,6 @@ type WikiEditRouteProps = {
     slug: string;
   }>;
   searchParams: Promise<{
-    authGate?: string | string[];
     themeColor?: string | string[];
   }>;
 };
@@ -24,66 +23,64 @@ export const revalidate = 0;
 const getSingleSearchParam = (value: string | string[] | undefined): string | undefined =>
   Array.isArray(value) ? value[0] : value;
 
-const buildGatedEditReturnPath = ({
+const buildEditReturnPath = ({
   editPath,
   themeColor,
 }: {
   editPath: string;
   themeColor?: string;
 }): string => {
-  const params = new URLSearchParams({ authGate: "1" });
+  const params = new URLSearchParams();
 
   if (themeColor) {
     params.set("themeColor", themeColor);
   }
 
-  return `${editPath}?${params.toString()}`;
+  const query = params.toString();
+
+  return query ? `${editPath}?${query}` : editPath;
 };
 
 export default async function Page({ params, searchParams }: WikiEditRouteProps) {
   const { language, slug } = await params;
-  const { authGate, themeColor } = await searchParams;
+  const { themeColor } = await searchParams;
   const normalizedThemeColor = getSingleSearchParam(themeColor);
   const editPath = buildWikiEditPath(language, slug);
-  const shouldGateEditAccess = getSingleSearchParam(authGate) === "1";
+  const editReturnPath = buildEditReturnPath({
+    editPath,
+    themeColor: normalizedThemeColor,
+  });
   const cookieStore = await cookies();
   const cookieHeader = cookieStore.toString();
   const wikiApiHeaders = cookieHeader ? { Cookie: cookieHeader } : undefined;
+  const authenticatedIdentity = await fetchAuthenticatedIdentity({
+    cookieHeader,
+  });
 
-  if (shouldGateEditAccess) {
-    const authenticatedIdentity = await fetchAuthenticatedIdentity({
-      cookieHeader,
-    });
+  if (!authenticatedIdentity) {
+    redirect(`/login?returnTo=${encodeURIComponent(editReturnPath)}`);
+  }
 
-    if (!authenticatedIdentity) {
-      redirect(
-        `/login?returnTo=${encodeURIComponent(
-          buildGatedEditReturnPath({ editPath, themeColor: normalizedThemeColor }),
-        )}`,
-      );
-    }
+  const principalState = await getCurrentWikiPrincipalForRequest({
+    cookieHeader,
+  });
 
-    const principalState = await getCurrentWikiPrincipalForRequest({
-      cookieHeader,
-    });
+  if (principalState.status === "missing") {
+    redirect(`/mypage?returnTo=${encodeURIComponent(editReturnPath)}`);
+  }
 
-    if (principalState.status === "missing") {
-      redirect("/mypage");
-    }
-
-    if (principalState.status === "error") {
-      return (
-        <WikiEditPage
-          language={language}
-          slug={slug}
-          themeColor={normalizedThemeColor}
-          wikiState={{
-            status: "error",
-            message: principalState.message,
-          }}
-        />
-      );
-    }
+  if (principalState.status === "error") {
+    return (
+      <WikiEditPage
+        language={language}
+        slug={slug}
+        themeColor={normalizedThemeColor}
+        wikiState={{
+          status: "error",
+          message: principalState.message,
+        }}
+      />
+    );
   }
 
   const wikiState = wikiApiHeaders

--- a/src/app/wiki/[slug]/WikiDetailPage.tsx
+++ b/src/app/wiki/[slug]/WikiDetailPage.tsx
@@ -60,7 +60,7 @@ export function WikiDetailPage({
   const { data } = wikiState;
   const effectiveThemeColor = themeColor ?? data.themeColor ?? undefined;
   const themeStyles = buildWikiThemeCssVariables(effectiveThemeColor);
-  const editHref = `${buildWikiEditPath(language, slug)}?authGate=1`;
+  const editHref = buildWikiEditPath(language, slug);
 
   return (
     <main

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -146,13 +146,13 @@ describe("WikiDetailPage", () => {
     );
     expect(screen.getAllByRole("link", { name: "Edit basic" })[0]).toHaveAttribute(
       "href",
-      "/wiki/ja/gr-aurora-echo/edit?authGate=1",
+      "/wiki/ja/gr-aurora-echo/edit",
     );
     const sectionEditLinks = screen.getAllByRole("link", { name: /Edit section/i });
     expect(sectionEditLinks).toHaveLength(2);
     expect(sectionEditLinks[0]).toHaveAttribute(
       "href",
-      "/wiki/ja/gr-aurora-echo/edit?authGate=1",
+      "/wiki/ja/gr-aurora-echo/edit",
     );
     expect(screen.queryByTestId("wiki-theme-badge")).not.toBeInTheDocument();
   });

--- a/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
+++ b/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
@@ -31,7 +31,7 @@ describe("WikiSectionAccordion", () => {
   it("renders section edit links without using the accordion toggle", () => {
     render(
       <WikiSectionAccordion
-        editHref="/wiki/ja/gr-aurora-echo/edit?authGate=1"
+        editHref="/wiki/ja/gr-aurora-echo/edit"
         language="ja"
         section={wikiStorySection}
       />,
@@ -43,7 +43,7 @@ describe("WikiSectionAccordion", () => {
     });
 
     expect(section).not.toHaveAttribute("open");
-    expect(editLink).toHaveAttribute("href", "/wiki/ja/gr-aurora-echo/edit?authGate=1");
+    expect(editLink).toHaveAttribute("href", "/wiki/ja/gr-aurora-echo/edit");
     editLink.addEventListener("click", (event) => event.preventDefault());
     fireEvent.click(editLink);
     expect(section).not.toHaveAttribute("open");

--- a/src/gateways/auth/authFlow.test.ts
+++ b/src/gateways/auth/authFlow.test.ts
@@ -1,12 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   getAuthErrorMessage,
   identityProviders,
+  loginWithEmail,
   normalizeReturnTo,
+  requestSocialRedirect,
 } from "./authFlow";
 
 describe("login auth flow helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("defines the supported SSO providers in display order", () => {
     expect(identityProviders).toEqual([
       expect.objectContaining({
@@ -44,6 +50,57 @@ describe("login auth flow helpers", () => {
 
     await expect(getAuthErrorMessage(response)).resolves.toBe(
       "メールアドレスまたはパスワードが違います。",
+    );
+  });
+
+  it("sends return_to with email login and normalizes the returned destination", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        identityIdentifier: "11111111-1111-1111-1111-111111111111",
+        username: "member",
+        email: "member@example.com",
+        language: "ja",
+        return_to: "/wiki/ja/gr-aurora-echo/edit",
+      })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      loginWithEmail({
+        email: "member@example.com",
+        password: "secret-password",
+        return_to: "/wiki/ja/gr-aurora-echo/edit",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      returnTo: "/wiki/ja/gr-aurora-echo/edit",
+    });
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toEqual({
+      email: "member@example.com",
+      password: "secret-password",
+      return_to: "/wiki/ja/gr-aurora-echo/edit",
+    });
+  });
+
+  it("sends return_to with social redirect requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        redirectUrl: "https://accounts.example.test/oauth",
+      })),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      requestSocialRedirect("google", "/wiki/ja/gr-aurora-echo/edit"),
+    ).resolves.toEqual({
+      ok: true,
+      redirectUrl: "https://accounts.example.test/oauth",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/identity/auth/social/google/redirect?return_to=%2Fwiki%2Fja%2Fgr-aurora-echo%2Fedit",
+      {
+        credentials: "include",
+      },
     );
   });
 });

--- a/src/gateways/auth/authFlow.ts
+++ b/src/gateways/auth/authFlow.ts
@@ -14,7 +14,7 @@ export type IdentityProvider = {
 };
 
 export type LoginResult =
-  | { ok: true }
+  | { ok: true; returnTo?: string }
   | {
       ok: false;
       message: string;
@@ -33,6 +33,7 @@ export type SocialRedirectResult =
 export type LoginAdapter = (credentials: IdentityLoginRequest) => Promise<LoginResult>;
 export type SocialRedirectAdapter = (
   provider: IdentityProvider["id"],
+  returnTo?: string,
 ) => Promise<SocialRedirectResult>;
 
 export const identityProviders: IdentityProvider[] = [
@@ -111,14 +112,26 @@ export const loginWithEmail: LoginAdapter = async (credentials) => {
     };
   }
 
-  parseIdentitySummary(await response.json());
+  const body = await response.json();
+  parseIdentitySummary(body);
+  const responseReturnTo = (body as { return_to?: unknown }).return_to;
 
-  return { ok: true };
+  return {
+    ok: true,
+    returnTo: typeof responseReturnTo === "string"
+      ? normalizeReturnTo(responseReturnTo)
+      : undefined,
+  };
 };
 
-export const requestSocialRedirect: SocialRedirectAdapter = async (provider) => {
+export const requestSocialRedirect: SocialRedirectAdapter = async (provider, returnTo) => {
+  const params = new URLSearchParams();
+  const normalizedReturnTo = normalizeReturnTo(returnTo);
+
+  params.set("return_to", normalizedReturnTo);
+
   const response = await fetch(
-    `/api/identity/auth/social/${encodeURIComponent(provider)}/redirect`,
+    `/api/identity/auth/social/${encodeURIComponent(provider)}/redirect?${params.toString()}`,
     {
       credentials: "include",
     },

--- a/src/gateways/wiki/wikiPrincipal.test.ts
+++ b/src/gateways/wiki/wikiPrincipal.test.ts
@@ -247,6 +247,28 @@ describe("wiki principal helpers", () => {
     });
   });
 
+  it.each([
+    [401, "ログインが必要です。"],
+    [403, "このアカウントでは Wiki principal を作成できません。"],
+  ])("returns a user-facing error when principal creation receives %s", async (status, detail) => {
+    const fetchAdapter = vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      json: vi.fn().mockResolvedValue({ detail }),
+    });
+
+    await expect(
+      createWikiPrincipal({
+        accountIdentifier: "22222222-2222-2222-2222-222222222222",
+        fetchAdapter,
+        identityIdentifier: "11111111-1111-1111-1111-111111111111",
+      }),
+    ).resolves.toEqual({
+      status: "error",
+      message: detail,
+    });
+  });
+
   it("reads accountId from identity payloads", () => {
     expect(
       getAccountIdentifierFromIdentity({


### PR DESCRIPTION
## 📝 変更内容

- Wiki編集ページを常時認証・Wiki principal 確認対象に変更
- `authGate=1` に依存していた編集導線を廃止し、編集URLをそのまま返却先として扱うよう変更
- メールログイン / SSO リダイレクト / mypage principal 作成後に `return_to` / `returnTo` で元の編集ページへ戻れるよう対応
- Wiki API エラーメッセージで `message` に加えて `detail` も拾うよう変更
- 認証遷移、principal 作成、編集ページ遷移、エラー表示のテストを追加・更新

## 🏷️ 変更の種類

- [x] 🐛 バグ修正 (Bug fix)
- [x] 🧪 テスト (Tests)

## 🎯 変更理由・背景

Wiki編集ページへの遷移時に、ログインや Wiki principal 作成が必要な場合でも元の編集ページへ戻れるようにするため。
また、`authGate=1` の有無で認証チェックの挙動が変わる状態をなくし、編集ページ側で一貫して認証・principal 状態を確認するようにしました。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- 自動テストでログイン後・SSO後・principal 作成後の return destination を確認

## 🔍 レビューのポイント

- Wiki編集ページを常時認証必須にした影響範囲
- `returnTo` / `return_to` の正規化とオープンリダイレクト対策
- principal 未作成時に `/mypage?returnTo=...` を経由して編集ページへ戻る流れ
- `authGate=1` 廃止後の既存編集リンク

## 📖 関連情報

### 関連Issue・タスク

Fixes #151

## ⚠️ 注意事項

特になし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
