### PR TITLE
Wikiセクション編集状態をcontentsに統一

### DIFF
--- a/packages/wiki/src/mockWikiDetail.ts
+++ b/packages/wiki/src/mockWikiDetail.ts
@@ -57,7 +57,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
         caption: "TWICE \"CHEER UP\" M/V",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -74,7 +73,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
         title: "TWICE Members",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -91,7 +89,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
           "2015년 데뷔 이후 한국과 일본을 중심으로 활동을 이어 왔으며, 대표곡으로는 \"CHEER UP\", \"TT\", \"FANCY\" 등이 있다.",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -114,7 +111,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
         content: "[include(틀:TWICE/음반)]",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -131,7 +127,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
           "한국 활동, 일본 활동, 월드투어, 유닛 및 솔로 활동이 병렬적으로 정리되는 편이며 시기별 정리와 하위 문서 분리가 잦다.",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -154,7 +149,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
         content: "[include(틀:TWICE의 기록)]",
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -171,7 +165,6 @@ const createTwiceCompatibilitySections = (): WikiDetail["sections"] => [
           "뮤직비디오, 리얼리티, 광고, 화보, SNS 활동 등이 방대한 편이라 관련 하위 문서나 목록성 서술로 분리되는 경우가 많다.",
       },
     ],
-    children: [],
   },
 ];
 
@@ -319,7 +312,6 @@ const createTwiceMemberSections = (name: string, overview: string): WikiDetail["
         content: overview,
       },
     ],
-    children: [],
   },
   {
     type: "section",
@@ -336,7 +328,6 @@ const createTwiceMemberSections = (name: string, overview: string): WikiDetail["
         title: "Group",
       },
     ],
-    children: [],
   },
 ];
 
@@ -511,8 +502,6 @@ export const createMockWikiDetail = (
             wikiIdentifiers: [],
             title: "Related profiles",
           },
-        ],
-        children: [
           {
             type: "section",
             sectionIdentifier: "sec-discography-highlights",
@@ -542,10 +531,8 @@ export const createMockWikiDetail = (
                       "Depth three content is editable but cannot receive a child section.",
                   },
                 ],
-                children: [],
               },
             ],
-            children: [],
           },
           {
             type: "section",
@@ -562,7 +549,6 @@ export const createMockWikiDetail = (
                   "Their first two mini albums framed a dusk-to-dawn narrative and expanded the live arrangement palette with brass and guitar sections.",
               },
             ],
-            children: [],
           },
         ],
       },
@@ -580,8 +566,6 @@ export const createMockWikiDetail = (
             content:
               "Aurora Echo debuted with a performance style built around fluid formations, layered harmonies, and warm retro production.",
           },
-        ],
-        children: [
           {
             type: "section",
             sectionIdentifier: "sec-overview-style",
@@ -597,7 +581,6 @@ export const createMockWikiDetail = (
                   "The visual direction mixes marine tailoring, brushed metal details, and sunset-toned lighting for a polished but lived-in stage mood.",
               },
             ],
-            children: [],
           },
         ],
       },
@@ -616,7 +599,6 @@ export const createMockWikiDetail = (
               "The lineup consists of five members handling a rotating balance of vocal, rap, and dance center duties.",
           },
         ],
-        children: [],
       },
     ],
   };

--- a/packages/wiki/src/types/wiki.ts
+++ b/packages/wiki/src/types/wiki.ts
@@ -7,7 +7,6 @@ export type WikiSection = {
   displayOrder: number;
   depth: number;
   contents: WikiSectionContent[];
-  children: WikiSection[];
 };
 
 export type WikiBlockType =
@@ -231,7 +230,22 @@ const wikiSectionSchema: z.ZodType<WikiSection> = z.lazy(() =>
     displayOrder: z.number().int(),
     depth: z.number().int().min(1),
     contents: z.array(z.union([wikiSectionSchema, wikiBlockSchema])),
-    children: z.array(wikiSectionSchema),
+    children: z.array(wikiSectionSchema).optional(),
+  }).transform(({ children, contents, ...section }) => {
+    const contentSectionIds = new Set(
+      contents
+        .filter((content): content is WikiSection => "sectionIdentifier" in content)
+        .map((content) => content.sectionIdentifier),
+    );
+    const mergedContents = [
+      ...contents,
+      ...(children ?? []).filter((child) => !contentSectionIds.has(child.sectionIdentifier)),
+    ].sort((left, right) => left.displayOrder - right.displayOrder);
+
+    return {
+      ...section,
+      contents: mergedContents,
+    };
   }),
 );
 

--- a/packages/wiki/src/wikiApiModel.test.ts
+++ b/packages/wiki/src/wikiApiModel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { adaptDraftWikiApiResponse, adaptWikiApiResponse } from "./wikiApiModel";
+import { isWikiSection } from "./wikiEditModel";
 
 const baseApiResponse = {
   basic: {
@@ -103,10 +104,10 @@ describe("wikiApiModel section identifiers", () => {
     });
 
     const firstRoot = wiki.sections[0];
-    const firstNested = firstRoot?.children[0];
-    const deepNested = firstNested?.children[0];
+    const firstNested = firstRoot?.contents.find(isWikiSection);
+    const deepNested = firstNested?.contents.find(isWikiSection);
     const secondRoot = wiki.sections[1];
-    const secondNested = secondRoot?.children[0];
+    const secondNested = secondRoot?.contents.find(isWikiSection);
 
     expect(firstRoot?.sectionIdentifier).toBe("section-1");
     expect(firstNested?.sectionIdentifier).toBe("section-1-1");

--- a/packages/wiki/src/wikiApiModel.test.ts
+++ b/packages/wiki/src/wikiApiModel.test.ts
@@ -64,3 +64,54 @@ describe("wikiApiModel SEO metadata", () => {
     });
   });
 });
