### PR TITLE
assignee変更をSlack通知するワークフローを追加

### DIFF
--- a/.github/workflows/notify-assignee-changes.yml
+++ b/.github/workflows/notify-assignee-changes.yml
@@ -1,0 +1,55 @@
+name: Notify assignee changes
+
+on:
+  issues:
+    types: [assigned, unassigned]
+  pull_request:
+    types: [assigned, unassigned]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          ITEM_TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          ITEM_URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+          ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
+          ASSIGNEE: ${{ github.event.assignee.login }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_WEBHOOK_URL is not set. Skipping Slack notification."
+            exit 0
+          fi
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            ITEM_LABEL="Pull request"
+          else
+            ITEM_LABEL="Issue"
+          fi
+
+          if [ "${ACTION}" = "assigned" ]; then
+            ICON=":bust_in_silhouette:"
+            ACTION_LABEL="assigned"
+          else
+            ICON=":no_entry_sign:"
+            ACTION_LABEL="unassigned"
+          fi
+
+          MESSAGE="${ICON} ${ITEM_LABEL} ${ACTION_LABEL}: #${ITEM_NUMBER} ${ITEM_TITLE}
+          Assignee: ${ASSIGNEE}
+          Changed by: ${ACTOR}
+          ${ITEM_URL}"
+
+          jq -n --arg text "${MESSAGE}" '{text: $text}' \
+            | curl -X POST -H 'Content-type: application/json' --data @- "${SLACK_WEBHOOK_URL}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /node_modules
 /packages/*/node_modules
+/.pnpm-store/
 /.pnp
 .pnp.*
 .yarn/*


### PR DESCRIPTION
## 📝 変更内容

- Issue / Pull Request の assignee assigned / unassigned イベントを Slack に通知する GitHub Actions ワークフローを追加
- Issue / Pull Request の種別、番号、タイトル、assignee、変更者、URL を通知内容に含めるように対応
- ローカルの pnpm store が未追跡ファイルとして出ないように `/.pnpm-store/` を `.gitignore` に追加

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

Issue / Pull Request の assignee 変更を Slack で把握できるようにするため。

## 🧪 テスト

### テストの実行確認

- [x] `task check` を実行し、ESLint、ビルド、ユニットテストがパスすることを確認
- [ ] 新しく追加した機能に対するテストを作成
- [x] 既存のテストが壊れていないことを確認

## 🔍 レビューのポイント

- `issues` / `pull_request` の assigned / unassigned イベント指定が意図通りか
- Issue と Pull Request の両方でタイトル、URL、番号を取得できる式になっているか
- Slack webhook 未設定時に workflow が失敗せず skip する挙動で問題ないか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

- Slack 通知には repository secret `SLACK_WEBHOOK_URL` の設定が必要です。
- 破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] UI 変更がある場合はスクリーンショットまたは確認内容を添付した
- [x] 破壊的変更がある場合は適切に文書化した
