### PR TITLE
unassigned通知のassigneeラベルを変更

### DIFF
--- a/.github/workflows/notify-assignee-changes.yml
+++ b/.github/workflows/notify-assignee-changes.yml
@@ -41,13 +41,15 @@ jobs:
           if [ "${ACTION}" = "assigned" ]; then
             ICON=":bust_in_silhouette:"
             ACTION_LABEL="assigned"
+            ASSIGNEE_LABEL="Assignee"
           else
             ICON=":no_entry_sign:"
             ACTION_LABEL="unassigned"
+            ASSIGNEE_LABEL="Unassigned"
           fi
 
           MESSAGE="${ICON} ${ITEM_LABEL} ${ACTION_LABEL}: #${ITEM_NUMBER} ${ITEM_TITLE}
-          Assignee: ${ASSIGNEE}
+          ${ASSIGNEE_LABEL}: ${ASSIGNEE}
           Changed by: ${ACTOR}
           ${ITEM_URL}"
 


### PR DESCRIPTION
## 📝 変更内容

- assignee 変更通知ワークフローで、unassigned 時の通知ラベルを `Assignee` から `Unassigned` に変更
- assigned 時は従来どおり `Assignee` と表示

## 🏷️ 変更の種類

- [ ] 🚀 新機能 (Feature)
- [ ] 🐛 バグ修正 (Bug fix)
- [ ] 🔧 リファクタリング (Refactoring)
- [ ] 📚 ドキュメント (Documentation)
- [ ] 🧪 テスト (Tests)
- [x] 🔨 ビルド/CI (Build/CI)
- [ ] 💄 UI/UX (Style)
- [ ] ⚡ パフォーマンス (Performance)
- [ ] 🗑️ 削除 (Removal)

## 🎯 変更理由・背景

unassigned 通知時に、対象ユーザーが割り当て解除されたユーザーであることをSlack上で分かりやすくするため。

## 🧪 テスト

### テストの実行確認

- [x] `git diff --check main...HEAD` を実行し、差分に空白エラーがないことを確認

## 🔍 レビューのポイント

- assigned / unassigned の分岐ごとに適切なラベルが設定されているか
- Slack通知文面が意図通り `Assignee` / `Unassigned` に切り替わるか

## 📖 関連情報

### 関連Issue・タスク

なし

## ⚠️ 注意事項

破壊的変更、マイグレーションはありません。

---

## チェックリスト

- [x] 自分でコードレビューを実施した
- [x] 適切なブランチ名を使用している
- [x] コミットメッセージが適切である
- [ ] 必要に応じてドキュメントを更新した
- [x] 破壊的変更がある場合は適切に文書化した