+
+describe("wikiApiModel section identifiers", () => {
+  it("generates unique fallback identifiers for nested sections without backend ids", () => {
+    const wiki = adaptDraftWikiApiResponse({
+      ...baseApiResponse,
+      status: "editing",
+      sections: [
+        {
+          type: "section",
+          title: "Overview",
+          contents: [
+            {
+              type: "section",
+              title: "Nested one",
+              contents: [
+                {
+                  type: "section",
+                  title: "Deep nested",
+                  contents: [],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "section",
+          title: "Another root",
+          contents: [
+            {
+              type: "section",
+              title: "Nested two",
+              contents: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    const firstRoot = wiki.sections[0];
+    const firstNested = firstRoot?.children[0];
+    const deepNested = firstNested?.children[0];
+    const secondRoot = wiki.sections[1];
+    const secondNested = secondRoot?.children[0];
+
+    expect(firstRoot?.sectionIdentifier).toBe("section-1");
+    expect(firstNested?.sectionIdentifier).toBe("section-1-1");
+    expect(deepNested?.sectionIdentifier).toBe("section-1-1-1");
+    expect(secondRoot?.sectionIdentifier).toBe("section-2");
+    expect(secondNested?.sectionIdentifier).toBe("section-2-1");
+  });
+});

--- a/packages/wiki/src/wikiApiModel.ts
+++ b/packages/wiki/src/wikiApiModel.ts
@@ -210,8 +210,8 @@ const adaptWikiBasic = (response: WikiApiResponseBase): WikiBasic => {
   };
 };
 
-const toSectionIdentifier = (value: unknown, index: number): string =>
-  typeof value === "string" && value.length > 0 ? value : `section-${index + 1}`;
+const toSectionIdentifier = (value: unknown, fallback: string): string =>
+  typeof value === "string" && value.length > 0 ? value : fallback;
 
 const toSectionTitle = (value: unknown, fallback: string): string =>
   typeof value === "string" && value.length > 0 ? value : fallback;
@@ -486,7 +486,7 @@ const adaptWikiSection = (
 ): WikiDetail["sections"][number] => {
   const sectionIdentifier = toSectionIdentifier(
     section.id ?? section.sectionIdentifier ?? section.section_identifier,
-    index,
+    path,
   );
   const rawContents = Array.isArray(section.contents) ? section.contents : [];
   const content = typeof section.content === "string" ? section.content : "";

--- a/packages/wiki/src/wikiApiModel.ts
+++ b/packages/wiki/src/wikiApiModel.ts
@@ -501,10 +501,6 @@ const adaptWikiSection = (
         ...adaptWikiSectionContents(rawContents, depth + 1, path),
       ]
     : adaptWikiSectionContents(rawContents, depth + 1, path);
-  const children = adaptedContents.filter(
-    (content): content is WikiDetail["sections"][number] => "sectionIdentifier" in content,
-  );
-
   return {
     type: "section",
     sectionIdentifier,
@@ -512,7 +508,6 @@ const adaptWikiSection = (
     displayOrder: toNumber(section.displayOrder ?? section.display_order, index + 1),
     depth,
     contents: adaptedContents,
-    children,
   };
 };
 

--- a/packages/wiki/src/wikiDetailView.test.ts
+++ b/packages/wiki/src/wikiDetailView.test.ts
@@ -46,8 +46,7 @@ const sections: WikiSection[] = [
     title: "Second",
     displayOrder: 20,
     depth: 1,
-    contents: [],
-    children: [
+    contents: [
       {
         type: "section",
         sectionIdentifier: "child-b",
@@ -55,7 +54,6 @@ const sections: WikiSection[] = [
         displayOrder: 20,
         depth: 2,
         contents: [],
-        children: [],
       },
       {
         type: "section",
@@ -64,7 +62,6 @@ const sections: WikiSection[] = [
         displayOrder: 10,
         depth: 2,
         contents: [],
-        children: [],
       },
     ],
   },
@@ -75,7 +72,6 @@ const sections: WikiSection[] = [
     displayOrder: 10,
     depth: 1,
     contents: [],
-    children: [],
   },
 ];
 
@@ -110,7 +106,6 @@ describe("wikiDetailView", () => {
         displayOrder: 10,
         depth: 1,
         contents: [],
-        children: [],
       },
       {
         type: "section",
@@ -118,8 +113,7 @@ describe("wikiDetailView", () => {
         title: "Second",
         displayOrder: 20,
         depth: 1,
-        contents: [],
-        children: [
+        contents: [
           {
             type: "section",
             sectionIdentifier: "child-a",
@@ -127,7 +121,6 @@ describe("wikiDetailView", () => {
             displayOrder: 10,
             depth: 2,
             contents: [],
-            children: [],
           },
           {
             type: "section",
@@ -136,7 +129,6 @@ describe("wikiDetailView", () => {
             displayOrder: 20,
             depth: 2,
             contents: [],
-            children: [],
           },
         ],
       },

--- a/packages/wiki/src/wikiDetailView.ts
+++ b/packages/wiki/src/wikiDetailView.ts
@@ -1,4 +1,5 @@
 import type { WikiBasic, WikiSection } from "./types/wiki";
+import { isWikiSection, sortWikiSectionContents } from "./wikiEditModel";
 import { buildWikiPath } from "./wikiRouting";
 
 export type WikiBasicFieldLink = {
@@ -99,7 +100,14 @@ export const sortWikiSections = (sections: WikiSection[]): WikiSection[] =>
     .sort((left, right) => left.displayOrder - right.displayOrder)
     .map((section) => ({
       ...section,
-      children: sortWikiSections(section.children),
+      contents: sortWikiSectionContents(section.contents).map((content) =>
+        isWikiSection(content)
+          ? {
+              ...content,
+              contents: sortWikiSectionContents(content.contents),
+            }
+          : content,
+      ),
     }));
 
 export const getSectionOffset = (depth: number): number =>

--- a/packages/wiki/src/wikiEditModel.test.ts
+++ b/packages/wiki/src/wikiEditModel.test.ts
@@ -6,6 +6,7 @@ import {
   createWikiBlock,
   deleteWikiContent,
   getWikiContentEditorId,
+  isWikiSection,
   parseWikiSectionsFromCode,
   serializeWikiSectionsToCode,
   toWikiEditRequestPayload,
@@ -30,7 +31,6 @@ const createSection = (overrides?: Partial<WikiSection>): WikiSection => ({
       content: "Root text",
     },
   ],
-  children: [],
   ...overrides,
 });
 
@@ -70,6 +70,45 @@ describe("wikiEditModel", () => {
       }),
     );
     expect(editId).toMatch(/^block:/);
+  });
+
+  it("adds one editable block to a nested section with contents as the canonical edit tree", () => {
+    const childSection = createSection({
+      sectionIdentifier: "sec-child",
+      title: "Child",
+      displayOrder: 20,
+      depth: 2,
+      contents: [],
+    });
+    const rootSection = createSection({
+      contents: [
+        ...(createSection().contents),
+        childSection,
+      ],
+    });
+
+    const [addedSections, editId] = addWikiBlock([rootSection], "sec-child", "embed");
+    const blockIdentifier = editId?.replace("block:", "");
+
+    expect(blockIdentifier).toBeTruthy();
+
+    const [updatedSections] = blockIdentifier
+      ? [updateWikiBlock(addedSections, blockIdentifier, { embedId: "ohVNJ2gxsmo" } as Partial<WikiBlock>)]
+      : [addedSections];
+    const normalizedRoot = updatedSections[0];
+    const contentsChild = normalizedRoot?.contents.find(isWikiSection);
+
+    expect(normalizedRoot).not.toHaveProperty("children");
+    expect(contentsChild?.sectionIdentifier).toBe("sec-child");
+    expect(contentsChild?.contents).toHaveLength(1);
+    expect(contentsChild).not.toHaveProperty("children");
+    expect((contentsChild?.contents[0] as WikiBlock | undefined)?.blockIdentifier).toBe(
+      blockIdentifier,
+    );
+    expect(serializeWikiSectionsToCode(updatedSections)).toContain(
+      "[[embed|provider:youtube|id:ohVNJ2gxsmo|caption:New embed caption]]",
+    );
+    expect(serializeWikiSectionsToCode(updatedSections)).not.toContain("id:new-embed-id");
   });
 
   it("creates new text blocks with empty content", () => {

--- a/packages/wiki/src/wikiEditModel.ts
+++ b/packages/wiki/src/wikiEditModel.ts
@@ -920,9 +920,6 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
 
     const nextParent = {
       ...parent,
-      children: parent.children.map((child) =>
-        child.sectionIdentifier === nextSection.sectionIdentifier ? nextSection : child,
-      ),
       contents: parent.contents.map((content) =>
         isWikiSection(content) && content.sectionIdentifier === nextSection.sectionIdentifier
           ? nextSection
@@ -997,13 +994,11 @@ export const parseWikiSectionsFromCode = (code: string): WikiCodeParseResult => 
         displayOrder: getNextDisplayOrder(parent ? parent.contents : rootSections),
         depth: normalizedHeadingDepth,
         contents: [],
-        children: [],
       };
 
       if (parent) {
         const nextParent = {
           ...parent,
-          children: [...parent.children, nextSection],
           contents: [...parent.contents, nextSection],
         };
 
@@ -1074,22 +1069,13 @@ export const getWikiContentEditorId = (
 export const normalizeWikiSectionContents = (
   section: WikiSection,
 ): WikiSection => {
-  const childSections = section.children.map(normalizeWikiSectionContents);
-  const existingContents = section.contents.length > 0 ? section.contents : [];
-  const childIds = new Set(childSections.map((child) => child.sectionIdentifier));
-  const retainedContents = existingContents.filter(
-    (content) =>
-      !isWikiSection(content) || !childIds.has(content.sectionIdentifier),
+  const normalizedContents = section.contents.map((content) =>
+    isWikiSection(content) ? normalizeWikiSectionContents(content) : content,
   );
-
   return {
     ...section,
     type: "section",
-    contents: sortWikiSectionContents([
-      ...retainedContents,
-      ...childSections,
-    ]),
-    children: childSections,
+    contents: sortWikiSectionContents(normalizedContents),
   };
 };
 
@@ -1110,7 +1096,6 @@ export const sortWikiSectionContents = <T extends WikiSectionContent>(
         ? ({
             ...content,
             contents: sortWikiSectionContents(content.contents),
-            children: sortWikiSectionContents(content.children),
           } as T)
         : content,
     );
@@ -1209,18 +1194,15 @@ const mapSections = (
   mapper: (section: WikiSection) => WikiSection,
 ): WikiSection[] =>
   sections.map((section) => {
-    const mappedChildren = section.children.length
-      ? mapSections(section.children, mapper)
-      : section.children;
-    const mappedContents = section.contents.map((content) =>
+    const normalizedSection = normalizeWikiSectionContents(section);
+    const mappedContents = normalizedSection.contents.map((content) =>
       isWikiSection(content)
         ? mapSections([content], mapper)[0] ?? content
         : content,
     );
 
     return mapper({
-      ...section,
-      children: mappedChildren,
+      ...normalizedSection,
       contents: mappedContents,
     });
   });
@@ -1241,7 +1223,6 @@ export const addWikiSection = (
       displayOrder,
       depth: parentDepth + 1,
       contents: [],
-      children: [],
     };
   };
 
@@ -1265,7 +1246,6 @@ export const addWikiSection = (
     return {
       ...section,
       contents: [...section.contents, child],
-      children: [...section.children, child],
     };
   });
 
@@ -1326,21 +1306,24 @@ export const deleteWikiContent = (
 ): WikiSection[] =>
   sections
     .filter((section) => section.sectionIdentifier !== identifier)
-    .map((section) => ({
-      ...section,
-      children: deleteWikiContent(section.children, identifier),
-      contents: section.contents
-        .filter((content) =>
-          isWikiSection(content)
-            ? content.sectionIdentifier !== identifier
-            : content.blockIdentifier !== identifier,
-        )
-        .map((content) =>
-          isWikiSection(content)
-            ? deleteWikiContent([content], identifier)[0] ?? content
-            : content,
-        ),
-    }));
+    .map((section) => {
+      const normalizedSection = normalizeWikiSectionContents(section);
+
+      return {
+        ...normalizedSection,
+        contents: normalizedSection.contents
+          .filter((content) =>
+            isWikiSection(content)
+              ? content.sectionIdentifier !== identifier
+              : content.blockIdentifier !== identifier,
+          )
+          .map((content) =>
+            isWikiSection(content)
+              ? deleteWikiContent([content], identifier)[0] ?? content
+              : content,
+          ),
+      };
+    });
 
 export const toWikiSectionContentPayload = (
   sections: WikiSection[],

--- a/src/app/wiki/[slug]/edit/WikiEditPage.tsx
+++ b/src/app/wiki/[slug]/edit/WikiEditPage.tsx
@@ -432,25 +432,26 @@ export function WikiEditContent({
         </div>
 
         <WikiEditSidebar
-          canPersist={canPersist}
+          canPersist={canPersist && !editingId}
           editorMode={editorMode}
+          isEditorModeDisabled={Boolean(editingId)}
           isBusy={isBusy}
           isOpen={isSidebarOpen}
           isReviewLocked={isEditLocked}
           onEditorModeChange={(mode) => {
-            if (!isEditLocked) {
+            if (!isEditLocked && !editingId) {
               setEditorMode(mode);
             }
           }}
           onClear={clearChanges}
           onPreviewModeChange={setPreviewMode}
           onSave={() => {
-            if (!isEditLocked) {
+            if (!isEditLocked && !editingId) {
               saveDraft();
             }
           }}
           onSubmit={() => {
-            if (!isEditLocked) {
+            if (!isEditLocked && !editingId) {
               void requestPublication();
             }
           }}

--- a/src/app/wiki/[slug]/edit/page.test.tsx
+++ b/src/app/wiki/[slug]/edit/page.test.tsx
@@ -885,6 +885,60 @@ describe("WikiEditPage", () => {
     expect(screen.getByText("Updated overview from code mode.")).toBeInTheDocument();
   });
 
+  it("keeps embed block edits out of code mode until the block form is saved", async () => {
+    const saveAdapter = vi.fn().mockResolvedValue({ ok: true });
+
+    renderPage(successState, saveAdapter);
+
+    const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview"));
+    fireEvent.click(addControls.getByText("+ Block"));
+    fireEvent.click(addControls.getByRole("button", { name: "Embed" }));
+    fireEvent.change(screen.getByLabelText("Embed ID"), {
+      target: { value: "ohVNJ2gxsmo" },
+    });
+
+    expect(screen.getByRole("button", { name: "code" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save wiki changes" })).toBeDisabled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" }).at(-1)!);
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+
+    const code = screen.getByLabelText("Wiki code") as HTMLTextAreaElement;
+    expect(code.value).toContain(
+      "[[embed|provider:youtube|id:ohVNJ2gxsmo|caption:New embed caption]]",
+    );
+    expect(code.value).not.toContain("id:new-embed-id");
+
+    fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
+
+    await waitFor(() => expect(saveAdapter).toHaveBeenCalled());
+    expect(JSON.stringify(saveAdapter.mock.calls[0]?.[0])).toContain(
+      '"embedId":"ohVNJ2gxsmo"',
+    );
+    expect(JSON.stringify(saveAdapter.mock.calls[0]?.[0])).not.toContain(
+      '"embedId":"new-embed-id"',
+    );
+  });
+
+  it("keeps new nested embed block edits when switching to code mode", () => {
+    renderPage();
+
+    const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview-style"));
+    fireEvent.click(addControls.getByText("+ Block"));
+    fireEvent.click(addControls.getByRole("button", { name: "Embed" }));
+    fireEvent.change(screen.getByLabelText("Embed ID"), {
+      target: { value: "ohVNJ2gxsmo" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" }).at(-1)!);
+    fireEvent.click(screen.getByRole("button", { name: "code" }));
+
+    const code = screen.getByLabelText("Wiki code") as HTMLTextAreaElement;
+    expect(code.value).toContain(
+      "[[embed|provider:youtube|id:ohVNJ2gxsmo|caption:New embed caption]]",
+    );
+    expect(code.value).not.toContain("id:new-embed-id");
+  });
+
   it("shows a parse error for invalid code and clears back to the last loaded draft", () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
@@ -991,6 +1045,7 @@ describe("WikiEditPage", () => {
     const addControls = within(screen.getByTestId("wiki-edit-add-section-sec-overview-style"));
     fireEvent.click(addControls.getByText("+ Block"));
     fireEvent.click(addControls.getByRole("button", { name: "Quote" }));
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" }).at(-1)!);
     fireEvent.click(screen.getByRole("button", { name: "Save wiki changes" }));
 
     await waitFor(() => expect(saveAdapter).toHaveBeenCalled());

--- a/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
+++ b/src/app/wiki/[slug]/edit/useWikiEditDraft.ts
@@ -17,7 +17,7 @@ import {
   type WikiDraftStatus,
   type WikiEditPayload,
 } from "@kpool/wiki";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   normalizeWikiSlugForResourceType,
@@ -94,6 +94,7 @@ export const useWikiEditDraft = (
   const initialDraft = useMemo(() => createInitialDraft(wiki), [wiki]);
   const initialCode = useMemo(() => getCodeFromSections(initialDraft.sections), [initialDraft]);
   const [draft, setDraft] = useState<WikiDraftDetail>(initialDraft);
+  const draftRef = useRef<WikiDraftDetail>(initialDraft);
   const [code, setCode] = useState(initialCode);
   const [codeParseError, setCodeParseError] = useState<string | null>(null);
   const [codeWarnings, setCodeWarnings] = useState(() => getWarningsFromCode(initialCode));
@@ -113,6 +114,7 @@ export const useWikiEditDraft = (
   const onSubmitSuccess = options?.onSubmitSuccess;
 
   useEffect(() => {
+    draftRef.current = initialDraft;
     setDraft(initialDraft);
     setCode(initialCode);
     setCodeParseError(null);
@@ -134,6 +136,7 @@ export const useWikiEditDraft = (
     const parsedCode = parseWikiSectionsFromCode(nextCode);
     const payload = toWikiEditPayload(nextDraft);
 
+    draftRef.current = nextDraft;
     setDraft(nextDraft);
     setCode(nextCode);
     setCodeParseError(null);
@@ -147,7 +150,8 @@ export const useWikiEditDraft = (
   };
 
   const saveDraft = () => {
-    const payload = toWikiEditPayload(draft);
+    const nextDraft = draftRef.current;
+    const payload = toWikiEditPayload(nextDraft);
 
     setSaveState({
       status: "saving",
@@ -156,7 +160,7 @@ export const useWikiEditDraft = (
       showMessage: true,
     });
 
-    void Promise.resolve(saveAdapter(draft)).then((adapterResult) => {
+    void Promise.resolve(saveAdapter(nextDraft)).then((adapterResult) => {
       const result: WikiPersistenceResult = isWikiPersistenceResult(adapterResult) ? adapterResult : { ok: false };
 
       setSaveState({
@@ -176,6 +180,7 @@ export const useWikiEditDraft = (
   };
 
   const clearDraft = () => {
+    draftRef.current = initialDraft;
     setDraft(initialDraft);
     setCode(getCodeFromSections(initialDraft.sections));
     setCodeParseError(null);
@@ -190,7 +195,8 @@ export const useWikiEditDraft = (
   };
 
   const requestPublication = () => {
-    const payload = toWikiEditPayload(draft);
+    const nextDraft = draftRef.current;
+    const payload = toWikiEditPayload(nextDraft);
 
     setSaveState({
       status: "submitting",
@@ -199,7 +205,7 @@ export const useWikiEditDraft = (
       showMessage: true,
     });
 
-    void Promise.resolve(submitAdapter(draft)).then((adapterResult) => {
+    void Promise.resolve(submitAdapter(nextDraft)).then((adapterResult) => {
       const result: WikiPersistenceResult = isWikiPersistenceResult(adapterResult) ? adapterResult : { ok: false };
 
       setSaveState({
@@ -249,10 +255,11 @@ export const useWikiEditDraft = (
     cancelEditing: () => {
       if (editingId && editingId === newContentEditorId) {
         const [, identifier] = editingId.split(":");
+        const currentDraft = draftRef.current;
 
         commitDraft({
-          ...draft,
-          sections: deleteWikiContent(draft.sections, identifier),
+          ...currentDraft,
+          sections: deleteWikiContent(currentDraft.sections, identifier),
         });
         setNewContentEditorId(null);
         setEditingId(null);
@@ -271,15 +278,16 @@ export const useWikiEditDraft = (
         setSaveState({
           status: "dirty",
           message: "Unsaved changes",
-          payload: toWikiEditPayload(draft),
+          payload: toWikiEditPayload(draftRef.current),
           showMessage: true,
         });
         return;
       }
 
+      const currentDraft = draftRef.current;
       commitDraft(
         {
-          ...draft,
+          ...currentDraft,
           sections: parsed.sections,
         },
         nextCode,
@@ -287,43 +295,44 @@ export const useWikiEditDraft = (
     },
     updateBasic: (basic: WikiDraftDetail["basic"]) =>
       commitDraft({
-        ...draft,
+        ...draftRef.current,
         basic,
         resourceType: basic.resourceType,
         slug: normalizeWikiSlugForResourceType(
-          draft.slug,
+          draftRef.current.slug,
           basic.resourceType as WikiResourceType,
         ),
       }),
     updateHeroImage: (heroImage: WikiDraftDetail["heroImage"]) =>
       commitDraft({
-        ...draft,
+        ...draftRef.current,
         heroImage,
       }),
     updateSettings: (
       settings: Partial<Pick<WikiDraftDetail, "resourceType" | "slug" | "themeColor" | "title" | "metaDescription" | "keywords">>,
     ) => {
+      const currentDraft = draftRef.current;
       const nextResourceType =
         (settings.resourceType as WikiResourceType | undefined) ??
-        (draft.resourceType as WikiResourceType);
+        (currentDraft.resourceType as WikiResourceType);
 
       commitDraft({
-        ...draft,
+        ...currentDraft,
         ...settings,
-        title: settings.title !== undefined ? settings.title : draft.title,
+        title: settings.title !== undefined ? settings.title : currentDraft.title,
         metaDescription: settings.metaDescription !== undefined
           ? settings.metaDescription
-          : draft.metaDescription,
+          : currentDraft.metaDescription,
         keywords: settings.keywords !== undefined
           ? settings.keywords
-          : draft.keywords,
+          : currentDraft.keywords,
         resourceType: nextResourceType,
         basic: {
-          ...draft.basic,
+          ...currentDraft.basic,
           resourceType: nextResourceType,
         },
         slug: normalizeWikiSlugForResourceType(
-          settings.slug ?? draft.slug,
+          settings.slug ?? currentDraft.slug,
           nextResourceType,
         ),
       });
@@ -332,54 +341,59 @@ export const useWikiEditDraft = (
       sectionIdentifier: string,
       changes: Parameters<typeof updateWikiSection>[2],
     ) => {
+      const currentDraft = draftRef.current;
       commitDraft({
-        ...draft,
-        sections: updateWikiSection(draft.sections, sectionIdentifier, changes),
+        ...currentDraft,
+        sections: updateWikiSection(currentDraft.sections, sectionIdentifier, changes),
       });
       if (editingId === newContentEditorId) {
         setNewContentEditorId(null);
       }
     },
     updateBlock: (blockIdentifier: string, changes: Partial<WikiBlock>) => {
+      const currentDraft = draftRef.current;
       commitDraft({
-        ...draft,
-        sections: updateWikiBlock(draft.sections, blockIdentifier, changes),
+        ...currentDraft,
+        sections: updateWikiBlock(currentDraft.sections, blockIdentifier, changes),
       });
       if (editingId === newContentEditorId) {
         setNewContentEditorId(null);
       }
     },
     addSection: (parentSectionIdentifier?: string) => {
+      const currentDraft = draftRef.current;
       const [sections, nextEditingId] = addWikiSection(
-        draft.sections,
+        currentDraft.sections,
         parentSectionIdentifier,
       );
 
       commitDraft({
-        ...draft,
+        ...currentDraft,
         sections,
       });
       setEditingId(nextEditingId);
       setNewContentEditorId(nextEditingId);
     },
     addBlock: (sectionIdentifier: string, blockType: WikiBlockType) => {
+      const currentDraft = draftRef.current;
       const [sections, nextEditingId] = addWikiBlock(
-        draft.sections,
+        currentDraft.sections,
         sectionIdentifier,
         blockType,
       );
 
       commitDraft({
-        ...draft,
+        ...currentDraft,
         sections,
       });
       setEditingId(nextEditingId);
       setNewContentEditorId(nextEditingId);
     },
     deleteContent: (identifier: string) => {
+      const currentDraft = draftRef.current;
       commitDraft({
-        ...draft,
-        sections: deleteWikiContent(draft.sections, identifier),
+        ...currentDraft,
+        sections: deleteWikiContent(currentDraft.sections, identifier),
       });
       setEditingId(null);
       setNewContentEditorId(null);

--- a/src/app/wiki/[slug]/page.test.tsx
+++ b/src/app/wiki/[slug]/page.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { WikiDetailPage } from "./WikiDetailPage";
@@ -82,7 +82,6 @@ const successState: WikiDetailState = {
             title: "Related profiles",
           },
         ],
-        children: [],
       },
       {
         type: "section",
@@ -106,7 +105,6 @@ const successState: WikiDetailState = {
             caption: "Overview video",
           },
         ],
-        children: [],
       },
     ],
   },
@@ -135,11 +133,13 @@ describe("WikiDetailPage", () => {
       "href",
       "/wiki/ko/tl-sana",
     );
+    fireEvent.click(screen.getByTestId("section-toggle-overview"));
     expect(screen.getByText("Overview body")).toBeInTheDocument();
     expect(screen.getByTitle("YouTube embed: Overview video")).toHaveAttribute(
       "src",
       "https://www.youtube-nocookie.com/embed/abc123",
     );
+    fireEvent.click(screen.getByTestId("section-toggle-members"));
     expect(screen.getByRole("link", { name: /Aurora Echo/i })).toHaveAttribute(
       "href",
       "/wiki/ja/gr-aurora-echo",

--- a/src/components/Wiki/WikiBlockDisplay/index.tsx
+++ b/src/components/Wiki/WikiBlockDisplay/index.tsx
@@ -19,14 +19,14 @@ type WikiBlockDisplayProps = {
 
 const textWrapClassName = "min-w-0 break-words [overflow-wrap:anywhere] [word-break:break-word]";
 const inlineLinkClassName = `${textWrapClassName} text-sky-700 underline decoration-sky-500 underline-offset-2 transition hover:text-sky-800`;
-const captionClassName = `${textWrapClassName} mt-2 text-sm text-text-muted`;
+const captionClassName = `${textWrapClassName} mt-2 text-base text-text-muted`;
 const tableCellClassName = `${textWrapClassName} border-b border-stroke-subtle px-3 py-2`;
 
 export function WikiBlockDisplay({
   block,
   language = "ja",
   showEditableImageOverlay = false,
-  textClassName = "text-sm leading-7 text-text-strong",
+  textClassName = "text-base leading-7 text-text-strong",
 }: WikiBlockDisplayProps) {
   const renderPlainTextWithNamuLinks = (text: string, keyPrefix: string) => {
     const pattern = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
@@ -103,7 +103,7 @@ export function WikiBlockDisplay({
           return (
             <sup
               aria-label={`Footnote: ${token.content}`}
-              className="ml-1 text-xs font-semibold text-text-muted"
+              className="ml-1 text-sm font-semibold text-text-muted"
               key={`footnote-${index}`}
               title={token.content}
             >
@@ -113,7 +113,7 @@ export function WikiBlockDisplay({
         case "include":
           return (
             <span
-              className={`${textWrapClassName} inline-flex max-w-full rounded-full border border-stroke-subtle px-2 py-0.5 text-xs font-semibold text-text-muted`}
+              className={`${textWrapClassName} inline-flex max-w-full rounded-full border border-stroke-subtle px-2 py-0.5 text-sm font-semibold text-text-muted`}
               key={`include-${index}`}
             >
               Included from {token.target}
@@ -171,18 +171,18 @@ export function WikiBlockDisplay({
       return <WikiEmbedFrame block={block} />;
     case "quote":
       return (
-        <blockquote className={`${textWrapClassName} border-l-4 border-text-muted/30 pl-4 text-base leading-8 text-text-strong`}>
+        <blockquote className={`${textWrapClassName} border-l-4 border-text-muted/30 pl-4 text-lg leading-8 text-text-strong`}>
           {block.content}
-          {block.source ? <cite className={`${textWrapClassName} mt-2 block text-sm text-text-muted`}>{block.source}</cite> : null}
+          {block.source ? <cite className={`${textWrapClassName} mt-2 block text-base text-text-muted`}>{block.source}</cite> : null}
         </blockquote>
       );
     case "list":
       return block.listType === "numbered" ? (
-        <ol className={`${textWrapClassName} list-decimal space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
+        <ol className={`${textWrapClassName} list-decimal space-y-2 pl-6 text-base leading-7 text-text-strong`}>
           {block.items.map((item) => <li className={textWrapClassName} key={item}>{renderInlineTokens(item)}</li>)}
         </ol>
       ) : (
-        <ul className={`${textWrapClassName} list-disc space-y-2 pl-6 text-sm leading-7 text-text-strong`}>
+        <ul className={`${textWrapClassName} list-disc space-y-2 pl-6 text-base leading-7 text-text-strong`}>
           {block.items.map((item) => <li className={textWrapClassName} key={item}>{renderInlineTokens(item)}</li>)}
         </ul>
       );
@@ -195,7 +195,7 @@ export function WikiBlockDisplay({
       return (
         <div className="overflow-x-auto">
           <table
-            className="min-w-full text-left text-sm"
+            className="min-w-full text-left text-base"
             style={block.tableWidth ? { width: `${block.tableWidth}px` } : undefined}
           >
             {headerCells ? (

--- a/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.test.tsx
+++ b/src/components/Wiki/WikiEditSidebar/WikiEditSidebar.test.tsx
@@ -160,4 +160,38 @@ describe("WikiEditSidebar", () => {
     expect(onUpdateSettings).not.toHaveBeenCalled();
     expect(onPreviewModeChange).toHaveBeenCalledWith("dark");
   });
+
+  it("disables editor mode controls while inline edits are pending", () => {
+    const onEditorModeChange = vi.fn();
+
+    render(
+      <WikiEditSidebar
+        canPersist
+        editorMode="gui"
+        isBusy={false}
+        isEditorModeDisabled
+        isOpen
+        onEditorModeChange={onEditorModeChange}
+        onClear={vi.fn()}
+        onPreviewModeChange={vi.fn()}
+        onSave={vi.fn()}
+        onSubmit={vi.fn()}
+        onToggle={vi.fn()}
+        onUpdateSettings={vi.fn()}
+        previewMode="light"
+        resourceType="group"
+        slug={wikiStoryDetail.slug}
+        themeColor={wikiStoryDetail.themeColor}
+        title="Aurora Echo SEO"
+        metaDescription="Aurora Echo meta description"
+        keywords={["aurora", "echo"]}
+      />,
+    );
+
+    const codeButton = screen.getByRole("button", { name: "code" });
+
+    expect(codeButton).toBeDisabled();
+    fireEvent.click(codeButton);
+    expect(onEditorModeChange).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Wiki/WikiEditSidebar/index.tsx
+++ b/src/components/Wiki/WikiEditSidebar/index.tsx
@@ -66,6 +66,7 @@ function WikiSubmitButton({
 type WikiEditSidebarProps = {
   canPersist: boolean;
   editorMode: WikiEditorMode;
+  isEditorModeDisabled?: boolean;
   isBusy: boolean;
   isOpen: boolean;
   isReviewLocked?: boolean;
@@ -90,6 +91,7 @@ type WikiEditSidebarProps = {
 export function WikiEditSidebar({
   canPersist,
   editorMode,
+  isEditorModeDisabled = false,
   isBusy,
   isOpen,
   isReviewLocked = false,
@@ -111,6 +113,7 @@ export function WikiEditSidebar({
   const customColorValue = themeColor ?? themeColorOptions[2];
   const isActionDisabled = isBusy || !canPersist || isReviewLocked;
   const isEditControlDisabled = isBusy || isReviewLocked;
+  const isEditorModeControlDisabled = isEditControlDisabled || isEditorModeDisabled;
   const [keywordInputs, setKeywordInputs] = useState<string[]>(
     () => keywords && keywords.length > 0 ? keywords : [""],
   );
@@ -187,9 +190,13 @@ export function WikiEditSidebar({
                   <button
                     aria-pressed={editorMode === mode}
                     className="rounded-full px-3 py-2 text-sm font-semibold uppercase tracking-[0.12em] text-text-muted transition aria-pressed:bg-surface-raised aria-pressed:text-text-strong aria-pressed:shadow-soft disabled:cursor-not-allowed"
-                    disabled={isEditControlDisabled}
+                    disabled={isEditorModeControlDisabled}
                     key={mode}
-                    onClick={() => onEditorModeChange(mode)}
+                    onClick={() => {
+                      if (!isEditorModeControlDisabled) {
+                        onEditorModeChange(mode);
+                      }
+                    }}
                     type="button"
                   >
                     {mode}

--- a/src/components/Wiki/WikiEmbedFrame/index.tsx
+++ b/src/components/Wiki/WikiEmbedFrame/index.tsx
@@ -121,7 +121,7 @@ export function WikiEmbedFrame({ block }: { block: WikiEmbedBlock }) {
         />
       </div>
       {block.caption ? (
-        <figcaption className="border-t border-stroke-subtle px-4 py-3 text-sm text-text-muted">
+        <figcaption className="border-t border-stroke-subtle px-4 py-3 text-base text-text-muted">
           {block.caption}
         </figcaption>
       ) : null}

--- a/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.test.tsx
+++ b/src/components/Wiki/WikiPublicHeroImage/WikiPublicHeroImage.test.tsx
@@ -8,7 +8,7 @@ import { WikiPublicHeroImage } from "./index";
 describe("WikiPublicHeroImage", () => {
   afterEach(() => cleanup());
 
-  it("renders the hero intro copy", () => {
+  it("renders the mobile flip helper copy outside the card", () => {
     render(
       <WikiPublicHeroImage
         basic={wikiStoryBasic}
@@ -17,7 +17,8 @@ describe("WikiPublicHeroImage", () => {
       />,
     );
 
-    expect(screen.getByText("Flip to reveal the basic profile")).toBeInTheDocument();
+    expect(screen.getByText("Tap anywhere on the card to flip to the basic details.")).toBeInTheDocument();
+    expect(screen.queryByText("Flip to reveal the basic profile")).not.toBeInTheDocument();
   });
 
   it("toggles the mobile helper copy when flipped", () => {

--- a/src/components/Wiki/WikiPublicHeroImage/index.tsx
+++ b/src/components/Wiki/WikiPublicHeroImage/index.tsx
@@ -9,7 +9,6 @@ import { WikiBasicFieldsList } from "../WikiBasicFieldsList";
 import {
   cardSurfaceMutedStyle,
   cardSurfaceStyle,
-  heroOverlayStyle,
   transparentFrameStyle,
 } from "../styles";
 import { EditIcon } from "../icons";
@@ -68,22 +67,6 @@ export function WikiPublicHeroImage({
                       src={heroImage.src}
                       unoptimized
                     />
-                  </div>
-                  <div className="absolute inset-0" style={heroOverlayStyle} />
-                  <div className="absolute inset-x-0 bottom-0 px-5 py-6 text-white">
-                    <p
-                      className="text-xs font-semibold uppercase tracking-[0.28em]"
-                      style={{ color: "var(--wiki-hero-accent, var(--brand-highlight))" }}
-                    >
-                      Tap The Card
-                    </p>
-                    <p className="mt-2 text-2xl font-semibold tracking-[-0.03em]">
-                      Flip to reveal the basic profile
-                    </p>
-                    <p className="mt-3 max-w-xs text-sm leading-6 text-white/78">
-                      The card turns like a physical profile card and exposes
-                      the group basics on the reverse side.
-                    </p>
                   </div>
                 </div>
                 <label

--- a/src/components/Wiki/WikiRelatedProfiles/index.tsx
+++ b/src/components/Wiki/WikiRelatedProfiles/index.tsx
@@ -25,9 +25,9 @@ export function WikiRelatedProfiles({
     return (
       <section aria-label={block.title ?? "Related profiles"}>
         {block.title ? (
-          <h3 className="text-base font-semibold text-text-strong">{block.title}</h3>
+          <h3 className="text-lg font-semibold text-text-strong">{block.title}</h3>
         ) : null}
-        <p className="mt-3 rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-5 text-sm text-text-muted">
+        <p className="mt-3 rounded-2xl border border-stroke-subtle bg-surface-base px-4 py-5 text-base text-text-muted">
           関連プロフィールはありません
         </p>
       </section>
@@ -37,7 +37,7 @@ export function WikiRelatedProfiles({
   return (
     <section aria-label={block.title ?? "Related profiles"}>
       {block.title ? (
-        <h3 className="text-base font-semibold text-text-strong">{block.title}</h3>
+        <h3 className="text-lg font-semibold text-text-strong">{block.title}</h3>
       ) : null}
       <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {profiles.map((profile) => (
@@ -62,7 +62,7 @@ export function WikiRelatedProfiles({
               )}
             </div>
             <div className="px-4 py-3">
-              <p className="text-sm font-semibold text-text-strong">{profile.name}</p>
+              <p className="text-base font-semibold text-text-strong">{profile.name}</p>
             </div>
           </Link>
         ))}

--- a/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
+++ b/src/components/Wiki/WikiSectionAccordion/WikiSectionAccordion.test.tsx
@@ -15,10 +15,17 @@ describe("WikiSectionAccordion", () => {
 
     expect(section).not.toHaveAttribute("open");
     expect(screen.getByText(wikiStorySection.title)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "The group balances brisk digital singles with a smaller number of concept-heavy mini albums.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
-  it("renders the section body content", () => {
+  it("renders the section body content after opening", () => {
     render(<WikiSectionAccordion language="ja" section={wikiStorySection} />);
+
+    fireEvent.click(screen.getByTestId(`section-toggle-${wikiStorySection.sectionIdentifier}`));
 
     expect(
       screen.getAllByText(

--- a/src/components/Wiki/WikiSectionAccordion/index.tsx
+++ b/src/components/Wiki/WikiSectionAccordion/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import {
   isWikiBlock,
   isWikiSection,
@@ -19,17 +20,23 @@ type WikiSectionAccordionProps = {
 };
 
 export function WikiSectionAccordion({ editHref, language, section }: WikiSectionAccordionProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const contents = sortWikiSectionContents(section.contents);
 
   return (
     <details
       className="section-accordion rounded-[1.75rem] border border-stroke-subtle bg-surface-raised shadow-soft"
       data-testid={`section-${section.sectionIdentifier}`}
+      open={isOpen}
       style={cardSurfaceStyle}
     >
       <summary
         className="flex list-none cursor-pointer items-center gap-3 p-5 text-left"
         data-testid={`section-toggle-${section.sectionIdentifier}`}
+        onClick={(event) => {
+          event.preventDefault();
+          setIsOpen((open) => !open);
+        }}
       >
         <span
           className="section-accordion__chevron rounded-full border border-stroke-subtle p-2 text-text-muted transition-transform"
@@ -55,28 +62,30 @@ export function WikiSectionAccordion({ editHref, language, section }: WikiSectio
         ) : null}
       </summary>
 
-      <div
-        className="space-y-4 border-t border-stroke-subtle px-5 pb-5 pt-4"
-        style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}
-      >
-        {contents.map((content) =>
-          isWikiBlock(content) ? (
-            <WikiBlockDisplay
-              block={content}
-              key={content.blockIdentifier}
-              language={language}
-              textClassName="max-w-3xl text-sm leading-7 text-text-muted"
-            />
-          ) : isWikiSection(content) ? (
-            <WikiSectionAccordion
-              editHref={editHref}
-              key={content.sectionIdentifier}
-              language={language}
-              section={content}
-            />
-          ) : null,
-        )}
-      </div>
+      {isOpen ? (
+        <div
+          className="space-y-4 border-t border-stroke-subtle px-5 pb-5 pt-4"
+          style={{ borderColor: "var(--wiki-card-border, var(--stroke-subtle))" }}
+        >
+          {contents.map((content) =>
+            isWikiBlock(content) ? (
+              <WikiBlockDisplay
+                block={content}
+                key={content.blockIdentifier}
+                language={language}
+                textClassName="max-w-3xl text-sm leading-7 text-text-muted"
+              />
+            ) : isWikiSection(content) ? (
+              <WikiSectionAccordion
+                editHref={editHref}
+                key={content.sectionIdentifier}
+                language={language}
+                section={content}
+              />
+            ) : null,
+          )}
+        </div>
+      ) : null}
     </details>
   );
 }

--- a/src/components/Wiki/WikiSectionAccordion/index.tsx
+++ b/src/components/Wiki/WikiSectionAccordion/index.tsx
@@ -73,7 +73,7 @@ export function WikiSectionAccordion({ editHref, language, section }: WikiSectio
                 block={content}
                 key={content.blockIdentifier}
                 language={language}
-                textClassName="max-w-3xl text-sm leading-7 text-text-muted"
+                textClassName="max-w-3xl text-base leading-7 text-text-muted"
               />
             ) : isWikiSection(content) ? (
               <WikiSectionAccordion

--- a/src/gateways/wiki/draftWiki.test.ts
+++ b/src/gateways/wiki/draftWiki.test.ts
@@ -118,7 +118,6 @@ describe("draftWiki", () => {
             content: "Draft sample for checking the editor state.",
           },
         ],
-        children: [],
       },
     ]);
   });
@@ -240,11 +239,12 @@ describe("draftWiki", () => {
         ],
       }),
     ]);
-    expect(wiki.sections[0]?.children).toEqual([
+    expect(wiki.sections[0]?.contents[1]).toEqual(
       expect.objectContaining({
+        type: "section",
         title: "Highlights",
       }),
-    ]);
+    );
   });
 
   it("normalizes a talent draft response into the shared detail shape", () => {

--- a/src/gateways/wiki/publicWiki.test.ts
+++ b/src/gateways/wiki/publicWiki.test.ts
@@ -130,7 +130,6 @@ describe("publicWiki", () => {
             content: "Published overview from the backend.",
           },
         ],
-        children: [],
       },
     ]);
   });


### PR DESCRIPTION
## 📝 変更内容

- Wikiセクションのフロント状態管理を `contents` に統一
- APIレスポンス由来の `children` はスキーマ入力時に `contents` へマージし、以後の編集・表示・保存payloadでは使わないように変更
- ネストsection内で新規Embedを追加した際に、Code表示や保存payloadで `new-embed-id` に戻る問題を修正
- Embed/YouTube表示をaccordion展開時に遅延読み込みするよう調整
- Wikiブロック表示の文字サイズ、ヒーローカード内説明文、公開ページテストを更新

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [x] 🐛 バグ修正 (Bug fix)
- [x] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [x] 🧪 テスト (Tests)
- [ ] 🔨 ビルド/CI (Build/CI)
- [x] 💄 UI/UX (Style)
- [x] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Wikiセクションが `contents` と `children` の二重構造で管理されており、ネストsection内の新規ブロック追加時に片方だけ更新されることで、Code表示・保存payload・再読み込み後の状態が不整合になることがあったため。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint とユニットテストがパスすることを確認
- [x] `pnpm build` を実行し、ビルドが成功することを確認
- [x] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

### 動作確認

- ネストsection内の新規Embed追加後、Code表示と保存payloadに編集後のEmbed IDが反映されることをテストで確認

## 🔍 レビューのポイント

- `children` をフロントの `WikiSection` 型から外し、`contents` へ一本化している点
- `wikiSectionSchema` でAPI互換入力の `children` を `contents` にマージしている点
- ネストsection内の新規ブロック追加・Code表示・保存payloadの回帰テスト

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

特になし

## 📸 スクリーンショット・デモ

なし

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [x] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
